### PR TITLE
fix(auth): fix cache key mismatch in BearerTokenUtils

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/auth/BearerTokenUtils.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/auth/BearerTokenUtils.java
@@ -56,7 +56,7 @@ public class BearerTokenUtils {
         headerClaims.put("alg", "HS256");
         headerClaims.put("sign_type", "SIGN");
         token = JWT.create().withPayload(payload).withHeader(headerClaims).sign(algorithm);
-        cache.put(id, token);
+        cache.put(apiKey, token);
         return token;
     }
 


### PR DESCRIPTION
## Summary

Fixes a cache key mismatch bug in `BearerTokenUtils.getToken()` that causes the token cache to never hit, resulting in a new JWT being generated on every call.

## Bug Description

In `BearerTokenUtils.getToken()`, the token cache is looked up and stored using **different keys**:

- **Lookup** (line 47): `cache.getIfPresent(apiKey)` — uses the full `{id}.{secret}` string
- **Storage** (line 59): `cache.put(id, token)` — uses only the `id` portion

Since the lookup key (`apiKey` = `{id}.{secret}`) never matches the storage key (`id`), `getIfPresent()` always returns `null`, and a new token is minted and signed on every invocation. This defeats the purpose of the cache and adds unnecessary JWT signing overhead on each request.

## Fix

Change line 59 from:

```java
cache.put(id, token);
```

to:

```java
cache.put(apiKey, token);
```

This ensures both the lookup and storage use the same key (`apiKey`), so cached tokens are properly found and reused until they expire.

## Test Plan

- [x] Verified the fix: `cache.getIfPresent(apiKey)` and `cache.put(apiKey, token)` now use the same key
- [ ] CI `java-regression` workflow passes (Maven package smoke + module tests for `ai4j`)