### PR TITLE
增加自定义异常方法，用于处理okhttp异步请求时的异常

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/listener/SseListener.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/listener/SseListener.java
@@ -32,6 +32,12 @@ import java.util.concurrent.CountDownLatch;
 
 @Slf4j
 public abstract class SseListener extends EventSourceListener {
+
+    /**
+     * 异常回调
+     */
+    protected abstract void error(Throwable t, Response response);
+
     protected abstract void send();
     /**
      * 最终的消息输出
@@ -93,7 +99,7 @@ public abstract class SseListener extends EventSourceListener {
 
     @Override
     public void onFailure(@NotNull EventSource eventSource, @Nullable Throwable t, @Nullable Response response) {
-
+        this.error(t, response);
         countDownLatch.countDown();
     }
 


### PR DESCRIPTION
增加自定义异常方法，用于处理okhttp异步请求时的异常

okhttp配置
```java
OkHttpClient okHttpClient = new OkHttpClient
                    .Builder()
                    .addInterceptor(httpLoggingInterceptor)
                    .addInterceptor(new ErrorInterceptor())
                    .connectTimeout(300, TimeUnit.SECONDS)
                    .writeTimeout(300, TimeUnit.SECONDS)
                    .readTimeout(300, TimeUnit.SECONDS)
                    .sslSocketFactory(OkHttpUtil.getIgnoreInitedSslContext().getSocketFactory(), OkHttpUtil.IGNORE_SSL_TRUST_MANAGER_X509)
                    .hostnameVerifier(OkHttpUtil.getIgnoreSslHostnameVerifier())
//                .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 10809)))
                    .build();
```

测试代码：
```java
@Test
public void test_chatCompletions_stream() {
    ChatCompletion chatCompletion = deepSeekConfig.chatCompletionBuilder()
            .message(ChatMessage.withUser("你知道葫芦娃吗"))
            .build();

    // 构造监听器
    SseListener sseListener = new SseListener() {
        @Override
        protected void error(Throwable t, Response response) {
            log.error("回调的异常", t);
        }

        @Override
        protected void send() {
            System.out.print(this.getCurrStr());
        }
    };
    try {
        chatService.chatCompletionStream(chatCompletion, sseListener);
    } catch (Exception e) {
        log.error("主线程异常", e);
    }
}
```

操作：设置错误的key，运行代码

测试日志：
![image](https://github.com/user-attachments/assets/a069b946-cfc3-4358-880b-01363172c2d2)

结论：满足期望，能捕获并处理okhttp异步请求时触发的异常和抛出的自定义异常
