### PR TITLE
feat(agent): AgentBuilder.anthropicMessages convenience for native Anthropic agents

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -1,6 +1,7 @@
 package io.github.lnyocly.ai4j.agent;
 
 import io.github.lnyocly.ai4j.agent.codeact.CodeActOptions;
+import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
 import io.github.lnyocly.ai4j.agent.codeact.CodeExecutor;
 import io.github.lnyocly.ai4j.agent.codeact.GraalVmCodeExecutor;
 import io.github.lnyocly.ai4j.agent.codeact.NashornCodeExecutor;
@@ -28,11 +29,16 @@ import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IMessagesService;
 import io.github.lnyocly.ai4j.agent.trace.AgentTraceListener;
 import io.github.lnyocly.ai4j.agent.trace.TraceConfig;
 import io.github.lnyocly.ai4j.agent.trace.TraceExporter;
 import io.github.lnyocly.ai4j.extension.ExtensionRegistry;
 import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import okhttp3.OkHttpClient;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -40,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public class AgentBuilder {
@@ -85,6 +92,68 @@ public class AgentBuilder {
     public AgentBuilder modelClient(AgentModelClient modelClient) {
         this.modelClient = modelClient;
         return this;
+    }
+
+    /**
+     * Convenience: wire the agent to the Anthropic Messages native surface ({@link IMessagesService}).
+     * Builds an {@link AnthropicMessagesService} + {@link MessagesModelClient} and injects it as the
+     * model client, so the agent runs on the Anthropic wire protocol (zero OpenAI conversion).
+     *
+     * @param apiKey Anthropic / coding-plan API key ({@code x-api-key})
+     * @return this builder
+     */
+    public AgentBuilder anthropicMessages(String apiKey) {
+        return anthropicMessages(apiKey, null, null);
+    }
+
+    /**
+     * Convenience: wire the agent to the Anthropic Messages native surface with a custom base URL.
+     * <p>Pass {@code baseUrl} to target a partner Anthropic-compatible endpoint, e.g.:
+     * <ul>
+     *   <li>zhipu coding plan: {@code https://open.bigmodel.cn/api/anthropic/}</li>
+     *   <li>minimax coding plan: {@code https://api.minimaxi.com/anthropic/}</li>
+     * </ul>
+     *
+     * @param apiKey  API key
+     * @param baseUrl Anthropic-compatible base URL (null/blank = default api.anthropic.com)
+     * @return this builder
+     */
+    public AgentBuilder anthropicMessages(String apiKey, String baseUrl) {
+        return anthropicMessages(apiKey, baseUrl, null);
+    }
+
+    /**
+     * Convenience: wire the agent to the Anthropic Messages native surface with base URL + api version.
+     *
+     * @param apiKey     API key
+     * @param baseUrl    Anthropic-compatible base URL (null/blank = default)
+     * @param apiVersion {@code anthropic-version} header (null/blank = default 2023-06-01)
+     * @return this builder
+     */
+    public AgentBuilder anthropicMessages(String apiKey, String baseUrl, String apiVersion) {
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey(apiKey);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
+        if (apiVersion != null && !apiVersion.trim().isEmpty()) {
+            config.setApiVersion(apiVersion);
+        }
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        configuration.setOkHttpClient(new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(300, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build());
+        IMessagesService service = new AnthropicMessagesService(configuration);
+        this.modelClient = new MessagesModelClient(service);
+        return this;
+    }
+
+    /** Test/inspection seam: the resolved model client. */
+    AgentModelClient peekModelClient() {
+        return modelClient;
     }
 
     public AgentBuilder toolRegistry(AgentToolRegistry toolRegistry) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/AgentAnthropicConvenienceLiveTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/AgentAnthropicConvenienceLiveTest.java
@@ -1,0 +1,50 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.AgentSession;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live: the {@code AgentBuilder.anthropicMessages(apiKey, baseUrl)} convenience wires a full agent
+ * that runs on the Anthropic native wire protocol end-to-end.
+ * <p>Env: {@code ANTHROPIC_API_KEY} (required), {@code ANTHROPIC_BASE_URL} (default zhipu coding plan),
+ * {@code ANTHROPIC_MODEL} (default glm-5.1).
+ */
+@Category(LiveProviderTest.class)
+public class AgentAnthropicConvenienceLiveTest {
+
+    @Test
+    public void agentRunsOnAnthropicNativeViaConvenience() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = System.getenv("ANTHROPIC_BASE_URL");
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            baseUrl = "https://open.bigmodel.cn/api/anthropic/";
+        }
+        String model = System.getenv("ANTHROPIC_MODEL");
+        if (model == null || model.trim().isEmpty()) {
+            model = "glm-5.1";
+        }
+
+        Agent agent = Agents.react()
+                .anthropicMessages(key, baseUrl)
+                .model(model)
+                .build();
+
+        AgentSession session = agent.newSession();
+        AgentResult result = session.run("Introduce yourself in one short sentence.");
+        System.out.println("=== agent anthropic convenience output ===");
+        System.out.println(result);
+        assertNotNull(result);
+        assertTrue("agent output must be non-empty via anthropicMessages convenience",
+                result.getOutputText() != null && !result.getOutputText().isEmpty());
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/AgentBuilderAnthropicConvenienceTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/AgentBuilderAnthropicConvenienceTest.java
@@ -1,0 +1,27 @@
+package io.github.lnyocly.ai4j.agent;
+
+import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AgentBuilderAnthropicConvenienceTest {
+
+    @Test
+    public void anthropicMessagesShouldWireMessagesModelClient() {
+        assertTrue("apiKey-only overload must wire MessagesModelClient",
+                Agents.builder().anthropicMessages("key").peekModelClient() instanceof MessagesModelClient);
+        assertTrue("apiKey+baseUrl overload must wire MessagesModelClient",
+                Agents.builder().anthropicMessages("key", "https://open.bigmodel.cn/api/anthropic/").peekModelClient() instanceof MessagesModelClient);
+        assertTrue("apiKey+baseUrl+version overload must wire MessagesModelClient",
+                Agents.builder().anthropicMessages("key", "https://x/", "2023-06-01").peekModelClient() instanceof MessagesModelClient);
+    }
+
+    @Test
+    public void buildShouldSucceedAfterConvenience() {
+        // build() throws "modelClient is required" if null; the convenience must set it.
+        Agent agent = Agents.builder().anthropicMessages("key").model("test-model").build();
+        assertNotNull(agent);
+    }
+}


### PR DESCRIPTION
One-liner to wire an agent onto the Anthropic Messages native surface (`IMessagesService`), making the native Anthropic wire protocol reachable from the normal builder API.

```java
Agents.react()
    .anthropicMessages(apiKey, "https://open.bigmodel.cn/api/anthropic/")
    .model("glm-5.1")
    .build();
```

Completes the P1.5 `MessagesModelClient` work (merged via #117) by exposing it ergonomically. `baseUrl` targets partner Anthropic-compatible endpoints (zhipu / minimax coding plans).

Verified: unit 2/2 (wires MessagesModelClient) + live agent turn via the convenience against zhipu coding plan returns native `AnthropicChatCompletionResponse` in `rawResponse` (zero OpenAI conversion), runId/sessionId/turnId correlation intact. ai4j-agent 132 tests 0 failures.