### PR TITLE
fix(anthropic): stream timeout backstop + typed-exception tests + starter doc

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicMessagesService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicMessagesService.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -47,6 +48,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class AnthropicMessagesService implements IMessagesService {
 
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
+    /** Safety-net upper bound for a single streaming call (10 min). Fine-grained stall detection
+     *  still relies on the caller's OkHttpClient read timeout; this only prevents indefinite block. */
+    private static final long STREAM_TIMEOUT_MS = 600_000L;
 
     private final AnthropicConfig anthropicConfig;
     private final OkHttpClient okHttpClient;
@@ -82,8 +86,12 @@ public class AnthropicMessagesService implements IMessagesService {
                 latch.countDown();
             }
         }, errorRef);
-        factory.newEventSource(httpRequest, listener);
-        latch.await();
+        EventSource eventSource = factory.newEventSource(httpRequest, listener);
+        if (!latch.await(STREAM_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            eventSource.cancel();
+            throw new AnthropicApiException(0, "stream_timeout",
+                    "anthropic stream timed out after " + STREAM_TIMEOUT_MS + "ms", null);
+        }
         Throwable err = errorRef.get();
         if (err != null) {
             if (err instanceof Exception) {

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/anthropic/errors/AnthropicApiExceptionTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/anthropic/errors/AnthropicApiExceptionTest.java
@@ -1,0 +1,50 @@
+package io.github.lnyocly.ai4j.platform.anthropic.errors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AnthropicApiExceptionTest {
+
+    @Test
+    public void ofMapsByErrorType() {
+        assertTrue(AnthropicApiException.of(429, "rate_limit_error", "m", "r")
+                instanceof AnthropicApiException.AnthropicRateLimitException);
+        assertTrue(AnthropicApiException.of(529, "overloaded_error", "m", "r")
+                instanceof AnthropicApiException.AnthropicOverloadedException);
+        assertTrue(AnthropicApiException.of(401, "authentication_error", "m", "r")
+                instanceof AnthropicApiException.AnthropicAuthenticationException);
+        assertTrue(AnthropicApiException.of(400, "invalid_request_error", "m", "r")
+                instanceof AnthropicApiException.AnthropicInvalidRequestException);
+        // type containing "invalid" (substring) also maps
+        assertTrue(AnthropicApiException.of(400, "invalid_json", "m", "r")
+                instanceof AnthropicApiException.AnthropicInvalidRequestException);
+        // type wins over status: rate_limit type on a 500 status still -> RateLimit
+        assertTrue(AnthropicApiException.of(500, "rate_limit_error", "m", "r")
+                instanceof AnthropicApiException.AnthropicRateLimitException);
+    }
+
+    @Test
+    public void ofMapsByStatusWhenTypeNull() {
+        assertTrue(AnthropicApiException.of(429, null, "m", null)
+                instanceof AnthropicApiException.AnthropicRateLimitException);
+        assertTrue(AnthropicApiException.of(529, null, "m", null)
+                instanceof AnthropicApiException.AnthropicOverloadedException);
+        assertTrue(AnthropicApiException.of(401, null, "m", null)
+                instanceof AnthropicApiException.AnthropicAuthenticationException);
+        assertTrue(AnthropicApiException.of(403, null, "m", null)
+                instanceof AnthropicApiException.AnthropicAuthenticationException);
+    }
+
+    @Test
+    public void ofFallsBackToBaseForUnknownStatusAndType() {
+        AnthropicApiException e = AnthropicApiException.of(500, "api_error", "boom", "req-1");
+        // exact base class, not one of the subclasses
+        assertEquals(AnthropicApiException.class, e.getClass());
+        assertEquals(500, e.getStatus());
+        assertEquals("api_error", e.getType());
+        assertEquals("boom", e.getMessage());
+        assertEquals("req-1", e.getRequestId());
+    }
+}

--- a/docs-site/docs/core-sdk/model-access/messages.md
+++ b/docs-site/docs/core-sdk/model-access/messages.md
@@ -126,7 +126,22 @@ AgentResult result = agent.newSession().run("Introduce yourself in one sentence.
 - 鉴权头：`x-api-key: <key>` + `anthropic-version: 2023-06-01`（非 `Authorization: Bearer`）。
 - 原生路径错误抛类型化 `AnthropicApiException`（子类 `AnthropicRateLimitException` / `AnthropicOverloadedException` / `AnthropicAuthenticationException` / `AnthropicInvalidRequestException`），可精确 catch；统一 `IChatService` 路径仍映射为 `CommonException`。
 
-## 9. 什么时候选 Messages
+## 9. Spring Boot starter 配置
+
+`ai4j-spring-boot-starter` 通过 `@ConfigurationProperties(prefix = "ai.anthropic")` 暴露 Anthropic 配置，auto-config 把 `ai.anthropic.*` 灌进 `AnthropicConfig`：
+
+```yaml
+ai:
+  anthropic:
+    api-key: ${ANTHROPIC_API_KEY}
+    api-host: https://open.bigmodel.cn/api/anthropic/   # 默认 api.anthropic.com；coding-plan 改这里
+    chat-completion-url: v1/messages                      # 默认
+    api-version: "2023-06-01"                             # 默认
+```
+
+配置后即可 `aiService.getMessagesService(PlatformType.ANTHROPIC)` 拿到原生服务；agent 侧用 `.anthropicMessages(apiKey, baseUrl)`（见第 5 节）。
+
+## 10. 什么时候选 Messages
 
 适合 `Messages` 原生路径：
 
@@ -139,7 +154,7 @@ AgentResult result = agent.newSession().run("Introduce yourself in one sentence.
 - 你想跨 provider 一套 OpenAI 格式调用，Anthropic 只是其中一家
 - 你已有成熟 OpenAI 兼容链路
 
-## 10. 继续阅读
+## 11. 继续阅读
 
 1. [Chat](/docs/core-sdk/model-access/chat)
 2. [Responses](/docs/core-sdk/model-access/responses)


### PR DESCRIPTION
Round-2 audit fixes.

- **#1 robustness**: native `messagesStream` used unbounded `latch.await()` — a direct `IMessagesService` caller with a long/no-read-timeout client could block forever on a hung stream. Add a 10-min safety-net (`STREAM_TIMEOUT_MS`): on timeout, cancel the `EventSource` and throw `AnthropicApiException`. (Fine-grained stall detection still relies on the caller's OkHttp read timeout; this only prevents indefinite block.)
- **#2 coverage**: `AnthropicApiException.of(status,type,...)` -> subclass mapping had zero tests. Add `AnthropicApiExceptionTest` (type-based, status-based-with-null-type, fallback-to-base, field preservation).
- **#3 docs**: `messages.md` add a Spring Boot starter section (`ai.anthropic` `@ConfigurationProperties` + `application.yml` example) so Spring users see the config path added in #137; renumber subsequent sections.

Verified: ai4j 122 tests 0 failures; `AnthropicApiExceptionTest` 3/3; `docs-site npm run build` SUCCESS.