### PR TITLE
fix:思考内容不显示的问题

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/listener/SseListener.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/listener/SseListener.java
@@ -196,6 +196,7 @@ public abstract class SseListener extends EventSourceListener {
 
         if(ChatMessageType.ASSISTANT.getRole().equals(responseMessage.getRole())
                 && (responseMessage.getContent()==null || StringUtils.isEmpty(responseMessage.getContent().getText()))
+                && StringUtils.isEmpty(responseMessage.getReasoningContent())
                 && responseMessage.getToolCalls() == null){
             // 空消息忽略
             return;


### PR DESCRIPTION
代码判断错误导致思考内容不显示，测试使用的是火山引擎 的DeepSeek