### PR TITLE
fix(minimax): default MinimaxConfig to current OpenAI-compatible gateway

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
@@ -14,7 +14,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MinimaxConfig {
-    private String apiHost = "https://api.minimax.chat/";
+    /**
+     * MiniMax 网关。默认指向当前推荐的 OpenAI 兼容网关 {@code https://api.minimaxi.com/}，
+     * 支持最新模型（MiniMax-M3 等）与 coding-plan key。
+     * 旧私有 {@code v1/text/chatcompletion_v2} 端点（{@code api.minimax.chat}）对新模型返回
+     * plan-not-support / 空 choices；如需回退到旧端点，覆盖本字段与 {@link #chatCompletionUrl}。
+     */
+    private String apiHost = "https://api.minimaxi.com/";
     private String apiKey = "";
-    private String chatCompletionUrl = "v1/text/chatcompletion_v2";
+    private String chatCompletionUrl = "v1/chat/completions";
 }

--- a/ai4j/src/test/java/io/github/lnyocly/MinimaxNewGatewayLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/MinimaxNewGatewayLiveTest.java
@@ -1,0 +1,69 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.config.MinimaxConfig;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletion;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletionResponse;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IChatService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live: verifies {@code PlatformType.MINIMAX} ({@code MinimaxChatService}) now defaults to the current
+ * OpenAI-compatible gateway and works with modern models (MiniMax-M3) + coding-plan key.
+ * <p>Before this fix the default pointed at the legacy {@code v1/text/chatcompletion_v2} endpoint which
+ * returned plan-not-support / empty choices for new models.
+ * <p>Env: {@code MINIMAX_API_KEY} (required).
+ */
+@Category(LiveProviderTest.class)
+public class MinimaxNewGatewayLiveTest {
+
+    @Test
+    public void minimaxChatServiceWorksOnNewGatewayWithM3() throws Exception {
+        String key = LiveProviderTestSupport.requireEnv("skip: MINIMAX_API_KEY not set", "MINIMAX_API_KEY");
+
+        // MinimaxConfig() now defaults to https://api.minimaxi.com/ + v1/chat/completions
+        MinimaxConfig config = new MinimaxConfig();
+        config.setApiKey(key);
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(300, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build();
+        Configuration configuration = new Configuration();
+        configuration.setMinimaxConfig(config);
+        configuration.setOkHttpClient(client);
+
+        IChatService chatService = new AiService(configuration).getChatService(PlatformType.MINIMAX);
+
+        ChatCompletion req = ChatCompletion.builder()
+                .model("MiniMax-M3")
+                .message(ChatMessage.withUser("Say hi in one short sentence."))
+                .maxCompletionTokens(128)
+                .build();
+
+        ChatCompletionResponse resp = chatService.chatCompletion(req);
+        System.out.println("=== MinimaxChatService (new gateway) M3 ===");
+        System.out.println(resp);
+
+        assertNotNull(resp);
+        assertNotNull(resp.getChoices());
+        assertFalse("choices must not be empty", resp.getChoices().isEmpty());
+        assertNotNull(resp.getChoices().get(0).getMessage());
+        assertNotNull(resp.getChoices().get(0).getMessage().getContent());
+        assertTrue("content must be non-empty",
+                resp.getChoices().get(0).getMessage().getContent().getText() != null
+                        && !resp.getChoices().get(0).getMessage().getContent().getText().isEmpty());
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/minimax/chat/MinimaxChatServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/minimax/chat/MinimaxChatServiceTest.java
@@ -97,7 +97,7 @@ public class MinimaxChatServiceTest {
         Assert.assertEquals("read_file", response.getChoices().get(0).getMessage().getToolCalls().get(0).getFunction().getName());
         Assert.assertEquals("{\"path\":\"README.md\"}", response.getChoices().get(0).getMessage().getToolCalls().get(0).getFunction().getArguments());
         Assert.assertEquals("Bearer config-api-key", recordedRequest.get().header("Authorization"));
-        Assert.assertEquals("https://unit.test/v1/text/chatcompletion_v2", recordedRequest.get().url().toString());
+        Assert.assertEquals("https://unit.test/v1/chat/completions", recordedRequest.get().url().toString());
         Assert.assertEquals(18L, response.getUsage().getTotalTokens());
     }
 


### PR DESCRIPTION
Fix: legacy default endpoint (`api.minimax.chat/v1/text/chatcompletion_v2`) returns plan-not-support / empty choices for modern models (MiniMax-M3) and coding-plan keys.

Switch default to the current OpenAI-compatible gateway (`api.minimaxi.com/v1/chat/completions`). `MinimaxChatCompletion`/`MinimaxChatCompletionResponse` are already OpenAI-compatible, so only the endpoint moves — no format change. Legacy users can still override `apiHost` + `chatCompletionUrl`.

Verified: `MinimaxChatServiceTest` green; live `PlatformType.MINIMAX` + MiniMax-M3 + coding-plan key returns content via the new default (was plan-not-support/empty before). ai4j 119 tests 0 failures.