### PR TITLE
docs(harness): update agent sdk roadmap after p1c merge

### DIFF
--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/brief.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/brief.md
@@ -64,7 +64,7 @@
 - 本地 permission sandbox 与真实远端 sandbox 的差异。
 - 远端 Agent Runner 的产品化边界。
 - CLI/TUI 体验、JLine 选择和 Harness 轻量桥接原则。
-- 当前下一步应继续 P0-B Memory Compact Context Projector。
+- P1-C CLI run Agent Blueprint YAML 已通过 PR #110 合并；当前下一步应启动 P2 Sandbox SPI。
 
 ## 2026-06-20 执行级路线图补充
 
@@ -79,4 +79,4 @@
 - P5 远端 Agent Runner 决策。
 - docs-site 同步要求与“不要做的事”。
 
-当前实际下一步：先收尾 `.worktrees/feature/agent-plugin-lifecycle-hooks` 的 P0-C worktree；不要重复开新的总规划任务。
+当前实际下一步：P1-C 已合并到 `origin/main`（PR #110，merge commit `384edd11424884e308c047f7e2a4b20997e95e49`）；不要重复开总规划任务，下一步进入 P2 Sandbox SPI。

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/findings.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/findings.md
@@ -30,7 +30,7 @@
 | ID | Severity | Finding | Evidence | Required Action | Status |
 | --- | --- | --- | --- | --- | --- |
 | F-010 | P1 | 任何对标 Pi 插件/TUI 的实现必须先做公开资料或本仓实测调研，不能凭印象复刻。 | `references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md` 第 4 节 | 后续开 R0-PI research digest，再进入 CLI/TUI 或插件 API 设计。 | open-follow-up |
-| F-011 | P2 | P0-C worktree 已有未提交实现；当前实际下一步应先收尾 P0-C，而不是继续新增总规划。 | `git worktree list`; `.worktrees/feature/agent-plugin-lifecycle-hooks` status | final harness status、stage、commit、task-review、push、PR、CI、merge。 | open-follow-up |
+| F-011 | P2 | P1-B/P1-C 已合并，当前实际下一步应启动 P2 Sandbox SPI，而不是继续新增总规划。 | P1-B PR #109 merge commit `908e410f946563dd204caad2cb3bcb0430edfd96`; P1-C PR #110 merge commit `384edd11424884e308c047f7e2a4b20997e95e49` | 新建 P2-A Sandbox SPI model task，先实现 fake provider 与 Java 8 SPI 合同。 | open-follow-up |
 | F-012 | P2 | Approval / Permission Policy 是 sandbox 前置缝隙；本地 permission sandbox 和真实远端 sandbox 需要在 P0-D 先分清。 | `references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md` 第 5、7 节 | 新建 P0-D planning/implementation task。 | open-follow-up |
 | F-013 | P2 | docs-site 需要按“每个能力能不能用起来”重构，不只是 roadmap 标记。 | `references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md` 第 11 节 | 每个能力页补：问题、最小示例、API/YAML、关系、限制、FAQ、下一步。 | open-follow-up |
 | F-014 | P3 | 远端 Agent Runner 是产品化差异点，但必须满足 P0-P4 门禁后再决定是否新增模块。 | `references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md` 第 10 节 | P5 只做协议合同和决策任务，不作为 P0/P1 阻塞项。 | open-follow-up |
@@ -39,6 +39,6 @@
 
 | ID | Severity | Finding | Evidence | Required Action | Status |
 | --- | --- | --- | --- | --- | --- |
-| F-015 | P1 | 当前不应继续扩散总规划；真实下一步是收尾 P1-B AgentFactory worktree。 | `git worktree list`; `.wt/p1b` status; `references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` 第 11 节 | 在 `.wt/p1b` 修复 docs markdown、复跑 targeted/broad/docs/Harness checks、更新 P1-B task package、提交 PR 并 merge。 | open-follow-up |
+| F-015 | P1 | 当前不应继续扩散总规划；真实下一步是 P2-A Sandbox SPI model。 | `references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` 第 14 节；PR #110 已合并 | 创建 P2-A worktree/branch/task package，先做 Sandbox SPI model + fake provider tests。 | open-follow-up |
 | F-016 | P2 | P2/P3/P4/P5 依赖关系必须保持顺序，否则会把 Sandbox、Coding tools、CLI 和 Runner 过早耦合。 | `references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` 第 5-8 节 | Sandbox 先 fake provider + SPI，再 coding routing，再 CLI UX，最后 Runner 决策。 | open-follow-up |
 | F-017 | P2 | CLI/TUI 增强应继续 Java + JLine + renderer abstraction，不应为了视觉效果过早引入 Ink/React 双栈。 | `references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` 第 7 节 | P4 任务先做布局、slash command、reply rendering 和 Harness bridge 的 Java 侧抽象。 | open-follow-up |

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/progress.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/progress.md
@@ -49,21 +49,28 @@
 
 ### [2026-06-20 02:58] - planning refresh recorded
 
-- 做了什么：补充完整规划刷新稿，覆盖 AI4J 差异化定位、插件生态、Memory/Compact/Session 分层、YAML Blueprint、真实 sandbox、远端 Agent Runner、CLI/TUI、Harness 轻量桥接和 P0-B 下一步。
+- 做了什么：补充完整规划刷新稿，覆盖 AI4J 差异化定位、插件生态、Memory/Compact/Session 分层、YAML Blueprint、真实 sandbox、远端 Agent Runner、CLI/TUI、Harness 轻量桥接和后续 P2/P3/P4/P5 路线。
 - 验证结果：新增 `references/ai4j-agent-sdk-complete-planning-refresh.md` 与 `references/INDEX.md`，并将刷新结论挂入 brief/task_plan/findings/review/walkthrough。
-- 下一步：运行 Harness status，确认任务包无 failure；后续实施应继续当前 P0-B worktree。
+- 下一步：运行 Harness status，确认任务包无 failure；后续实施按当前最终集成规划推进。
 - 证据：report:TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-complete-planning-refresh.md:complete planning refresh for agent sdk roadmap
 
 ### [2026-06-20 04:45] - execution roadmap and research gates recorded
 
-- 做了什么：补充执行级路线图与调研门禁，把 `ai4j-agent` 增强拆为 R0 source-backed research、P0 Agent core、P1 Blueprint YAML、P2 Sandbox SPI、P3 coding sandbox routing、P4 CLI/TUI、P5 Remote Runner decision，并记录当前实际下一步应先收尾 P0-C worktree。
+- 做了什么：补充执行级路线图与调研门禁，把 `ai4j-agent` 增强拆为 R0 source-backed research、P0 Agent core、P1 Blueprint YAML、P2 Sandbox SPI、P3 coding sandbox routing、P4 CLI/TUI、P5 Remote Runner decision。
 - 验证结果：新增 `references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md`；同步更新 `references/INDEX.md`、`brief.md`、`task_plan.md`、`findings.md`、`visual_map.md`、`review.md`、`walkthrough.md`。
-- 下一步：运行 Harness status；如材料通过，重新提交 agent review summary，随后按 P0-C worktree 收尾。
+- 下一步：运行 Harness status；如材料通过，按最终集成规划推进后续小任务。
 - 证据：report:TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md:execution roadmap and research gates for ai4j-agent roadmap
 
 ### [2026-06-20 07:10] - integrated implementation plan recorded
 
 - 做了什么：按用户要求利用 Coding Agent Harness skill 将上方关于 ai4j-agent 改进完善增强方向的完整讨论，合并记录为最终集成实施规划。
 - 验证结果：新增 `references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md`，并把它挂入 `references/INDEX.md`、`task_plan.md`、`findings.md`、`visual_map.md`、`review.md`、`walkthrough.md`。
-- 下一步：运行 Harness status；后续实际开发优先收尾 P1-B `.wt/p1b` / `feature/agent-blueprint-factory`。
+- 下一步：运行 Harness status；后续实际开发优先按当前队列推进。
 - 证据：report:TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md:integrated implementation plan for ai4j-agent roadmap and P1-B next step
+
+### [2026-06-20 08:30] - current-state planning refresh recorded
+
+- 做了什么：按当前真实仓库状态刷新最终集成规划，将早期 “P0-B/P0-C/P1-B/P1-C 下一步” 统一修正为 “P1-B/P1-C 已合并，当前进入 P2 Sandbox SPI”。
+- 验证结果：PR #110 已合并到 `origin/main`，merge commit `384edd11424884e308c047f7e2a4b20997e95e49`；当前规划任务保持 planning-only。
+- 下一步：清理 P1-C worktree 后，创建 P2-A Sandbox SPI model worktree/task，继续 implementation + docs-site + regression。
+- 证据：report:TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md:current-state plan updated after P1-C merge for P2 Sandbox SPI next step

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/INDEX.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/INDEX.md
@@ -3,13 +3,13 @@
 | ID | Path | Purpose | Status |
 | --- | --- | --- | --- |
 | R-001 | `ai4j-agent-sdk-enhancement-plan.md` | 初版 `ai4j-agent` 架构增强规划，定义 Session/Memory/Compact/Plugin/Sandbox/Runner/Blueprint 路线。 | current-base |
-| R-002 | `ai4j-agent-sdk-complete-planning-refresh.md` | 2026-06-20 完整规划刷新稿，补充插件生态、YAML Blueprint、真实 sandbox、远端 Runner、CLI/TUI、Harness 边界和 P0-B 下一步。 | current-refresh |
+| R-002 | `ai4j-agent-sdk-complete-planning-refresh.md` | 2026-06-20 完整规划刷新稿，补充插件生态、YAML Blueprint、真实 sandbox、远端 Runner、CLI/TUI、Harness 边界和 P2 下一步。 | current-refresh |
 | R-003 | `ai4j-agent-sdk-execution-roadmap-and-research-gates.md` | 执行级路线图与调研门禁，明确 P0-P5 拆分、Pi/Codex/Java SDK/source-backed research gates、docs-site 同步路线和当前实际下一步。 | current-execution |
-| R-004 | `ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` | 最终集成实施规划，把前序规划、执行路线、当前 P1-B worktree 状态和下一步收口顺序合并为后续实施入口。 | current-integrated |
+| R-004 | `ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md` | 最终集成实施规划，把前序规划、执行路线、P1-C 已合并后的 P2 Sandbox SPI 下一步合并为后续实施入口。 | current-integrated |
 
 ## 使用顺序
 
-1. 先读 `ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md`，获得当前最终实施入口和 P1-B 下一步。
+1. 先读 `ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md`，获得当前最终实施入口和 P2 Sandbox SPI 下一步。
 2. 再读 `ai4j-agent-sdk-execution-roadmap-and-research-gates.md`，获得可执行任务队列和调研门禁。
 3. 再读 `ai4j-agent-sdk-complete-planning-refresh.md`，获得完整背景结论。
 4. 最后读 `ai4j-agent-sdk-enhancement-plan.md`，了解初版路线和审查历史。

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md
@@ -2,25 +2,46 @@
 
 > Task: `2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312`  
 > Date: 2026-06-20  
-> Scope: planning-only；本文件只记录路线和任务拆分，不修改生产代码、不新增 Maven 模块、不写 provider token。
+> Scope: planning-only；本文件只记录路线、边界和任务拆分，不修改生产代码、不新增 Maven 模块、不写 provider token。
 
-## 1. 本文件要固定什么
+## 1. 本文件固定的结论
 
-本文件把本轮关于 `ai4j-agent`、插件生态、YAML Agent、Sandbox、远端 Runner、CLI/TUI、Memory/Compact 的讨论合并为一份后续实施者可直接读取的计划。
+本文件把本轮关于 `ai4j-agent`、插件生态、YAML Agent、Sandbox、远端 Runner、CLI/TUI、Memory/Compact、docs-site 的讨论合并为后续实施者可直接读取的计划。
 
 最终结论：
 
 1. `ai4j-agent` 就是 AI4J 的通用 Agent SDK 主入口，不再新增 `AgentHost`、`Host Kernel`、`ai4j-runtime` 作为主概念。
-2. AI4J 的差异化不是“大而全”，而是降低 Java Agent 接入和组装成本：少概念、短路径、可插件化、可声明式、可做 coding agent 和远端 sandbox agent 产品。
-3. Sandbox 是执行环境绑定和 provider SPI，不是普通 tool；无 sandbox 时就是本地执行，不需要叫 `local sandbox`。
-4. 远端 Runner 是后置产品化能力，必须等 Session、Memory/Compact、Blueprint、Sandbox SPI、Coding routing、CLI attach/status 基础稳定后再决定是否新增模块。
-5. CLI/TUI 保持 Java + JLine 路线，做 renderer abstraction 和交互增强；不引入 Ink/React 作为主栈，不完整内化 Coding Agent Harness。
+2. AI4J 不和 Spring AI、LangChain4j、AgentScope Java 拼“大而全”；核心差异是降低 Java Agent 接入、组装、运行和产品化成本。
+3. 特色方向不是堆概念，而是：短路径 Java API、声明式 YAML、插件生态、Session/Memory/Compact、可选真实 sandbox、好用 CLI/TUI、远端 Agent Runner 产品化路径。
+4. Sandbox 是真实执行环境绑定和 provider SPI，不是普通 tool；无 sandbox 时就是本地执行，不需要叫 `local sandbox`。
+5. 远端 Runner 是后置产品化能力，必须等 Session、Memory/Compact、Blueprint、Sandbox SPI、Coding routing、CLI attach/status 基础稳定后再决定是否新增模块。
+6. CLI/TUI 保持 Java + JLine 路线，做 renderer abstraction 和交互增强；不引入 Ink/React 作为主栈，不完整内化 Coding Agent Harness。
+7. 后续对标 Pi、Codex、Claude Code、OpenCode、Spring AI、LangChain4j、AgentScope Java、Sandbox provider 时，必须先做 R0 source-backed research，不能凭印象复刻。
+8. Sponsor、中转平台或具体厂商名不能变成 SDK 概念；模型兼容层统一表达为 `openai-compatible`。
 
-## 2. 模块边界
+## 2. 产品定位
 
-| 模块 | 责任 | 当前规划结论 |
+推荐对外表达：
+
+> AI4J 是面向 Java 开发者的轻量 AI Agent SDK：用更少概念、更短路径，把模型、工具、插件、记忆、上下文压缩、声明式 Agent、Coding Agent 和可选远端执行环境组合起来。
+
+面向开发者的价值：
+
+| 价值 | 说明 |
+| --- | --- |
+| 接入成本低 | Java 开发者不需要理解一堆框架概念才能跑一个 Agent。 |
+| 使用成本低 | 默认路径短，复杂能力逐步启用；不把用户逼进大型框架心智。 |
+| 可组合 | 第三方插件可贡献 tools、commands、prompts、skills、guardrails、lifecycle hooks、memory/compact/sandbox providers。 |
+| 可声明 | YAML Agent Blueprint 让小白用户、团队模板、CLI 和未来 FlowGram/低代码导出都能复用同一份 Agent 定义。 |
+| 可产品化 | 同一套 Session/Blueprint/Sandbox/Coding/CLI 基础可以向“云端 Agent 产品”演进。 |
+
+禁用表达：不要写“企业采用”这类生硬字眼；不要把任何 sponsor 或中转平台名字写进 SDK 架构概念。
+
+## 3. 模块边界
+
+| 模块 | 责任 | 本规划结论 |
 | --- | --- | --- |
-| `ai4j` | 基础模型 SDK：Provider、Chat、Responses、Streaming、Tool Schema、RAG、MCP。 | 不承载 Agent 长程运行状态。 |
+| `ai4j` | 基础模型 SDK：Provider、Chat、Responses、Streaming、Tool Schema、RAG、MCP、向量、图像、音频、realtime。 | 不承载 Agent 长程运行状态。 |
 | `ai4j-agent` | 通用 Agent SDK：Agent、Runtime、Session、Memory、Compact、Event、Lifecycle、Blueprint、Sandbox Binding。 | 本轮增强的核心模块。 |
 | `ai4j-extension-api` | 第三方扩展合同：Manifest、Tool、Command、Prompt、Skill、Guardrail、Lifecycle Hook、Memory/Compact/Sandbox provider。 | 公共插件合同放这里；运行编排不放这里。 |
 | `ai4j-coding` | 官方 Coding Agent 能力包：file、shell、git、browser、project run、test runner、diff、artifact。 | 后续感知 sandbox；无 sandbox 时保持本地语义。 |
@@ -28,41 +49,126 @@
 | `docs-site` | 开发者文档站。 | 每个能力必须讲清问题、最小例子、API/YAML、限制、FAQ、下一步。 |
 | future optional `ai4j-agent-runner` | 远端 sandbox 内运行 Agent 的产品化入口。 | P5 再决策；不能阻塞 P0-P4。 |
 
-## 3. P0：先完成 Agent SDK 内核
+## 4. 插件生态设计方向
+
+第三方应该能像 Pi 一样写插件、发布插件、让使用者安装并组装出自己的 Agent 效果。AI4J 不应只把插件理解为 tool 注册。
+
+| 插件贡献点 | 用途 | 首要落点 |
+| --- | --- | --- |
+| Tool | 给 Agent 增加可调用动作。 | `ai4j-extension-api` + `ai4j-agent` runtime adapter |
+| Command | 给 CLI/TUI 增加 slash command 或 host command。 | `ai4j-cli` command bridge |
+| Prompt / Skill | 给 Agent 增加可复用行为模板。 | extension resources |
+| Guardrail | 输入、输出、tool call 前后检查。 | extension-api contract + runtime dispatch |
+| Lifecycle Hook | turn/model/tool/compact/session 生命周期观察或治理。 | P0-C |
+| Memory / Compact Provider | 接入外部记忆、摘要、长期知识。 | P0-B 后续扩展 |
+| SandboxProvider | 接入 CubeSandbox、Docker/K8s、E2B、内部 VM/microVM 等。 | P2 |
+
+插件系统验收重点：
+
+- 第三方插件可独立打包和发现。
+- 默认安全：显式 enable、显式 expose、权限可见。
+- 插件能力能被 YAML Blueprint 引用。
+- CLI 能列出、检查、启用、禁用或解释插件贡献。
+
+## 5. Session / Memory / Compact / Permission / Sandbox 的关系
+
+`AgentSession` 应是长程 Agent 运行态容器，而不是简单的一轮请求包装。
+
+```text
+AgentSession
+  ├─ metadata / status / owner / workspace
+  ├─ event log: user, assistant, model, tool, approval, compact, sandbox, artifact
+  ├─ memory state: short-term / project / optional external memory
+  ├─ compact state: budget, strategy, summaries, retained facts
+  ├─ permission policy: tool approval and host-side permission gate
+  ├─ sandbox binding: optional external execution environment summary
+  └─ snapshot / resume / checkpoint
+```
+
+设计原则：
+
+1. Memory 和 Compact 是 Agent runtime 能力，不应只散落在 coding-specific 层。
+2. Compact 不是简单截断；要有 `ContextBudget`、`ContextProjector`、`ContextReport`、`CompactPolicy`、`CompactResult`。
+3. Permission Policy 是所有工具执行前的 host-side gate，不能因为 sandbox 存在就自动放开。
+4. Sandbox binding 只记录非敏感摘要，snapshot 不能写 secret。
+
+## 6. P0：Agent SDK 内核
 
 P0 的目标是让 `ai4j-agent` 有可长程运行、可恢复、可压缩、可被插件观察和治理的基础。
 
-| 子任务 | 状态认知 | 目标 | 不做 |
+| 子任务 | 目标 | 不做 | 状态认知 |
 | --- | --- | --- | --- |
-| P0-A AgentSession runtime container | 已有任务与实现记录，生命周期仍在 review / closeout 队列中。 | session id、metadata、event log、snapshot、store、resume。 | 不接真实 sandbox。 |
-| P0-B Memory / Compact / Context Projector | 已有任务与实现记录，生命周期仍在 review / closeout 队列中。 | `ContextBudget`、`ContextProjector`、`ContextReport`、`CompactPolicy`、`CompactResult`、session compact state。 | 不把 coding-specific checkpoint 全量上移。 |
-| P0-C Plugin Lifecycle Hooks | 已有任务与实现记录，生命周期仍在 review / closeout 队列中。 | observation-first lifecycle hooks，覆盖 turn/model/tool/compact。 | 不强迫老插件升级，不先做可变拦截器。 |
-| P0-D Approval / Permission Policy | 已有任务与实现记录，生命周期仍在 review / closeout 队列中。 | tool execution 前的 host-side policy gate。 | 不创建 VM/容器/远端执行环境。 |
+| P0-A AgentSession runtime container | session id、metadata、event log、snapshot、store、resume。 | 不接真实 sandbox。 | 已有任务与实现记录，后续按 Harness lifecycle 收口。 |
+| P0-B Memory / Compact / Context Projector | `ContextBudget`、`ContextProjector`、`ContextReport`、`CompactPolicy`、`CompactResult`、session compact state。 | 不把 coding-specific checkpoint 全量上移。 | 已有任务与实现记录，后续按 Harness lifecycle 收口。 |
+| P0-C Plugin Lifecycle Hooks | observation-first lifecycle hooks，覆盖 turn/model/tool/compact。 | 不强迫老插件升级，不先做可变拦截器。 | 已有实现/合并记录，后续看 Harness 队列补 closeout。 |
+| P0-D Approval / Permission Policy | tool execution 前的 host-side policy gate。 | 不创建 VM/容器/远端执行环境。 | 已有任务与实现记录，后续补 closeout / docs / regression。 |
 
 P0 通过后，`AgentSession`、Memory/Compact、Hook、Permission Policy 会成为后续 Blueprint、Sandbox、Coding Agent、CLI 的基础，而不是各层各自发明状态模型。
 
-## 4. P1：Agent Blueprint YAML
+## 7. P1：Agent Blueprint YAML
 
 目标：让用户用一份 YAML 声明单 Agent，适合小白用户、团队模板、插件组合、CLI 运行和未来 FlowGram/低代码导出。
+
+首版 YAML 示例：
+
+```yaml
+version: ai4j.agent/v1
+id: coding-assistant
+name: Coding Assistant
+
+model:
+  provider: openai-compatible
+  profile: default
+  model: gpt-4.1
+
+instructions:
+  system: |
+    You are a careful coding agent.
+
+plugins:
+  - id: ask-user
+
+tools:
+  - ref: coding.file
+  - ref: coding.shell
+    approval: safe
+
+session:
+  memory:
+    enabled: true
+    scope: project
+  compact:
+    enabled: true
+    trigger:
+      contextRatio: 0.75
+    strategy: structured-summary
+
+sandbox:
+  enabled: false
+
+workflow:
+  mode: react
+  maxTurns: 20
+```
 
 拆分：
 
 | 子任务 | 范围 | 当前状态 / 下一步 |
 | --- | --- | --- |
-| P1-A schema/model/loader/validator | Java 8 DTO、YAML loader、validator、fixtures、稳定错误码。 | 已完成并合入过；Harness lifecycle 仍需后续确认/closeout。 |
-| P1-B Blueprint to AgentFactory | host-supplied context -> `AgentBuilder` / `Agent`；不读 token、不读 profile secret、不创建真实 sandbox。 | 当前工作树：`.wt/p1b`，分支：`feature/agent-blueprint-factory`，应优先收尾。 |
-| P1-C CLI `ai4j run agent.yaml` | 读取 YAML、校验、渲染错误、构造 Agent 并运行。 | P1-B 合并后再开。 |
+| P1-A schema/model/loader/validator | Java 8 DTO、YAML loader、validator、fixtures、稳定错误码。 | 已完成并合入过；Harness lifecycle 继续收口。 |
+| P1-B Blueprint to AgentFactory | host-supplied context -> `AgentBuilder` / `Agent`；不读 token、不读 profile secret、不创建真实 sandbox。 | 已完成并合并；PR #109，merge commit `908e410f946563dd204caad2cb3bcb0430edfd96`。 |
+| P1-C CLI `ai4j run agent.yaml` | 读取 YAML、校验、解析 host provider/profile、构造 Agent 并运行一次。 | 已完成并合并；PR #110，merge commit `384edd11424884e308c047f7e2a4b20997e95e49`。 |
 | P1-D Team / Workflow Blueprint | 多 Agent、handoff、nodes/edges、FlowGram bridge。 | 后置；单 Agent 稳定前不做。 |
 
-Blueprint 首版原则：
+首版原则：
 
 - `provider: openai-compatible` 是通用概念，不写任何中转平台名称作为 SDK 概念。
 - Blueprint 不保存 provider token；token 来自 env、宿主配置或 secret store。
-- `sandbox.enabled=true` 只能表达声明和 guard，真实 provider 绑定属于 P2/P3/P4。
+- `sandbox.enabled=true` 在 P1 只能表达声明和 guard，真实 provider 绑定属于 P2/P3/P4。
 
-## 5. P2：Sandbox SPI
+## 8. P2：Sandbox SPI
 
-目标：提供真实沙箱/远端执行环境的最小合同，让用户或第三方能接 CubeSandbox、Docker/K8s、E2B、公司内部沙箱等。
+目标：提供真实沙箱/远端执行环境的最小合同，让用户或第三方能接 CubeSandbox、Docker/K8s、E2B、公司内部 VM/microVM 等。
 
 核心设计：
 
@@ -92,13 +198,19 @@ AgentSession / CodingSession
 | P2-B AgentSession sandbox binding | session metadata/snapshot/event log 记录 sandbox binding 摘要。 | resume 不丢 binding 摘要；不把 secret 写进 snapshot。 |
 | P2-C Sandbox plugin contribution | extension-api / plugin manifest 允许第三方贡献 provider。 | manifest/validator/discovery tests。 |
 
+沙箱隔离建议：
+
+- 对不可信代码、shell、浏览器、文件系统操作，默认按 task/session 创建独立沙箱。
+- 可以在用户/项目层持久化缓存或 workspace snapshot，但不要让多个用户共享同一个可写运行环境。
+- 真正执行环境由 provider 负责，SDK 提供抽象、事件、权限和 artifact 合同。
+
 不做：
 
 - 不官方维护多个 provider。
 - 不把 sandbox 做成普通 `run_in_sandbox` tool。
 - 不让 sandbox 自动绕过 approval / permission policy。
 
-## 6. P3：`ai4j-coding` 接入 Sandbox Routing
+## 9. P3：`ai4j-coding` 接入 Sandbox Routing
 
 目标：执行型 coding tools 自动感知 sandbox。
 
@@ -117,7 +229,7 @@ AgentSession / CodingSession
 3. approval、timeout、cancel、artifact 结果可测试。
 4. sandbox 结果必须能进入 session event log / artifact refs。
 
-## 7. P4：CLI/TUI 体验
+## 10. P4：CLI/TUI 体验
 
 目标：终端输入 `ai4j` 后，是一个接近 Codex / Claude Code / OpenCode / Pi 的 coding agent 交互体验。
 
@@ -140,7 +252,7 @@ AgentSession / CodingSession
 
 需要先做 R0 调研：Pi / Codex / Claude Code / OpenCode 的插件、TUI、slash command、provider/model 切换、回复渲染模式必须有公开资料或本仓实测支撑。
 
-## 8. P5：远端 Agent Runner 决策
+## 11. P5：远端 Agent Runner 决策
 
 目标：帮助开发者快速做出“云端 sandbox agent 产品”的运行端，但必须后置。
 
@@ -173,7 +285,7 @@ Runner 需要能力：
 4. P3 Coding tools 能路由 sandbox。
 5. P4 CLI 能 attach/resume/status。
 
-## 9. R0 调研门禁
+## 12. R0 调研门禁
 
 后续凡是“对标某个框架/产品”的实现，先做调研任务，不凭印象复刻。
 
@@ -184,7 +296,7 @@ Runner 需要能力：
 | R0-JAVA-SDK | Spring AI、LangChain4j、AgentScope Java 官方文档 | AI4J 必须覆盖哪些能力？应该避开什么复杂度？差异化如何表达？ | comparison matrix |
 | R0-SANDBOX | CubeSandbox、E2B、Docker/K8s/internal sandbox 公开 API | 最小 sandbox contract 如何抽象？session/task 隔离和 artifact 回收怎么做？ | Sandbox SPI design input |
 
-## 10. docs-site 同步要求
+## 13. docs-site 同步要求
 
 每个能力页必须能让用户“用起来”，不是只展示 roadmap。
 
@@ -198,33 +310,41 @@ Runner 需要能力：
 6. 常见错误。
 7. 下一步链接。
 
-措辞要求：
+建议页面队列：
 
-- 不写“企业采用”。
-- Sponsor 或中转平台只能作为 README 赞助信息，不作为 SDK 架构概念。
-- 不展示 provider token。
-- OpenAI-compatible 统一作为通用协议/接口兼容概念。
+- Agent SDK Roadmap
+- Session Runtime
+- Memory / Compact / Context
+- Plugin Lifecycle Hooks
+- Plugin Authoring Guide
+- Agent Blueprint YAML
+- Sandbox SPI
+- Coding Agent Tools
+- CLI/TUI Guide
+- Provider configuration with `openai-compatible`
 
-## 11. 当前仓库状态与实际下一步
+## 14. 当前仓库状态与实际下一步
 
-根据本轮 Harness status 与 git worktree 诊断：
+根据本轮 PR / CI / Harness 诊断：
 
-- 主仓：`G:\My_Project\java\ai4j-sdk`，当前分支 `main`。
-- 未跟踪路径：`.wt/p1b/` 是 Git worktree，不应当作业务源文件直接提交到 main。
-- 当前活跃实现：`G:\My_Project\java\ai4j-sdk\.wt\p1b`，分支 `feature/agent-blueprint-factory`。
-- 当前任务：`MODULES/agent-runtime/2026-06-20-p1-b-agent-blueprint-to-agentfactory-8b418210`。
-- 下一步优先级：先收尾 P1-B，而不是继续新增总规划任务。
+- 主仓：`G:\My_Project\java\ai4j-sdk`，当前分支 `main` 已对齐 `origin/main` 的 P1-C merge 后状态。
+- P1-B 已完成并合并：PR #109，merge commit `908e410f946563dd204caad2cb3bcb0430edfd96`。
+- P1-C 已完成并合并：PR #110，merge commit `384edd11424884e308c047f7e2a4b20997e95e49`。
+- P1-C CI 通过：build、java-regression、module-tests(ai4j/agent/cli/coding/extension/plugin/starters/demos)、package-smoke 均 pass。
+- 未跟踪路径：`.wt/` 是 Git worktree 容器，不应当作业务源文件提交；P1-C worktree 可清理。
+- 下一步优先级：启动 P2-A Sandbox SPI model，而不是继续新增总规划任务。
 
-P1-B 收尾顺序：
+P2-A 启动顺序：
 
-1. 修复 `.wt/p1b/docs-site/docs/agent/agent-blueprint.md` 中的 markdown fence / P1-A wording 问题。
-2. 复跑 targeted test：`mvn -pl ai4j-agent -am "-Dtest=AgentBlueprintFactoryTest" -DskipTests=false -DfailIfNoTests=false test`。
-3. 复跑 broad agent regression：`mvn -pl ai4j-agent -am -DskipTests=false test`。
-4. docs-site 若变更，跑 `npm run build`。
-5. 更新 P1-B task package、Regression SSoT / Cadence Ledger（如固定回归面改变）。
-6. `harness status --json .` 无 failure 后提交、推送、PR、CI、merge、清理 worktree。
+1. 创建 `feature/agent-sandbox-spi-model` 分支和独立 worktree。
+2. 用 Harness 创建 `P2-A Sandbox SPI model` module task，并 `task-start`。
+3. 在 `ai4j-agent` 内定义 Java 8 兼容的 sandbox SPI model：provider/session/spec/command/result/artifact/event/timeout/cancel。
+4. 提供 fake provider tests，证明不依赖真实外部 sandbox。
+5. 更新 docs-site `Sandbox SPI` 技术页与 Agent SDK Roadmap。
+6. 更新 Regression SSoT / Cadence Ledger（如新增固定回归面）。
+7. targeted/broad/docs/Harness 验证后提交、PR、CI、merge、清理 worktree。
 
-## 12. 不要做的事
+## 15. 不要做的事
 
 - 不要重复新建总规划任务。
 - 不要一次性实现 P0-P5。

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/review.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/review.md
@@ -120,9 +120,9 @@
 | Evidence ID | Type | Path | Summary |
 | --- | --- | --- | --- |
 | E-004 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-complete-planning-refresh.md | 最新完整规划刷新稿补充差异化、插件生态、Blueprint、Sandbox、Runner、CLI/TUI 和 Harness 边界。 |
-| E-005 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md | 执行级路线图补充 R0 调研门禁、P0-P5 拆分、docs-site 同步要求和当前 P0-C worktree 收尾顺序。 |
+| E-005 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-execution-roadmap-and-research-gates.md | 执行级路线图补充 R0 调研门禁、P0-P5 拆分、docs-site 同步要求；当前已推进至 P2 Sandbox SPI。 |
 
-补充审查结论：刷新稿没有改变本任务“只做规划、不改生产代码”的边界；它把后续实施继续收敛到 P0-B/P0-C/P1/P2... 小任务队列，避免一次性大改。
+补充审查结论：刷新稿没有改变本任务“只做规划、不改生产代码”的边界；P1-C 已合并后，后续实施继续收敛到 P2/P3/P4/P5 小任务队列，避免一次性大改。
 
 ## 执行级路线图审查补充
 
@@ -130,13 +130,13 @@
 | --- | --- |
 | 是否仍然 planning-only | yes；只新增任务包 reference 和索引/审查材料，不改 Java 生产代码。 |
 | 是否避免凭空复刻 Pi/Codex/Claude/OpenCode | yes；新增 R0 source-backed research gates，后续实现前必须调研。 |
-| 是否明确当前下一步 | yes；先收尾 P0-C `feature/agent-plugin-lifecycle-hooks` worktree，再推进 P0-D/P1-A。 |
+| 是否明确当前下一步 | yes；P1-B/P1-C 已合并；下一步推进 P2-A Sandbox SPI model，再进入 P3/P4/P5。 |
 | 是否新增阻塞 material finding | no；新增发现均为后续路线和调研门禁。 |
 
 ## 最终集成规划审查补充
 
 | Evidence ID | Type | Path | Summary |
 | --- | --- | --- | --- |
-| E-006 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md | 最终集成实施规划固定模块边界、P0-P5 顺序、R0 调研门禁、P1-B 当前 worktree 收尾顺序和不要做事项。 |
+| E-006 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md | 最终集成实施规划固定模块边界、P0-P5 顺序、R0 调研门禁、P1-C 合并状态、P2 下一步和不要做事项。 |
 
-补充审查结论：本次补充没有改变 planning-only 边界，反而进一步收敛下一步到 P1-B AgentFactory 收尾；无新增 blocking material finding。
+补充审查结论：本次补充没有改变 planning-only 边界；P1-C 已合并，下一步收敛到 P2-A Sandbox SPI model；无新增 blocking material finding。

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/task_plan.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/task_plan.md
@@ -100,35 +100,35 @@ Task Package Index: required
 - [ ] 下一轮实施者能从 `references/INDEX.md` 找到最新完整规划刷新稿。
 - [ ] 规划明确“不把 Harness 完整内化到 CLI”，只做轻量识别和桥接。
 - [ ] 规划明确“OpenAI-compatible”是通用概念，不把任何中转平台名称写成 SDK 概念。
-- [ ] 规划明确当前下一步是继续 P0-B，而不是重复规划或一次性实现 P0-P5。
+- [ ] 规划明确 P1-C 已合并，当前下一步是 P2 Sandbox SPI，而不是重复规划或一次性实现 P0-P5。
 - [ ] 执行级路线图明确 Pi/Codex/Claude/OpenCode/Java SDK/Sandbox 调研必须 source-backed，不能凭印象复刻。
-- [ ] 执行级路线图明确当前仓库现实：先收尾 P0-C worktree，再推进后续任务。
+- [ ] 执行级路线图明确当前仓库现实：P1-B/P1-C 已合并，下一步推进 P2 Sandbox SPI，再进入 P3/P4/P5。
 
 ## 执行级路线图补充
 
 | Track | 状态 | 后续任务 |
 | --- | --- | --- |
 | R0 source-backed research | planned | Pi 插件/TUI、Codex/Claude/OpenCode CLI 模式、Spring AI/LangChain4j/AgentScope Java、Sandbox provider API。 |
-| P0 Agent core | active | P0-A/P0-B review closeout；P0-C worktree 提交/PR/merge；P0-D Approval / Permission Policy。 |
+| P0 Agent core | active | P0-A/P0-B/P0-C/P0-D 按 Harness 生命周期补 closeout；P1-C CLI run YAML 已合并。 |
 | P1 Blueprint YAML | planned | schema/model/loader/validator -> AgentFactory -> CLI run。 |
 | P2 Sandbox SPI | planned | fake provider、session binding、extension provider contribution。 |
 | P3 Coding sandbox routing | planned | shell/file/git/browser/project run/test runner routing。 |
 | P4 CLI/TUI | planned | JLine renderer abstraction、slash commands、provider/model/session/plugin/sandbox UX、Harness bridge。 |
 | P5 Remote Runner | deferred | 先写协议合同；满足 P0-P4 后再决定是否新增 Maven module。 |
 
-当前实际下一步：P0-C `feature/agent-plugin-lifecycle-hooks` worktree 已存在未提交实现，应优先收尾；本规划任务不应继续扩散范围。
+当前实际下一步：P1-C 已通过 PR #110 合并到 `origin/main`；本规划任务不应继续扩散范围，后续实现应转入 P2-A Sandbox SPI model。
 
 ## 最终集成实施规划补充
 
 | ID | 类型 | 路径 | 为什么需要 | 使用者 |
 | --- | --- | --- | --- | --- |
-| C-008 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md | 当前最终实施入口，合并 ai4j-agent 增强路线、插件生态、Blueprint、Sandbox、CLI/TUI、Runner、R0 调研门禁和当前 P1-B 收尾顺序 | coordinator / reviewer / future worker |
+| C-008 | report | TARGET:coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/references/ai4j-agent-sdk-integrated-implementation-plan-2026-06-20.md | 当前最终实施入口，合并 ai4j-agent 增强路线、插件生态、Blueprint、Sandbox、CLI/TUI、Runner、R0 调研门禁和 P2 Sandbox SPI 下一步 | coordinator / reviewer / future worker |
 
 新增验收补充：
 
 - [ ] 后续实施者能从 `references/INDEX.md` 优先找到集成实施规划。
-- [ ] 规划明确当前活跃实现是 P1-B `.wt/p1b` / `feature/agent-blueprint-factory`，下一步是收尾 P1-B，而不是重复开总规划。
+- [ ] 规划明确 P1-B/P1-C 均已合并，下一步是启动 P2-A Sandbox SPI model，而不是重复开总规划。
 - [ ] 规划明确 P2 Sandbox SPI、P3 coding routing、P4 CLI/TUI、P5 Runner 的门禁关系。
 - [ ] 规划明确 R0 调研门禁，后续对标 Pi / Codex / Claude Code / OpenCode / Java SDK / Sandbox provider 必须 source-backed。
 
-当前实际下一步：收尾 `MODULES/agent-runtime/2026-06-20-p1-b-agent-blueprint-to-agentfactory-8b418210`，工作树为 `G:\My_Project\java\ai4j-sdk\.wt\p1b`，分支为 `feature/agent-blueprint-factory`。
+当前实际下一步：启动 P2-A Sandbox SPI model 任务；P1-C 已通过 PR #110 合并，merge commit `384edd11424884e308c047f7e2a4b20997e95e49`。

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/visual_map.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/visual_map.md
@@ -163,17 +163,16 @@ MAP-04 Source Evidence: `references/ai4j-agent-sdk-execution-roadmap-and-researc
 
 ```text
 Current reality
-  main has planning records
-  .wt/p1b -> feature/agent-blueprint-factory -> P1-B AgentFactory
+  main includes P1-B -> PR #109 / 908e410f
+  main includes P1-C -> PR #110 / 384edd1
         |
         v
-Close P1-B first
-  fix docs markdown
-  targeted AgentBlueprintFactoryTest
-  broad ai4j-agent regression
-  docs-site build
-  P1-B task package + review
-  PR / CI / merge / cleanup
+Start P2-A next
+  feature/agent-sandbox-spi-model worktree
+  SandboxProvider / SandboxSession / SandboxSpec
+  SandboxCommand / SandboxResult / SandboxArtifact / SandboxEvent
+  fake provider tests
+  docs-site Sandbox SPI page
         |
         v
 Continue roadmap

--- a/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/walkthrough.md
+++ b/coding-agent-harness/planning/tasks/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312/walkthrough.md
@@ -60,7 +60,7 @@ Closeout Status: pending-human-confirmation
 
 ## 2026-06-20 刷新补充
 
-本收口记录补充引用 `references/ai4j-agent-sdk-complete-planning-refresh.md`。该文件是当前最新完整规划入口，后续实现者应优先读取。刷新后的直接下一步是继续 `P0-B Memory Compact Context Projector`，不要重复创建新的总规划任务，也不要一次性实现 P0-P5 全部能力。
+本收口记录补充引用 `references/ai4j-agent-sdk-complete-planning-refresh.md`。该文件是历史完整规划入口；后续实现者应优先读取最终集成实施规划。P1-C 已通过 PR #110 合并，当前直接下一步是启动 `P2-A Sandbox SPI model`，不要重复创建新的总规划任务，也不要一次性实现 P0-P5 全部能力。
 
 ## 2026-06-20 执行路线补充
 
@@ -69,7 +69,7 @@ Closeout Status: pending-human-confirmation
 - 后续涉及 Pi、Codex、Claude Code、OpenCode、Spring AI、LangChain4j、AgentScope Java、Sandbox provider 的对标设计，必须先做 source-backed research。
 - `ai4j-agent` 内核优先收尾 P0-A/P0-B/P0-C，并新增 P0-D Approval / Permission Policy。
 - YAML Blueprint、Sandbox SPI、Coding sandbox routing、CLI/TUI、Remote Runner 分阶段推进。
-- 当前仓库已有 P0-C worktree 未提交，实际下一步应先收尾 P0-C，而不是继续扩散总规划。
+- 当前仓库 P1-C 已通过 PR #110 合并，实际下一步应进入 P2 Sandbox SPI，而不是继续扩散总规划。
 
 ## 2026-06-20 最终集成实施规划补充
 
@@ -79,4 +79,4 @@ Closeout Status: pending-human-confirmation
 - P0 内核、P1 Blueprint、P2 Sandbox SPI、P3 coding routing、P4 CLI/TUI、P5 Runner 必须分阶段推进。
 - CLI/TUI 保持 Java + JLine + renderer abstraction，不完整内化 Coding Agent Harness。
 - 后续对标 Pi / Codex / Claude Code / OpenCode / Spring AI / LangChain4j / AgentScope Java / Sandbox provider 必须先做 R0 source-backed research。
-- 当前真实下一步是收尾 P1-B `G:\My_Project\java\ai4j-sdk\.wt\p1b` / `feature/agent-blueprint-factory`。
+- 当前真实下一步是启动 P2-A Sandbox SPI model；P1-C merge commit 为 `384edd11424884e308c047f7e2a4b20997e95e49`。


### PR DESCRIPTION
## Summary

- Refresh the agent SDK integrated roadmap after P1-C was merged.
- Record PR #110 / merge commit `384edd11424884e308c047f7e2a4b20997e95e49` as completed.
- Move the immediate next implementation step to P2-A Sandbox SPI model.
- Keep the planning task as planning-only and avoid reopening P1-C worktree work.

## Verification

- `git diff --check`
- `npx --yes coding-agent-harness status --json .` -> pass, failures=0, warnings=0

## Harness

Task: `TASKS/2026-06-20-ai4j-agent-sdk-architecture-enhancement-planning-b6a2e312`