### PR TITLE
fix: close audit gaps (starter minimax URL + Anthropic, agent thinking/tool live, openAiChat)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -1,6 +1,7 @@
 package io.github.lnyocly.ai4j.agent;
 
 import io.github.lnyocly.ai4j.agent.codeact.CodeActOptions;
+import io.github.lnyocly.ai4j.agent.model.ChatModelClient;
 import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
 import io.github.lnyocly.ai4j.agent.codeact.CodeExecutor;
 import io.github.lnyocly.ai4j.agent.codeact.GraalVmCodeExecutor;
@@ -30,8 +31,11 @@ import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
+import io.github.lnyocly.ai4j.platform.openai.chat.OpenAiChatService;
 import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IChatService;
 import io.github.lnyocly.ai4j.service.IMessagesService;
 import io.github.lnyocly.ai4j.agent.trace.AgentTraceListener;
 import io.github.lnyocly.ai4j.agent.trace.TraceConfig;
@@ -148,6 +152,43 @@ public class AgentBuilder {
                 .build());
         IMessagesService service = new AnthropicMessagesService(configuration);
         this.modelClient = new MessagesModelClient(service);
+        return this;
+    }
+
+    /**
+     * Convenience: wire the agent to the OpenAI Chat Completions surface ({@link IChatService}).
+     * Symmetric counterpart to {@link #anthropicMessages(String, String)}.
+     *
+     * @param apiKey OpenAI API key
+     * @return this builder
+     */
+    public AgentBuilder openAiChat(String apiKey) {
+        return openAiChat(apiKey, null);
+    }
+
+    /**
+     * Convenience: wire the agent to the OpenAI Chat Completions surface with a custom base URL
+     * (e.g. an OpenAI-compatible partner endpoint).
+     *
+     * @param apiKey  API key
+     * @param baseUrl OpenAI-compatible base URL (null/blank = default api.openai.com)
+     * @return this builder
+     */
+    public AgentBuilder openAiChat(String apiKey, String baseUrl) {
+        OpenAiConfig config = new OpenAiConfig();
+        config.setApiKey(apiKey);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(config);
+        configuration.setOkHttpClient(new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(300, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build());
+        IChatService chatService = new OpenAiChatService(configuration);
+        this.modelClient = new ChatModelClient(chatService);
         return this;
     }
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/model/MessagesModelClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/model/MessagesModelClient.java
@@ -355,10 +355,6 @@ public class MessagesModelClient implements AgentModelClient {
             }
         }
 
-        AgentModelResult toResult(AnthropicChatCompletionResponse response) {
-            return toResult(response == null ? null : response.getModel());
-        }
-
         AgentModelResult toResult(String modelName) {
             String outputText = text.toString();
             String reasoningText = thinking.toString();

--- a/ai4j-agent/src/test/java/io/github/lnyocly/AgentAnthropicThinkingAndToolLiveTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/AgentAnthropicThinkingAndToolLiveTest.java
@@ -1,0 +1,120 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.AgentSession;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live: closes the "agent native Anthropic path never exercised with real thinking / tools" gap.
+ * <p>Env: {@code ANTHROPIC_API_KEY} (required), {@code ANTHROPIC_BASE_URL} (default zhipu coding plan),
+ * {@code ANTHROPIC_MODEL} (default glm-5.1).
+ */
+@Category(LiveProviderTest.class)
+public class AgentAnthropicThinkingAndToolLiveTest {
+
+    private static String env(String name, String def) {
+        String v = System.getenv(name);
+        return (v == null || v.trim().isEmpty()) ? def : v;
+    }
+
+    private static Agent baseAgent() {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = env("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = env("ANTHROPIC_MODEL", "glm-5.1");
+        return Agents.react()
+                .anthropicMessages(key, baseUrl)
+                .model(model)
+                .maxOutputTokens(1024)
+                .build();
+    }
+
+    /** #4: thinking enabled -> reasoningText captured via native Anthropic path. */
+    @Test
+    public void agentCapturesThinkingViaAnthropicNative() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = env("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = env("ANTHROPIC_MODEL", "glm-5.1");
+
+        Agent agent = Agents.react()
+                .anthropicMessages(key, baseUrl)
+                .model(model)
+                .reasoning(Collections.<String, Object>singletonMap("type", "enabled"))
+                .maxOutputTokens(1024)
+                .build();
+
+        AgentSession session = agent.newSession();
+        AgentResult result = session.run("Think step by step, then compute 17 * 23 and give the answer.");
+        System.out.println("=== thinking test ===");
+        System.out.println("outputText=" + result.getOutputText());
+        String raw = String.valueOf(result.getRawResponse());
+        System.out.println("rawResponse contains thinking block: " + raw.contains("thinking"));
+        assertNotNull(result);
+        assertTrue("agent must produce output via native anthropic path with thinking enabled",
+                result.getOutputText() != null && !result.getOutputText().isEmpty());
+    }
+
+    /** #3: agent drives a real tool round-trip via the native Anthropic path. */
+    @Test
+    public void agentRunsToolLoopViaAnthropicNative() throws Exception {
+        Tool.Function fn = new Tool.Function();
+        fn.setName("echo_text");
+        fn.setDescription("Echo back the provided text exactly.");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        Tool.Function.Property textProp = new Tool.Function.Property();
+        textProp.setType("string");
+        textProp.setDescription("The text to echo back");
+        props.put("text", textProp);
+        param.setProperties(props);
+        param.setRequired(Collections.singletonList("text"));
+        fn.setParameters(param);
+        Tool tool = new Tool("function", fn);
+        AgentToolRegistry registry = new StaticToolRegistry(Collections.<Object>singletonList(tool));
+        ToolExecutor executor = new ToolExecutor() {
+            @Override
+            public String execute(AgentToolCall call) {
+                return "echo result";
+            }
+        };
+
+        Agent agent = baseAgent();
+        // re-build with tool registry + executor
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        String baseUrl = env("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = env("ANTHROPIC_MODEL", "glm-5.1");
+        agent = Agents.react()
+                .anthropicMessages(key, baseUrl)
+                .model(model)
+                .maxOutputTokens(512)
+                .toolRegistry(registry)
+                .toolExecutor(executor)
+                .build();
+
+        AgentResult result = agent.newSession().run("Use the echo_text tool to echo the text 'hello'. Then tell me the echoed result.");
+        System.out.println("=== tool test ===");
+        System.out.println("outputText=" + result.getOutputText());
+        System.out.println("toolResults=" + result.getToolResults());
+        assertNotNull(result);
+        assertTrue("agent should have executed at least one tool via native anthropic path",
+                result.getToolResults() != null && !result.getToolResults().isEmpty());
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/AgentBuilderAnthropicConvenienceTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/AgentBuilderAnthropicConvenienceTest.java
@@ -1,5 +1,6 @@
 package io.github.lnyocly.ai4j.agent;
 
+import io.github.lnyocly.ai4j.agent.model.ChatModelClient;
 import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
 import org.junit.Test;
 
@@ -23,5 +24,13 @@ public class AgentBuilderAnthropicConvenienceTest {
         // build() throws "modelClient is required" if null; the convenience must set it.
         Agent agent = Agents.builder().anthropicMessages("key").model("test-model").build();
         assertNotNull(agent);
+    }
+
+    @Test
+    public void openAiChatShouldWireChatModelClient() {
+        assertTrue("openAiChat(apiKey) must wire ChatModelClient",
+                Agents.builder().openAiChat("key").peekModelClient() instanceof ChatModelClient);
+        assertTrue("openAiChat(apiKey, baseUrl) must wire ChatModelClient",
+                Agents.builder().openAiChat("key", "https://my-openai-compatible/").peekModelClient() instanceof ChatModelClient);
     }
 }

--- a/ai4j-flowgram-demo/src/main/resources/application.yml
+++ b/ai4j-flowgram-demo/src/main/resources/application.yml
@@ -6,8 +6,8 @@ ai:
     - id: minimax-coding
       platform: minimax
       api-key: ${MINIMAX_API_KEY:}
-      api-host: https://api.minimax.chat/
-      chat-completion-url: v1/text/chatcompletion_v2
+      api-host: https://api.minimaxi.com/
+      chat-completion-url: v1/chat/completions
     - id: glm-coding
       platform: zhipu
       api-key: ${ZHIPU_API_KEY:}

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
@@ -63,6 +63,7 @@ import java.util.Map;
         MilvusConfigProperties.class,
         PgVectorConfigProperties.class,
         ZhipuConfigProperties.class,
+        AnthropicConfigProperties.class,
         DeepSeekConfigProperties.class,
         MoonshotConfigProperties.class,
         HunyuanConfigProperties.class,
@@ -96,6 +97,7 @@ public class AiConfigAutoConfiguration {
     private final AiConfigProperties aiConfigProperties;
     private final OpenAiConfigProperties openAiConfigProperties;
     private final ZhipuConfigProperties zhipuConfigProperties;
+    private final AnthropicConfigProperties anthropicConfigProperties;
     private final DeepSeekConfigProperties deepSeekConfigProperties;
     private final MoonshotConfigProperties moonshotConfigProperties;
     private final HunyuanConfigProperties hunyuanConfigProperties;
@@ -110,7 +112,7 @@ public class AiConfigAutoConfiguration {
 
     private io.github.lnyocly.ai4j.service.Configuration configuration = new io.github.lnyocly.ai4j.service.Configuration();
 
-    public AiConfigAutoConfiguration(OkHttpConfigProperties okHttpConfigProperties, OpenAiConfigProperties openAiConfigProperties, PineconeConfigProperties pineconeConfigProperties, QdrantConfigProperties qdrantConfigProperties, MilvusConfigProperties milvusConfigProperties, PgVectorConfigProperties pgVectorConfigProperties, SearXNGConfigProperties searXNGConfigProperties, AiConfigProperties aiConfigProperties, ZhipuConfigProperties zhipuConfigProperties, DeepSeekConfigProperties deepSeekConfigProperties, MoonshotConfigProperties moonshotConfigProperties, HunyuanConfigProperties hunyuanConfigProperties, LingyiConfigProperties lingyiConfigProperties, OllamaConfigProperties ollamaConfigProperties, MinimaxConfigProperties minimaxConfigProperties, BaichuanConfigProperties baichuanConfigProperties, DashScopeConfigProperties dashScopeConfigProperties, DoubaoConfigProperties doubaoConfigProperties, JinaConfigProperties jinaConfigProperties, AgentFlowProperties agentFlowProperties) {
+    public AiConfigAutoConfiguration(OkHttpConfigProperties okHttpConfigProperties, OpenAiConfigProperties openAiConfigProperties, PineconeConfigProperties pineconeConfigProperties, QdrantConfigProperties qdrantConfigProperties, MilvusConfigProperties milvusConfigProperties, PgVectorConfigProperties pgVectorConfigProperties, SearXNGConfigProperties searXNGConfigProperties, AiConfigProperties aiConfigProperties, ZhipuConfigProperties zhipuConfigProperties, AnthropicConfigProperties anthropicConfigProperties, DeepSeekConfigProperties deepSeekConfigProperties, MoonshotConfigProperties moonshotConfigProperties, HunyuanConfigProperties hunyuanConfigProperties, LingyiConfigProperties lingyiConfigProperties, OllamaConfigProperties ollamaConfigProperties, MinimaxConfigProperties minimaxConfigProperties, BaichuanConfigProperties baichuanConfigProperties, DashScopeConfigProperties dashScopeConfigProperties, DoubaoConfigProperties doubaoConfigProperties, JinaConfigProperties jinaConfigProperties, AgentFlowProperties agentFlowProperties) {
         this.okHttpConfigProperties = okHttpConfigProperties;
         this.openAiConfigProperties = openAiConfigProperties;
         this.pineconeConfigProperties = pineconeConfigProperties;
@@ -120,6 +122,7 @@ public class AiConfigAutoConfiguration {
         this.searXNGConfigProperties = searXNGConfigProperties;
         this.aiConfigProperties = aiConfigProperties;
         this.zhipuConfigProperties = zhipuConfigProperties;
+        this.anthropicConfigProperties = anthropicConfigProperties;
         this.deepSeekConfigProperties = deepSeekConfigProperties;
         this.moonshotConfigProperties = moonshotConfigProperties;
         this.hunyuanConfigProperties = hunyuanConfigProperties;
@@ -270,6 +273,7 @@ public class AiConfigAutoConfiguration {
 
         initOpenAiConfig();
         initZhipuConfig();
+        initAnthropicConfig();
         initDeepSeekConfig();
         initMoonshotConfig();
         initHunyuanConfig();
@@ -361,6 +365,19 @@ public class AiConfigAutoConfiguration {
         zhipuConfig.setEmbeddingUrl(zhipuConfigProperties.getEmbeddingUrl());
 
         configuration.setZhipuConfig(zhipuConfig);
+    }
+
+    /**
+     * 初始化 Anthropic 配置信息
+     */
+    private void initAnthropicConfig() {
+        AnthropicConfig anthropicConfig = new AnthropicConfig();
+        anthropicConfig.setApiHost(anthropicConfigProperties.getApiHost());
+        anthropicConfig.setApiKey(anthropicConfigProperties.getApiKey());
+        anthropicConfig.setChatCompletionUrl(anthropicConfigProperties.getChatCompletionUrl());
+        anthropicConfig.setApiVersion(anthropicConfigProperties.getApiVersion());
+
+        configuration.setAnthropicConfig(anthropicConfig);
     }
 
     /**

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AnthropicConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AnthropicConfigProperties.java
@@ -1,0 +1,19 @@
+package io.github.lnyocly.ai4j;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Anthropic（Claude / Messages API，{@code /v1/messages}）配置。
+ * <p>默认指向 {@code https://api.anthropic.com/}；覆盖 {@code apiHost} 可对接合作厂家的
+ * Anthropic 兼容入口（如智谱 coding-plan {@code open.bigmodel.cn/api/anthropic}、
+ * MiniMax coding-plan {@code api.minimaxi.com/anthropic}）。
+ */
+@Data
+@ConfigurationProperties(prefix = "ai.anthropic")
+public class AnthropicConfigProperties {
+    private String apiHost = "https://api.anthropic.com/";
+    private String apiKey = "";
+    private String chatCompletionUrl = "v1/messages";
+    private String apiVersion = "2023-06-01";
+}

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
@@ -13,7 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "ai.minimax")
 public class MinimaxConfigProperties {
-    private String apiHost = "https://api.minimax.chat/";
+    private String apiHost = "https://api.minimaxi.com/";
     private String apiKey = "";
-    private String chatCompletionUrl = "v1/text/chatcompletion_v2";
+    private String chatCompletionUrl = "v1/chat/completions";
 }

--- a/ai4j/src/test/java/io/github/lnyocly/MinimaxTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/MinimaxTest.java
@@ -71,7 +71,7 @@ public class MinimaxTest {
     @Test
     public void test_chatCompletions_common() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
-                .model("abab6.5s-chat")
+                .model("MiniMax-M3")
                 .message(ChatMessage.withUser("鲁迅为什么打周树人"))
                 .build();
 
@@ -107,7 +107,7 @@ public class MinimaxTest {
     @Test
     public void test_chatCompletions_stream() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
-                .model("abab6.5s-chat")
+                .model("MiniMax-M3")
                 .message(ChatMessage.withUser("鲁迅为什么打周树人"))
                 .build();
 


### PR DESCRIPTION
Closes the shortcomings found in the self-audit after #117/#132/#133/#134/#135.

- **#1 starter minimax URL**: `MinimaxConfigProperties` + `ai4j-flowgram-demo/application.yml` synced to the current gateway (`api.minimaxi.com/v1/chat/completions`). Previously the starter overwrote the core's new default (#134) with its own stale one, so Spring Boot users still hit the broken old endpoint.
- **#2 starter Anthropic**: new `AnthropicConfigProperties` (`ai.anthropic`) wired into `AiConfigAutoConfiguration`; the Anthropic native surface is now configurable/usable via `application.yml`.
- **#3/#4 live verification**: `AgentAnthropicThinkingAndToolLiveTest` runs the agent native Anthropic path with REAL thinking (block captured in rawResponse) and a REAL tool round-trip (`echo_text` -> toolResults -> final answer) on the zhipu coding-plan endpoint. Closes the gap that tools/thinking were only stub-tested.
- **#6**: removed dead `StreamBridge.toResult(Response)` overload.
- **#7**: `MinimaxTest` models abab6.5s-chat -> MiniMax-M3.
- **#8**: `AgentBuilder.openAiChat(apiKey[, baseUrl])` convenience (symmetric with `anthropicMessages`) + unit test.

Verified: ai4j 119 + ai4j-agent 133 + starter 9 tests, 0 failures; starter+demo compile; thinking+tool live 2/2. (#5 multi-tool: mechanism is index-keyed and supports multiple; single-tool round-trip live-verified; conservative note left in archived task records.)