### PR TITLE
chore: anchor .gitignore docs/ rule to repo root (free docs-site/docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ tmp-*.log
 /ai4j-spring-boot-stater/.gitignore
 .ai4j/
 .docs/
-docs/
+/docs/
 APIResponse.md
 AGENT.md
 ai4j-release-package.log


### PR DESCRIPTION
The unanchored `docs/` pattern matched any directory named `docs`, so it误caught:

- `docs-site/docs/` (267 tracked Docusaurus docs) — every new docs-site doc needed `git add -f` (hit this while adding the Anthropic Messages doc in #135).
- the `ai4j` test source package `io.github.lnyocly.ai4j.docs`.

Anchor it to the repo root (`/docs/`) so only the legacy root `docs/` (historical harness SSoT; AGENTS.md forbids new files there) stays ignored. Build/temp `docs/` subdirs stay ignored via their own rules (`target/`, docs-site `/build-*`, `.tmp*/`).

Verified via `git check-ignore`: `docs-site/docs/<new>` no longer ignored; root `docs/<new>` still ignored; `ai4j/target/...`, `docs-site/build-*/docs`, `docs-site/.tmp/.../docs` still ignored.