### PR TITLE
feat(anthropic): configurable stream timeout + offline http test + openAiChat live

### DIFF
--- a/ai4j-agent/src/test/java/io/github/lnyocly/AgentOpenAiChatConvenienceLiveTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/AgentOpenAiChatConvenienceLiveTest.java
@@ -1,0 +1,51 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.AgentSession;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live: {@code AgentBuilder.openAiChat(apiKey, baseUrl)} wires an agent onto the OpenAI Chat
+ * Completions surface end-to-end. Uses MiniMax's new OpenAI-compatible gateway
+ * (api.minimaxi.com/v1/chat/completions) + MiniMax-M3 + coding-plan key (all verified to interop).
+ * <p>Env: {@code MINIMAX_API_KEY} (required), {@code OPENAI_CHAT_BASE_URL} (default minimax gateway),
+ * {@code OPENAI_CHAT_MODEL} (default MiniMax-M3).
+ */
+@Category(LiveProviderTest.class)
+public class AgentOpenAiChatConvenienceLiveTest {
+
+    @Test
+    public void agentRunsOnOpenAiChatViaConvenience() throws Exception {
+        String key = System.getenv("MINIMAX_API_KEY");
+        Assume.assumeTrue("skip: MINIMAX_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = System.getenv("OPENAI_CHAT_BASE_URL");
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            baseUrl = "https://api.minimaxi.com/";
+        }
+        String model = System.getenv("OPENAI_CHAT_MODEL");
+        if (model == null || model.trim().isEmpty()) {
+            model = "MiniMax-M3";
+        }
+
+        Agent agent = Agents.react()
+                .openAiChat(key, baseUrl)
+                .model(model)
+                .build();
+
+        AgentSession session = agent.newSession();
+        AgentResult result = session.run("Introduce yourself in one short sentence.");
+        System.out.println("=== openAiChat convenience output ===");
+        System.out.println(result.getOutputText());
+        assertNotNull(result);
+        assertTrue("agent output must be non-empty via openAiChat convenience",
+                result.getOutputText() != null && !result.getOutputText().isEmpty());
+    }
+}

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
@@ -376,6 +376,7 @@ public class AiConfigAutoConfiguration {
         anthropicConfig.setApiKey(anthropicConfigProperties.getApiKey());
         anthropicConfig.setChatCompletionUrl(anthropicConfigProperties.getChatCompletionUrl());
         anthropicConfig.setApiVersion(anthropicConfigProperties.getApiVersion());
+        anthropicConfig.setStreamTimeoutMillis(anthropicConfigProperties.getStreamTimeoutMillis());
 
         configuration.setAnthropicConfig(anthropicConfig);
     }

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AnthropicConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AnthropicConfigProperties.java
@@ -16,4 +16,5 @@ public class AnthropicConfigProperties {
     private String apiKey = "";
     private String chatCompletionUrl = "v1/messages";
     private String apiVersion = "2023-06-01";
+    private long streamTimeoutMillis = 600_000L;
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/AnthropicConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/AnthropicConfig.java
@@ -20,4 +20,7 @@ public class AnthropicConfig {
     private String apiKey = "";
     private String chatCompletionUrl = "v1/messages";
     private String apiVersion = "2023-06-01";
+
+    /** 单次流式调用的安全网超时上限（毫秒），防止挂起的流永久阻塞 messagesStream。默认 10 分钟。 */
+    private long streamTimeoutMillis = 600_000L;
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicMessagesService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicMessagesService.java
@@ -87,10 +87,12 @@ public class AnthropicMessagesService implements IMessagesService {
             }
         }, errorRef);
         EventSource eventSource = factory.newEventSource(httpRequest, listener);
-        if (!latch.await(STREAM_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        long timeoutMs = anthropicConfig.getStreamTimeoutMillis() > 0
+                ? anthropicConfig.getStreamTimeoutMillis() : STREAM_TIMEOUT_MS;
+        if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
             eventSource.cancel();
             throw new AnthropicApiException(0, "stream_timeout",
-                    "anthropic stream timed out after " + STREAM_TIMEOUT_MS + "ms", null);
+                    "anthropic stream timed out after " + timeoutMs + "ms", null);
         }
         Throwable err = errorRef.get();
         if (err != null) {

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicChatServiceHttpTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/anthropic/chat/AnthropicChatServiceHttpTest.java
@@ -1,0 +1,90 @@
+package io.github.lnyocly.ai4j.platform.anthropic.chat;
+
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletion;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletionResponse;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.service.Configuration;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Offline (CI-runnable) test of the unified {@link AnthropicChatService} non-stream path:
+ * convert ChatCompletion -> Anthropic Messages, send with x-api-key + anthropic-version,
+ * parse the Anthropic response back to ChatCompletionResponse. Uses an OkHttp interceptor
+ * (no real network) so this runs in CI without credentials.
+ */
+public class AnthropicChatServiceHttpTest {
+
+    @Test
+    public void chatCompletionShouldSendAnthropicRequestAndParseResponse() throws Exception {
+        final AtomicInteger requestCount = new AtomicInteger();
+        final AtomicReference<Request> recordedRequest = new AtomicReference<Request>();
+        final String responseJson = "{"
+                + "\"id\":\"msg_1\","
+                + "\"type\":\"message\","
+                + "\"role\":\"assistant\","
+                + "\"model\":\"claude-test\","
+                + "\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}],"
+                + "\"stop_reason\":\"end_turn\","
+                + "\"usage\":{\"input_tokens\":5,\"output_tokens\":3}"
+                + "}";
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    requestCount.incrementAndGet();
+                    recordedRequest.set(chain.request());
+                    return new Response.Builder()
+                            .request(chain.request())
+                            .protocol(Protocol.HTTP_1_1)
+                            .code(200)
+                            .message("OK")
+                            .body(ResponseBody.create(responseJson, MediaType.get("application/json")))
+                            .build();
+                })
+                .build();
+
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey("test-key");
+        config.setApiHost("https://unit.test/");
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        configuration.setOkHttpClient(okHttpClient);
+
+        AnthropicChatService service = new AnthropicChatService(configuration);
+
+        ChatCompletion req = ChatCompletion.builder()
+                .model("claude-test")
+                .message(ChatMessage.withUser("hi"))
+                .build();
+
+        ChatCompletionResponse resp = service.chatCompletion(req);
+
+        // response mapping: text block -> outputText; stop_reason end_turn -> stop
+        Assert.assertNotNull(resp);
+        Assert.assertEquals(1, resp.getChoices().size());
+        Assert.assertEquals("Hello", resp.getChoices().get(0).getMessage().getContent().getText());
+        Assert.assertEquals("stop", resp.getChoices().get(0).getFinishReason());
+        Assert.assertEquals(8L, resp.getUsage().getTotalTokens());
+
+        // request shape: single round, anthropic auth headers, v1/messages URL
+        Assert.assertEquals("single round-trip expected", 1, requestCount.get());
+        Request sent = recordedRequest.get();
+        Assert.assertNotNull(sent);
+        Assert.assertEquals("test-key", sent.header("x-api-key"));
+        Assert.assertEquals("2023-06-01", sent.header("anthropic-version"));
+        String url = sent.url().toString();
+        Assert.assertTrue("url should target unit.test: " + url, url.contains("unit.test"));
+        Assert.assertTrue("url should end with v1/messages: " + url, url.endsWith("v1/messages"));
+        Assert.assertEquals("POST", sent.method());
+    }
+}


### PR DESCRIPTION
Round-3 edge improvements from the third self-audit pass.

- **#1 configurable stream timeout**: `AnthropicConfig.streamTimeoutMillis` (default 600000ms) now drives the native `messagesStream` safety-net (was a fixed constant); mirrored in `AnthropicConfigProperties` + starter auto-config. Callers with long thinking streams can raise it instead of editing code.
- **#2 openAiChat live**: `AgentOpenAiChatConvenienceLiveTest` runs `.openAiChat` end-to-end on MiniMax's OpenAI-compatible gateway (MiniMax-M3 + coding-plan key) — closes the 'openAiChat only unit-tested' gap.
- **#3 offline http test**: `AnthropicChatServiceHttpTest` exercises the unified non-stream path (convert -> x-api-key/anthropic-version -> parse) via an OkHttp interceptor — CI-runnable without credentials (previously only live-tested via AnthropicTest).
- **#4 provider scan**: all other provider apiHost defaults look current; only Minimax was stale (fixed in #134).

Verified: ai4j 123 + ai4j-agent 133 + starter 9 tests, 0 failures; openAiChat live 1/1; diff hygiene clean.