### PR TITLE
feat(agent): E2B sandbox provider (Connect process.Start)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BApiException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BApiException.java
@@ -1,0 +1,34 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import java.io.IOException;
+
+/**
+ * HTTP-level E2B API error.
+ */
+final class E2BApiException extends IOException {
+
+    private final int statusCode;
+    private final String responseBody;
+
+    E2BApiException(int statusCode, String message, String responseBody) {
+        super(message);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    int getStatusCode() {
+        return statusCode;
+    }
+
+    String getResponseBody() {
+        return responseBody;
+    }
+
+    boolean isNotFound() {
+        return statusCode == 404;
+    }
+
+    boolean isAuthFailure() {
+        return statusCode == 401 || statusCode == 403;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BCreateSandboxResponse.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BCreateSandboxResponse.java
@@ -1,0 +1,70 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+/**
+ * Minimal E2B {@code POST /sandboxes} response DTO.
+ *
+ * <p>The modern E2B control API returns {@code sandboxID}, {@code clientID}, {@code envdVersion},
+ * {@code templateID} and {@code alias}. Older/secure flows additionally return an
+ * {@code envdAccessToken} used to authenticate the per-sandbox execution host; when absent the
+ * API key itself is used as the execution bearer token.</p>
+ */
+public final class E2BCreateSandboxResponse {
+
+    private String sandboxID;
+    private String clientID;
+    private String envdVersion;
+    private String templateID;
+    private String alias;
+    private String envdAccessToken;
+
+    public E2BCreateSandboxResponse() {
+    }
+
+    public String getSandboxID() {
+        return sandboxID;
+    }
+
+    public void setSandboxID(String sandboxID) {
+        this.sandboxID = sandboxID;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public String getEnvdVersion() {
+        return envdVersion;
+    }
+
+    public void setEnvdVersion(String envdVersion) {
+        this.envdVersion = envdVersion;
+    }
+
+    public String getTemplateID() {
+        return templateID;
+    }
+
+    public void setTemplateID(String templateID) {
+        this.templateID = templateID;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getEnvdAccessToken() {
+        return envdAccessToken;
+    }
+
+    public void setEnvdAccessToken(String envdAccessToken) {
+        this.envdAccessToken = envdAccessToken;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BProcessResult.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BProcessResult.java
@@ -1,0 +1,52 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+/**
+ * Aggregated result of one E2B {@code process.Process/Start} Connect server-streaming call.
+ *
+ * <p>Assembled by {@link E2BSandboxClient} from the Connect envelope frames: {@code start}
+ * (pid), {@code data} (base64-encoded {@code stdout}/{@code stderr} chunks) and {@code end}
+ * (numeric {@code exitCode}). If the stream terminates with a Connect error trailer the
+ * {@code error} field is populated instead and {@code exitCode} stays null.</p>
+ */
+public final class E2BProcessResult {
+
+    private final Long pid;
+    private final Integer exitCode;
+    private final String stdout;
+    private final String stderr;
+    private final String error;
+    private final boolean exited;
+
+    E2BProcessResult(Long pid, Integer exitCode, String stdout, String stderr, String error, boolean exited) {
+        this.pid = pid;
+        this.exitCode = exitCode;
+        this.stdout = stdout;
+        this.stderr = stderr;
+        this.error = error;
+        this.exited = exited;
+    }
+
+    public Long getPid() {
+        return pid;
+    }
+
+    public Integer getExitCode() {
+        return exitCode;
+    }
+
+    public String getStdout() {
+        return stdout;
+    }
+
+    public String getStderr() {
+        return stderr;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public boolean isExited() {
+        return exited;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxClient.java
@@ -1,0 +1,388 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Small Java 8 E2B HTTP client used by {@link E2BSandboxProvider}.
+ *
+ * <p>Speaks two surfaces: the control API (JSON REST, {@code X-API-Key} auth) for
+ * create/delete, and the per-sandbox execution host (Connect server-streaming
+ * {@code process.Process/Start}, Bearer auth) for running commands.</p>
+ */
+public class E2BSandboxClient {
+
+    private static final String UTF_8 = StandardCharsets.UTF_8.name();
+    private static final long MAX_FRAME_BYTES = 64L * 1024 * 1024;
+
+    private final E2BSandboxConfig config;
+
+    public E2BSandboxClient(E2BSandboxConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("e2b sandbox config must not be null");
+        }
+        this.config = config;
+    }
+
+    E2BSandboxConfig getConfig() {
+        return config;
+    }
+
+    public E2BCreateSandboxResponse createSandbox() throws IOException {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        body.put("templateID", config.getTemplateId());
+        body.put("timeout", config.getTimeoutSeconds());
+        Map<String, Object> options = config.getCreateOptions();
+        if (options != null && !options.isEmpty()) {
+            body.putAll(options);
+        }
+        return request("POST", config.getApiUrl() + "/sandboxes", body, E2BCreateSandboxResponse.class);
+    }
+
+    public void deleteSandbox(String sandboxId) throws IOException {
+        String id = requireText(sandboxId, "sandbox id must not be blank");
+        request("DELETE", config.getApiUrl() + "/sandboxes/" + encodePath(id), null, null);
+    }
+
+    /**
+     * Runs one command against a sandbox execution host using the Connect server-streaming
+     * {@code process.Process/Start} RPC and aggregates the streamed response into a result.
+     *
+     * @param sandboxHost     execution host, e.g. {@code https://49983-<sid>.e2b.app}
+     * @param executionToken  bearer token for the execution host (API key or envd access token)
+     * @param accessToken     optional {@code X-Access-Token} (envd access token); may be null
+     * @param cmd             executable
+     * @param args            argument list
+     * @param envs            environment variables
+     * @param cwd             working directory; may be null
+     * @param readTimeoutMillis socket read timeout for the streaming response
+     */
+    public E2BProcessResult execute(String sandboxHost,
+                                    String executionToken,
+                                    String accessToken,
+                                    String cmd,
+                                    List<String> args,
+                                    Map<String, String> envs,
+                                    String cwd,
+                                    long readTimeoutMillis) throws IOException {
+        byte[] frame = buildProcessFrame(cmd, args, envs, cwd);
+        String base = E2BSandboxConfig.trimTrailingSlash(sandboxHost);
+        if (base == null) {
+            throw new IOException("E2B sandbox host is not configured");
+        }
+        String url = base + "/process.Process/Start";
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(safeTimeout(config.getConnectTimeoutMillis()));
+            connection.setReadTimeout(safeTimeout(readTimeoutMillis));
+            connection.setRequestProperty("Content-Type", "application/connect+json");
+            connection.setRequestProperty("Connect-Protocol-Version", "1");
+            connection.setRequestProperty("Accept", "application/connect+json");
+            connection.setRequestProperty("User-Agent", "ai4j-agent-e2b-sandbox/1");
+            if (executionToken != null) {
+                connection.setRequestProperty("Authorization", "Bearer " + executionToken);
+            }
+            if (accessToken != null) {
+                connection.setRequestProperty("X-Access-Token", accessToken);
+            }
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Length", String.valueOf(frame.length));
+            OutputStream output = connection.getOutputStream();
+            try {
+                output.write(frame);
+            } finally {
+                output.close();
+            }
+            int status = connection.getResponseCode();
+            InputStream stream = status >= 400 ? connection.getErrorStream() : connection.getInputStream();
+            if (status >= 400) {
+                String errorBody = readBody(stream);
+                throw new E2BApiException(status, "E2B execute failed: POST " + url + " -> " + status, errorBody);
+            }
+            E2BProcessResult result = parseConnectStream(stream);
+            // A Connect trailer carrying a top-level "error" is a protocol failure (not a command
+            // non-zero exit), so surface it as an exception.
+            if (result.getError() != null && !result.isExited()) {
+                throw new E2BApiException(status, "E2B execute protocol error: " + result.getError(),
+                        result.getStderr());
+            }
+            return result;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /**
+     * Builds the Connect unary request frame for {@code process.Process/Start}:
+     * one envelope {@code 0x00 + big-endian uint32 length + JSON payload}.
+     */
+    static byte[] buildProcessFrame(String cmd, List<String> args, Map<String, String> envs, String cwd) {
+        Map<String, Object> process = new LinkedHashMap<String, Object>();
+        process.put("cmd", cmd);
+        process.put("args", args != null ? args : Collections.<String>emptyList());
+        process.put("envs", envs != null ? envs : Collections.<String, String>emptyMap());
+        if (cwd != null) {
+            process.put("cwd", cwd);
+        }
+        Map<String, Object> root = new LinkedHashMap<String, Object>();
+        root.put("process", process);
+        root.put("stdin", false);
+        byte[] json = JSON.toJSONString(root).getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(json.length + 5);
+        out.write(0x00);
+        writeUnsignedInt(out, json.length);
+        out.write(json, 0, json.length);
+        return out.toByteArray();
+    }
+
+    /**
+     * Parses a Connect streaming response (sequence of envelopes) into an aggregated result.
+     * Each envelope is {@code 1 byte flags + big-endian uint32 length + JSON payload}; the
+     * end-of-stream envelope has flag bit {@code 0x02} set and may carry a trailer object.
+     */
+    static E2BProcessResult parseConnectStream(InputStream input) throws IOException {
+        java.io.DataInputStream din = new java.io.DataInputStream(new BufferedInputStream(input));
+        StringBuilder stdout = new StringBuilder();
+        StringBuilder stderr = new StringBuilder();
+        Long pid = null;
+        Integer exitCode = null;
+        boolean exited = false;
+        String error = null;
+        while (true) {
+            int flagsByte = din.read();
+            if (flagsByte == -1) {
+                break;
+            }
+            long length = readUnsignedInt(din);
+            if (length < 0 || length > MAX_FRAME_BYTES) {
+                throw new IOException("invalid Connect frame length: " + length);
+            }
+            byte[] payload = new byte[(int) length];
+            if (length > 0) {
+                din.readFully(payload);
+            }
+            if (length == 0) {
+                if ((flagsByte & 0x02) != 0) {
+                    break;
+                }
+                continue;
+            }
+            String json = new String(payload, StandardCharsets.UTF_8);
+            JSONObject root = parseLenient(json);
+            if (root != null) {
+                JSONObject errorObj = root.getJSONObject("error");
+                if (errorObj != null) {
+                    String message = errorObj.getString("message");
+                    error = message != null ? message : json;
+                }
+                JSONObject event = root.getJSONObject("event");
+                if (event != null) {
+                    JSONObject start = event.getJSONObject("start");
+                    if (start != null && pid == null) {
+                        Integer p = start.getInteger("pid");
+                        pid = p == null ? null : p.longValue();
+                    }
+                    JSONObject data = event.getJSONObject("data");
+                    if (data != null) {
+                        appendBase64(stdout, data.getString("stdout"));
+                        appendBase64(stderr, data.getString("stderr"));
+                    }
+                    JSONObject end = event.getJSONObject("end");
+                    if (end != null) {
+                        exited = true;
+                        Integer code = end.getInteger("exitCode");
+                        if (code == null) {
+                            // E2B omits the numeric exitCode on a clean (0) exit and only sends
+                            // "status":"exit status <N>"; fall back to parsing it.
+                            code = parseExitCodeFromStatus(end.getString("status"));
+                        }
+                        if (code != null) {
+                            exitCode = code;
+                        }
+                    }
+                }
+            }
+            if ((flagsByte & 0x02) != 0) {
+                break;
+            }
+        }
+        return new E2BProcessResult(pid, exitCode, stdout.toString(), stderr.toString(), error, exited);
+    }
+
+    private static JSONObject parseLenient(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON.parseObject(json);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the trailing integer from an E2B process end status such as
+     * {@code "exit status 0"} or {@code "exit status 7"}.
+     */
+    private static Integer parseExitCodeFromStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        int end = status.length();
+        while (end > 0 && !Character.isDigit(status.charAt(end - 1))) {
+            end--;
+        }
+        int start = end;
+        while (start > 0 && Character.isDigit(status.charAt(start - 1))) {
+            start--;
+        }
+        if (start == end) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(status.substring(start, end));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static void appendBase64(StringBuilder target, String encoded) {
+        if (encoded == null || encoded.isEmpty()) {
+            return;
+        }
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(encoded);
+        } catch (IllegalArgumentException notBase64) {
+            // Fall back to the raw token rather than dropping the output.
+            target.append(encoded);
+            return;
+        }
+        target.append(new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    private static void writeUnsignedInt(ByteArrayOutputStream out, int value) {
+        out.write((value >>> 24) & 0xFF);
+        out.write((value >>> 16) & 0xFF);
+        out.write((value >>> 8) & 0xFF);
+        out.write(value & 0xFF);
+    }
+
+    private static long readUnsignedInt(java.io.DataInputStream din) throws IOException {
+        int ch1 = din.read();
+        int ch2 = din.read();
+        int ch3 = din.read();
+        int ch4 = din.read();
+        if ((ch1 | ch2 | ch3 | ch4) < 0) {
+            throw new EOFException("unexpected end of Connect frame header");
+        }
+        return ((long) ch1 << 24) | ((long) ch2 << 16) | ((long) ch3 << 8) | (long) ch4;
+    }
+
+    protected <T> T request(String method, String url, Object payload, Class<T> responseType) throws IOException {
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestMethod(method);
+            connection.setConnectTimeout(safeTimeout(config.getConnectTimeoutMillis()));
+            connection.setReadTimeout(safeTimeout(config.getReadTimeoutMillis()));
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("User-Agent", "ai4j-agent-e2b-sandbox/1");
+            setAuthHeaders(connection);
+            byte[] requestBytes = null;
+            if (payload != null) {
+                requestBytes = JSON.toJSONString(payload).getBytes(StandardCharsets.UTF_8);
+                connection.setDoOutput(true);
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setRequestProperty("Content-Length", String.valueOf(requestBytes.length));
+            }
+            if (requestBytes != null) {
+                OutputStream output = connection.getOutputStream();
+                try {
+                    output.write(requestBytes);
+                } finally {
+                    output.close();
+                }
+            }
+            int status = connection.getResponseCode();
+            String body = readBody(status >= 400 ? connection.getErrorStream() : connection.getInputStream());
+            if (status < 200 || status >= 300) {
+                throw new E2BApiException(status, "E2B API request failed: " + method + " " + url + " -> " + status, body);
+            }
+            if (responseType == null || responseType == Void.class) {
+                return null;
+            }
+            if (body == null || body.trim().isEmpty()) {
+                return null;
+            }
+            return JSON.parseObject(body, responseType);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private void setAuthHeaders(HttpURLConnection connection) {
+        String apiKey = config.getApiKey();
+        if (apiKey != null) {
+            connection.setRequestProperty("X-API-Key", apiKey);
+        }
+    }
+
+    private static String readBody(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int read;
+        try {
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+        } finally {
+            input.close();
+        }
+        return new String(output.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static int safeTimeout(long timeoutMillis) {
+        if (timeoutMillis > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) timeoutMillis;
+    }
+
+    static String encodePath(String value) throws IOException {
+        return URLEncoder.encode(value, UTF_8).replace("+", "%20");
+    }
+
+    static String requireText(String value, String message) {
+        String text = E2BSandboxConfig.trimToNull(value);
+        if (text == null) {
+            throw new IllegalArgumentException(message);
+        }
+        return text;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxConfig.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxConfig.java
@@ -1,0 +1,586 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Connection and creation settings for the E2B sandbox provider.
+ *
+ * <p>E2B exposes two surfaces: a main control API (default {@code https://api.e2b.app},
+ * authenticated with {@code X-API-Key}) used to create/delete sandboxes, and a per-sandbox
+ * execution host (default {@code https://49983-&lt;sandboxID&gt;.e2b.app}, authenticated with
+ * {@code Authorization: Bearer &lt;apiKey&gt;}) that speaks the Connect server-streaming
+ * {@code process.Process/Start} protocol.</p>
+ */
+public final class E2BSandboxConfig {
+
+    public static final String DEFAULT_PROVIDER_ID = "e2b";
+    public static final String DEFAULT_DOMAIN = "e2b.app";
+    public static final String DEFAULT_TEMPLATE_ID = "base";
+    public static final int DEFAULT_ENVD_PORT = 49983;
+    public static final int DEFAULT_TIMEOUT_SECONDS = 300;
+
+    private final String providerId;
+    private final String apiKey;
+    private final String apiDomain;
+    private final String apiUrl;
+    private final String templateId;
+    private final Integer timeoutSeconds;
+    private final Integer envdPort;
+    private final String sandboxUrl;
+    private final String envdAccessToken;
+    private final boolean useShellWrap;
+    private final boolean deleteOnClose;
+    private final long connectTimeoutMillis;
+    private final long readTimeoutMillis;
+    private final long startTimeoutMillis;
+    private final long pollIntervalMillis;
+    private final Map<String, String> labels;
+    private final Map<String, String> environment;
+    private final Map<String, Object> createOptions;
+    private final SandboxSpec spec;
+
+    private E2BSandboxConfig(Builder builder) {
+        this.providerId = firstNonBlank(builder.providerId, DEFAULT_PROVIDER_ID);
+        this.apiKey = trimToNull(builder.apiKey);
+        this.apiDomain = trimTrailingSlash(firstNonBlank(builder.apiDomain, DEFAULT_DOMAIN));
+        this.apiUrl = trimTrailingSlash(firstNonBlank(builder.apiUrl, "https://api." + this.apiDomain));
+        this.templateId = firstNonBlank(builder.templateId, DEFAULT_TEMPLATE_ID);
+        this.timeoutSeconds = builder.timeoutSeconds == null ? Integer.valueOf(DEFAULT_TIMEOUT_SECONDS) : builder.timeoutSeconds;
+        this.envdPort = builder.envdPort == null ? Integer.valueOf(DEFAULT_ENVD_PORT) : builder.envdPort;
+        this.sandboxUrl = trimTrailingSlash(builder.sandboxUrl);
+        this.envdAccessToken = trimToNull(builder.envdAccessToken);
+        this.useShellWrap = builder.useShellWrap == null || builder.useShellWrap.booleanValue();
+        this.deleteOnClose = builder.deleteOnClose == null || builder.deleteOnClose.booleanValue();
+        this.connectTimeoutMillis = positiveOrDefault(builder.connectTimeoutMillis, 10000L);
+        this.readTimeoutMillis = positiveOrDefault(builder.readTimeoutMillis, 120000L);
+        this.startTimeoutMillis = nonNegativeOrDefault(builder.startTimeoutMillis, 60000L);
+        this.pollIntervalMillis = positiveOrDefault(builder.pollIntervalMillis, 1000L);
+        this.labels = copyStringMap(builder.labels);
+        this.environment = copyStringMap(builder.environment);
+        this.createOptions = copyObjectMap(builder.createOptions);
+        this.spec = builder.spec == null
+                ? SandboxSpec.builder().providerId(this.providerId).build()
+                : builder.spec.copy();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static E2BSandboxConfig fromEnvironment(SandboxSpec spec) {
+        return fromEnvironment(spec, System.getenv());
+    }
+
+    public static E2BSandboxConfig fromEnvironment(SandboxSpec spec, Map<String, String> env) {
+        Builder builder = builder()
+                .providerId(DEFAULT_PROVIDER_ID)
+                .apiKey(envValue(env, "E2B_API_KEY"))
+                .apiDomain(firstNonBlank(envValue(env, "E2B_DOMAIN"), DEFAULT_DOMAIN))
+                .apiUrl(envValue(env, "E2B_API_URL"))
+                .templateId(firstNonBlank(envValue(env, "E2B_TEMPLATE_ID"), DEFAULT_TEMPLATE_ID))
+                .envdAccessToken(envValue(env, "E2B_ACCESS_TOKEN"))
+                .sandboxUrl(envValue(env, "E2B_SANDBOX_URL"));
+        String envdPort = envValue(env, "E2B_ENVD_PORT");
+        if (envdPort != null) {
+            builder.envdPort(asInt(envdPort));
+        }
+        String timeout = envValue(env, "E2B_TIMEOUT");
+        if (timeout != null) {
+            builder.timeoutSeconds(asInt(timeout));
+        }
+        applySpec(builder, spec);
+        return builder.build();
+    }
+
+    private static void applySpec(Builder builder, SandboxSpec spec) {
+        if (spec == null) {
+            return;
+        }
+        builder.spec(spec.copy());
+        if (spec.getProviderId() != null) {
+            builder.providerId(spec.getProviderId());
+        }
+        if (spec.getImage() != null) {
+            builder.templateId(spec.getImage());
+        }
+        builder.labels(spec.getLabels());
+
+        Map<String, Object> config = spec.getConfig();
+        builder.apiKey(asString(config.get("apiKey")));
+        builder.apiDomain(asString(config.get("apiDomain")));
+        builder.apiUrl(asString(config.get("apiUrl")));
+        builder.templateId(firstNonBlank(asString(config.get("templateId")), asString(config.get("templateID"))));
+        builder.envdPort(asInt(config.get("envdPort")));
+        builder.timeoutSeconds(asInt(config.get("timeoutSeconds")));
+        builder.sandboxUrl(asString(config.get("sandboxUrl")));
+        builder.envdAccessToken(asString(config.get("envdAccessToken")));
+        builder.useShellWrap(asBoolean(config.get("useShellWrap")));
+        builder.deleteOnClose(asBoolean(config.get("deleteOnClose")));
+        builder.connectTimeoutMillis(asLong(config.get("connectTimeoutMillis")));
+        builder.readTimeoutMillis(asLong(config.get("readTimeoutMillis")));
+        builder.startTimeoutMillis(asLong(config.get("startTimeoutMillis")));
+        builder.pollIntervalMillis(asLong(config.get("pollIntervalMillis")));
+        builder.environment(asStringMap(config.get("env")));
+
+        Map<String, Object> createOptions = new LinkedHashMap<String, Object>();
+        copyKnownCreateOption(config, createOptions, "public");
+        copyKnownCreateOption(config, createOptions, "secure");
+        copyKnownCreateOption(config, createOptions, "metadata");
+        copyKnownCreateOption(config, createOptions, "resources");
+        builder.createOptions(createOptions);
+    }
+
+    private static void copyKnownCreateOption(Map<String, Object> source, Map<String, Object> target, String key) {
+        if (source.containsKey(key)) {
+            target.put(key, source.get(key));
+        }
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getApiDomain() {
+        return apiDomain;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public Integer getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public Integer getEnvdPort() {
+        return envdPort;
+    }
+
+    public String getSandboxUrl() {
+        return sandboxUrl;
+    }
+
+    public String getEnvdAccessToken() {
+        return envdAccessToken;
+    }
+
+    public boolean isUseShellWrap() {
+        return useShellWrap;
+    }
+
+    public boolean isDeleteOnClose() {
+        return deleteOnClose;
+    }
+
+    public long getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public long getReadTimeoutMillis() {
+        return readTimeoutMillis;
+    }
+
+    public long getStartTimeoutMillis() {
+        return startTimeoutMillis;
+    }
+
+    public long getPollIntervalMillis() {
+        return pollIntervalMillis;
+    }
+
+    public Map<String, String> getLabels() {
+        return copyStringMap(labels);
+    }
+
+    public Map<String, String> getEnvironment() {
+        return copyStringMap(environment);
+    }
+
+    public Map<String, Object> getCreateOptions() {
+        return copyObjectMap(createOptions);
+    }
+
+    public SandboxSpec getSpec() {
+        return spec.copy();
+    }
+
+    /**
+     * Builds the per-sandbox execution host URL for a given sandbox id.
+     */
+    public String buildSandboxHost(String sandboxId) {
+        if (sandboxUrl != null) {
+            return sandboxUrl;
+        }
+        String id = trimToNull(sandboxId);
+        if (id == null) {
+            return null;
+        }
+        return "https://" + envdPort.intValue() + "-" + id + "." + apiDomain;
+    }
+
+    E2BSandboxConfig withSpecOverrides(SandboxSpec spec) {
+        if (spec == null) {
+            return this;
+        }
+        Builder builder = builder()
+                .providerId(providerId)
+                .apiKey(apiKey)
+                .apiDomain(apiDomain)
+                .apiUrl(apiUrl)
+                .templateId(templateId)
+                .envdPort(envdPort)
+                .timeoutSeconds(timeoutSeconds)
+                .sandboxUrl(sandboxUrl)
+                .envdAccessToken(envdAccessToken)
+                .useShellWrap(Boolean.valueOf(useShellWrap))
+                .deleteOnClose(Boolean.valueOf(deleteOnClose))
+                .connectTimeoutMillis(Long.valueOf(connectTimeoutMillis))
+                .readTimeoutMillis(Long.valueOf(readTimeoutMillis))
+                .startTimeoutMillis(Long.valueOf(startTimeoutMillis))
+                .pollIntervalMillis(Long.valueOf(pollIntervalMillis))
+                .labels(labels)
+                .environment(environment)
+                .createOptions(createOptions)
+                .spec(this.spec);
+        applySpec(builder, spec);
+        builder.apiKey(firstNonBlank(apiKey, builder.apiKey));
+        builder.apiUrl(firstNonBlank(apiUrl, builder.apiUrl));
+        builder.templateId(firstNonBlank(templateId, builder.templateId));
+        return builder.build();
+    }
+
+    E2BSandboxConfig withDeleteOnClose(boolean deleteOnClose) {
+        return builder()
+                .providerId(providerId)
+                .apiKey(apiKey)
+                .apiDomain(apiDomain)
+                .apiUrl(apiUrl)
+                .templateId(templateId)
+                .envdPort(envdPort)
+                .timeoutSeconds(timeoutSeconds)
+                .sandboxUrl(sandboxUrl)
+                .envdAccessToken(envdAccessToken)
+                .useShellWrap(useShellWrap)
+                .deleteOnClose(deleteOnClose)
+                .connectTimeoutMillis(connectTimeoutMillis)
+                .readTimeoutMillis(readTimeoutMillis)
+                .startTimeoutMillis(startTimeoutMillis)
+                .pollIntervalMillis(pollIntervalMillis)
+                .labels(labels)
+                .environment(environment)
+                .createOptions(createOptions)
+                .spec(spec)
+                .build();
+    }
+
+    static String firstNonBlank(String first, String second) {
+        String value = trimToNull(first);
+        return value != null ? value : trimToNull(second);
+    }
+
+    static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    static String trimTrailingSlash(String value) {
+        String trimmed = trimToNull(value);
+        if (trimmed == null) {
+            return null;
+        }
+        while (trimmed.endsWith("/") && trimmed.length() > 1) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    static Map<String, String> copyStringMap(Map<String, String> source) {
+        Map<String, String> copy = new LinkedHashMap<String, String>();
+        if (source != null) {
+            for (Map.Entry<String, String> entry : source.entrySet()) {
+                if (entry != null && trimToNull(entry.getKey()) != null && entry.getValue() != null) {
+                    copy.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return copy;
+    }
+
+    static Map<String, Object> copyObjectMap(Map<String, Object> source) {
+        Map<String, Object> copy = new LinkedHashMap<String, Object>();
+        if (source != null) {
+            for (Map.Entry<String, Object> entry : source.entrySet()) {
+                if (entry != null && trimToNull(entry.getKey()) != null && entry.getValue() != null) {
+                    copy.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return copy;
+    }
+
+    static String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value);
+        return trimToNull(text);
+    }
+
+    private static Boolean asBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String text = asString(value);
+        return text == null ? null : Boolean.valueOf(text);
+    }
+
+    static Integer asInt(Object value) {
+        if (value instanceof Number) {
+            return Integer.valueOf(((Number) value).intValue());
+        }
+        String text = asString(value);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(text);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long asLong(Object value) {
+        if (value instanceof Number) {
+            return Long.valueOf(((Number) value).longValue());
+        }
+        String text = asString(value);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return Long.valueOf(text);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> asStringMap(Object value) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        if (!(value instanceof Map)) {
+            return result;
+        }
+        Map<Object, Object> source = (Map<Object, Object>) value;
+        for (Map.Entry<Object, Object> entry : source.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                result.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    private static long positiveOrDefault(Long value, long fallback) {
+        return value != null && value.longValue() > 0L ? value.longValue() : fallback;
+    }
+
+    private static long nonNegativeOrDefault(Long value, long fallback) {
+        return value != null && value.longValue() >= 0L ? value.longValue() : fallback;
+    }
+
+    private static String envValue(Map<String, String> env, String key) {
+        return env == null ? null : env.get(key);
+    }
+
+    public static final class Builder {
+        private String providerId;
+        private String apiKey;
+        private String apiDomain;
+        private String apiUrl;
+        private String templateId;
+        private Integer timeoutSeconds;
+        private Integer envdPort;
+        private String sandboxUrl;
+        private String envdAccessToken;
+        private Boolean useShellWrap;
+        private Boolean deleteOnClose;
+        private Long connectTimeoutMillis;
+        private Long readTimeoutMillis;
+        private Long startTimeoutMillis;
+        private Long pollIntervalMillis;
+        private Map<String, String> labels;
+        private Map<String, String> environment;
+        private Map<String, Object> createOptions;
+        private SandboxSpec spec;
+
+        private Builder() {
+        }
+
+        public Builder providerId(String providerId) {
+            if (providerId != null) {
+                this.providerId = providerId;
+            }
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            if (apiKey != null) {
+                this.apiKey = apiKey;
+            }
+            return this;
+        }
+
+        public Builder apiDomain(String apiDomain) {
+            if (apiDomain != null) {
+                this.apiDomain = apiDomain;
+            }
+            return this;
+        }
+
+        public Builder apiUrl(String apiUrl) {
+            if (apiUrl != null) {
+                this.apiUrl = apiUrl;
+            }
+            return this;
+        }
+
+        public Builder templateId(String templateId) {
+            if (templateId != null) {
+                this.templateId = templateId;
+            }
+            return this;
+        }
+
+        public Builder timeoutSeconds(Integer timeoutSeconds) {
+            if (timeoutSeconds != null) {
+                this.timeoutSeconds = timeoutSeconds;
+            }
+            return this;
+        }
+
+        public Builder envdPort(Integer envdPort) {
+            if (envdPort != null) {
+                this.envdPort = envdPort;
+            }
+            return this;
+        }
+
+        public Builder sandboxUrl(String sandboxUrl) {
+            if (sandboxUrl != null) {
+                this.sandboxUrl = sandboxUrl;
+            }
+            return this;
+        }
+
+        public Builder envdAccessToken(String envdAccessToken) {
+            if (envdAccessToken != null) {
+                this.envdAccessToken = envdAccessToken;
+            }
+            return this;
+        }
+
+        public Builder useShellWrap(Boolean useShellWrap) {
+            if (useShellWrap != null) {
+                this.useShellWrap = useShellWrap;
+            }
+            return this;
+        }
+
+        public Builder deleteOnClose(Boolean deleteOnClose) {
+            if (deleteOnClose != null) {
+                this.deleteOnClose = deleteOnClose;
+            }
+            return this;
+        }
+
+        public Builder connectTimeoutMillis(Long connectTimeoutMillis) {
+            if (connectTimeoutMillis != null) {
+                this.connectTimeoutMillis = connectTimeoutMillis;
+            }
+            return this;
+        }
+
+        public Builder readTimeoutMillis(Long readTimeoutMillis) {
+            if (readTimeoutMillis != null) {
+                this.readTimeoutMillis = readTimeoutMillis;
+            }
+            return this;
+        }
+
+        public Builder startTimeoutMillis(Long startTimeoutMillis) {
+            if (startTimeoutMillis != null) {
+                this.startTimeoutMillis = startTimeoutMillis;
+            }
+            return this;
+        }
+
+        public Builder pollIntervalMillis(Long pollIntervalMillis) {
+            if (pollIntervalMillis != null) {
+                this.pollIntervalMillis = pollIntervalMillis;
+            }
+            return this;
+        }
+
+        public Builder label(String key, String value) {
+            if (labels == null) {
+                labels = new LinkedHashMap<String, String>();
+            }
+            if (key != null && value != null) {
+                labels.put(key, value);
+            }
+            return this;
+        }
+
+        public Builder labels(Map<String, String> labels) {
+            if (labels != null) {
+                if (this.labels == null) {
+                    this.labels = new LinkedHashMap<String, String>();
+                }
+                this.labels.putAll(copyStringMap(labels));
+            }
+            return this;
+        }
+
+        public Builder environment(Map<String, String> environment) {
+            if (environment != null) {
+                if (this.environment == null) {
+                    this.environment = new LinkedHashMap<String, String>();
+                }
+                this.environment.putAll(copyStringMap(environment));
+            }
+            return this;
+        }
+
+        public Builder createOptions(Map<String, Object> createOptions) {
+            if (createOptions != null) {
+                if (this.createOptions == null) {
+                    this.createOptions = new LinkedHashMap<String, Object>();
+                }
+                this.createOptions.putAll(copyObjectMap(createOptions));
+            }
+            return this;
+        }
+
+        public Builder spec(SandboxSpec spec) {
+            this.spec = spec;
+            return this;
+        }
+
+        public E2BSandboxConfig build() {
+            return new E2BSandboxConfig(this);
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxProvider.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxProvider.java
@@ -1,0 +1,81 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+
+import java.io.IOException;
+
+/**
+ * E2B implementation of the agent sandbox provider SPI.
+ *
+ * <p>Creates a fresh E2B sandbox via the control API ({@code POST /sandboxes}) and hands back an
+ * {@link E2BSandboxSession} that runs commands against the sandbox's execution host using the
+ * Connect server-streaming {@code process.Process/Start} RPC.</p>
+ */
+public class E2BSandboxProvider implements SandboxProvider {
+
+    private final E2BSandboxConfig explicitConfig;
+    private final E2BSandboxClient explicitClient;
+
+    public E2BSandboxProvider() {
+        this.explicitConfig = null;
+        this.explicitClient = null;
+    }
+
+    public E2BSandboxProvider(E2BSandboxConfig config) {
+        this.explicitConfig = config;
+        this.explicitClient = null;
+    }
+
+    E2BSandboxProvider(E2BSandboxConfig config, E2BSandboxClient client) {
+        this.explicitConfig = config;
+        this.explicitClient = client;
+    }
+
+    @Override
+    public String getProviderId() {
+        return explicitConfig == null ? E2BSandboxConfig.DEFAULT_PROVIDER_ID : explicitConfig.getProviderId();
+    }
+
+    @Override
+    public boolean supports(SandboxSpec spec) {
+        if (spec == null || spec.getProviderId() == null) {
+            return true;
+        }
+        return getProviderId().equalsIgnoreCase(spec.getProviderId());
+    }
+
+    @Override
+    public SandboxSession createSession(SandboxSpec spec) throws SandboxException {
+        if (!supports(spec)) {
+            throw new SandboxException("unsupported sandbox provider: " + (spec == null ? null : spec.getProviderId()));
+        }
+        E2BSandboxConfig config = explicitConfig == null
+                ? E2BSandboxConfig.fromEnvironment(spec)
+                : explicitConfig.withSpecOverrides(spec);
+        if (E2BSandboxConfig.trimToNull(config.getApiKey()) == null) {
+            throw new SandboxException("E2B API key is required. Set E2B_API_KEY or sandbox config apiKey.");
+        }
+        E2BSandboxClient client = explicitClient == null ? new E2BSandboxClient(config) : explicitClient;
+        E2BSandboxSession session = null;
+        try {
+            E2BCreateSandboxResponse created = client.createSandbox();
+            if (created == null || E2BSandboxConfig.trimToNull(created.getSandboxID()) == null) {
+                throw new SandboxException("E2B API returned an empty sandbox id");
+            }
+            session = new E2BSandboxSession(client, config.withDeleteOnClose(config.isDeleteOnClose()), created);
+            return session;
+        } catch (IOException e) {
+            if (session != null) {
+                try {
+                    session.close();
+                } catch (Exception ignored) {
+                    // best-effort cleanup of a partially-created session
+                }
+            }
+            throw new SandboxException("failed to create E2B sandbox session", e);
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxSession.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxSession.java
@@ -1,0 +1,203 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxArtifact;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxEvent;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxEventType;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Live E2B sandbox session.
+ *
+ * <p>By default the agent-supplied command string is wrapped in {@code sh -c} so the full shell
+ * semantics (pipes, redirection, multi-statement scripts) match other providers; an optional
+ * {@code stdin} is piped into the command. Direct exec ({@code useShellWrap=false}) splits the
+ * command into {@code cmd + args} on whitespace.</p>
+ */
+public class E2BSandboxSession implements SandboxSession {
+
+    private final E2BSandboxClient client;
+    private final E2BSandboxConfig config;
+    private final SandboxSpec spec;
+    private final String sessionId;
+    private final String sandboxHost;
+    private final String executionToken;
+    private final String accessToken;
+    private volatile SandboxStatus status;
+
+    E2BSandboxSession(E2BSandboxClient client,
+                      E2BSandboxConfig config,
+                      E2BCreateSandboxResponse created) {
+        if (client == null) {
+            throw new IllegalArgumentException("e2b sandbox client must not be null");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("e2b sandbox config must not be null");
+        }
+        if (created == null || E2BSandboxConfig.trimToNull(created.getSandboxID()) == null) {
+            throw new IllegalArgumentException("e2b sandbox id must not be blank");
+        }
+        this.client = client;
+        this.config = config;
+        this.spec = config.getSpec();
+        this.sessionId = created.getSandboxID();
+        this.sandboxHost = config.buildSandboxHost(sessionId);
+        // Execution auth: prefer a per-sandbox envd access token when the create response or config
+        // supplied one, otherwise fall back to the API key as the bearer token.
+        String token = E2BSandboxConfig.firstNonBlank(
+                E2BSandboxConfig.firstNonBlank(created.getEnvdAccessToken(), config.getEnvdAccessToken()),
+                config.getApiKey());
+        this.executionToken = token;
+        // X-Access-Token is only sent when an envd access token was explicitly provided.
+        this.accessToken = E2BSandboxConfig.firstNonBlank(created.getEnvdAccessToken(), config.getEnvdAccessToken());
+        this.status = SandboxStatus.RUNNING;
+    }
+
+    @Override
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public String getProviderId() {
+        return config.getProviderId();
+    }
+
+    @Override
+    public SandboxSpec getSpec() {
+        return spec.copy();
+    }
+
+    @Override
+    public SandboxStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public synchronized SandboxResult execute(SandboxCommand command) throws SandboxException {
+        if (status == SandboxStatus.CLOSED) {
+            throw new SandboxException("E2B sandbox session is closed");
+        }
+        SandboxCommand safeCommand = command.copy();
+        String[] resolved = resolveCommand(safeCommand);
+        String cmd = resolved[0];
+        List<String> args = resolved.length > 1
+                ? Arrays.asList(Arrays.copyOfRange(resolved, 1, resolved.length))
+                : Collections.<String>emptyList();
+        Map<String, String> envs = mergeEnvironments(safeCommand);
+        long readTimeoutMillis = resolveReadTimeoutMillis(safeCommand);
+
+        long startedAt = System.currentTimeMillis();
+        SandboxEvent started = event(SandboxEventType.COMMAND_STARTED, safeCommand.getCommandId(), "E2B command started");
+        try {
+            status = SandboxStatus.RUNNING;
+            E2BProcessResult result = client.execute(
+                    sandboxHost, executionToken, accessToken,
+                    cmd, args, envs, safeCommand.getWorkingDirectory(), readTimeoutMillis);
+            long duration = System.currentTimeMillis() - startedAt;
+            SandboxEvent finished = event(SandboxEventType.COMMAND_FINISHED, safeCommand.getCommandId(),
+                    "E2B command finished (exitCode=" + result.getExitCode() + ")");
+            return SandboxResult.builder()
+                    .commandId(safeCommand.getCommandId())
+                    .exitCode(result.getExitCode())
+                    .stdout(result.getStdout())
+                    .stderr(result.getStderr())
+                    .durationMillis(Long.valueOf(duration))
+                    .events(Arrays.asList(started, finished))
+                    .build();
+        } catch (IOException e) {
+            SandboxEvent error = event(SandboxEventType.ERROR, safeCommand.getCommandId(), e.getMessage());
+            throw new SandboxException("failed to execute command in E2B sandbox. event=" + error.getEventId(), e);
+        }
+    }
+
+    @Override
+    public boolean cancel(String commandId) {
+        // Cancellation via process.Process/SendSignal (by pid) is not wired in v1.
+        return false;
+    }
+
+    @Override
+    public List<SandboxArtifact> listArtifacts() {
+        return new ArrayList<SandboxArtifact>();
+    }
+
+    @Override
+    public synchronized void close() throws SandboxException {
+        if (status == SandboxStatus.CLOSED) {
+            return;
+        }
+        try {
+            if (config.isDeleteOnClose()) {
+                client.deleteSandbox(sessionId);
+            }
+            status = SandboxStatus.CLOSED;
+        } catch (IOException e) {
+            status = SandboxStatus.FAILED;
+            throw new SandboxException("failed to close E2B sandbox session", e);
+        }
+    }
+
+    private String[] resolveCommand(SandboxCommand command) {
+        String raw = command.getCommand();
+        if (config.isUseShellWrap()) {
+            String shellScript = raw;
+            String stdin = command.getStdin();
+            if (stdin != null && !stdin.isEmpty()) {
+                // Feed stdin via a pipe so the command's exit code is preserved (last pipeline stage).
+                shellScript = "printf '%s' '" + escapeSingleQuotes(stdin) + "' | ( " + raw + " )";
+            }
+            return new String[]{"sh", "-c", shellScript};
+        }
+        // Direct exec: naive whitespace tokenization (opt-in escape hatch, no quoting support).
+        return raw.split("\\s+");
+    }
+
+    private Map<String, String> mergeEnvironments(SandboxCommand command) {
+        Map<String, String> merged = new LinkedHashMap<String, String>();
+        Map<String, String> base = config.getEnvironment();
+        if (base != null) {
+            merged.putAll(base);
+        }
+        Map<String, String> commandEnv = command.getEnvironment();
+        if (commandEnv != null) {
+            merged.putAll(commandEnv);
+        }
+        return merged;
+    }
+
+    private long resolveReadTimeoutMillis(SandboxCommand command) {
+        long base = config.getReadTimeoutMillis();
+        Long commandTimeout = command.getTimeoutMillis();
+        if (commandTimeout != null && commandTimeout.longValue() > 0L) {
+            long withBuffer = commandTimeout.longValue() + 5000L;
+            return Math.max(base, withBuffer);
+        }
+        return base;
+    }
+
+    private static String escapeSingleQuotes(String value) {
+        return value.replace("'", "'\\''");
+    }
+
+    private SandboxEvent event(SandboxEventType type, String commandId, String message) {
+        return SandboxEvent.builder()
+                .type(type)
+                .sessionId(sessionId)
+                .commandId(commandId)
+                .message(message)
+                .build();
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BLocalHttpServer.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BLocalHttpServer.java
@@ -1,0 +1,159 @@
+package io.github.lnyocly.agent.e2b;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+/**
+ * Minimal offline HTTP harness for E2B provider tests. Unlike a plain JSON stub it can return raw
+ * Connect-framed bytes (for {@code process.Process/Start}) and records request bodies as bytes so
+ * the Connect request envelope can be inspected.
+ */
+final class E2BLocalHttpServer implements AutoCloseable {
+
+    private final HttpServer server;
+    private final List<RequestRecord> records = Collections.synchronizedList(new ArrayList<RequestRecord>());
+    private final List<Response> responses = Collections.synchronizedList(new ArrayList<Response>());
+
+    private E2BLocalHttpServer(HttpServer server) {
+        this.server = server;
+    }
+
+    static E2BLocalHttpServer start() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        final E2BLocalHttpServer harness = new E2BLocalHttpServer(server);
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                harness.handle(exchange);
+            }
+        });
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        return harness;
+    }
+
+    String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    E2BLocalHttpServer enqueue(int status, String contentType, byte[] body) {
+        responses.add(new Response(status, contentType, body));
+        return this;
+    }
+
+    E2BLocalHttpServer enqueueJson(int status, String body) {
+        return enqueue(status, "application/json", body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    List<RequestRecord> records() {
+        synchronized (records) {
+            return new ArrayList<RequestRecord>(records);
+        }
+    }
+
+    RequestRecord record(int index) {
+        return records().get(index);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        byte[] body = read(exchange.getRequestBody());
+        records.add(new RequestRecord(
+                exchange.getRequestMethod(),
+                exchange.getRequestURI().toString(),
+                exchange.getRequestHeaders().getFirst("X-API-Key"),
+                exchange.getRequestHeaders().getFirst("Authorization"),
+                exchange.getRequestHeaders().getFirst("Content-Type"),
+                body));
+
+        Response response;
+        synchronized (responses) {
+            response = responses.isEmpty()
+                    ? new Response(500, "application/json", "{\"message\":\"unexpected request\"}".getBytes(StandardCharsets.UTF_8))
+                    : responses.remove(0);
+        }
+        Headers headers = exchange.getResponseHeaders();
+        if (response.contentType != null) {
+            headers.set("Content-Type", response.contentType);
+        }
+        exchange.sendResponseHeaders(response.status, response.body.length == 0 ? -1 : response.body.length);
+        if (response.body.length > 0) {
+            OutputStream output = exchange.getResponseBody();
+            try {
+                output.write(response.body);
+            } finally {
+                output.close();
+            }
+        } else {
+            exchange.getResponseBody().close();
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private static byte[] read(InputStream input) throws IOException {
+        if (input == null) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        try {
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+        } finally {
+            input.close();
+        }
+        return output.toByteArray();
+    }
+
+    static final class RequestRecord {
+        final String method;
+        final String path;
+        final String apiKey;
+        final String authorization;
+        final String contentType;
+        final byte[] body;
+
+        private RequestRecord(String method, String path, String apiKey, String authorization, String contentType, byte[] body) {
+            this.method = method;
+            this.path = path;
+            this.apiKey = apiKey;
+            this.authorization = authorization;
+            this.contentType = contentType;
+            this.body = body;
+        }
+
+        String bodyUtf8() {
+            return new String(body, StandardCharsets.UTF_8);
+        }
+    }
+
+    private static final class Response {
+        final int status;
+        final String contentType;
+        final byte[] body;
+
+        private Response(int status, String contentType, byte[] body) {
+            this.status = status;
+            this.contentType = contentType;
+            this.body = body == null ? new byte[0] : body;
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxConfigTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxConfigTest.java
@@ -1,0 +1,91 @@
+package io.github.lnyocly.agent.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.e2b.E2BSandboxConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class E2BSandboxConfigTest {
+
+    @Test
+    public void fromEnvironmentShouldReadEnvAndDefaults() {
+        Map<String, String> env = new LinkedHashMap<String, String>();
+        env.put("E2B_API_KEY", "env-key");
+        env.put("E2B_DOMAIN", "e2b.test");
+        env.put("E2B_TEMPLATE_ID", "custom-tpl");
+        env.put("E2B_ENVD_PORT", "3000");
+        env.put("E2B_TIMEOUT", "120");
+        env.put("E2B_ACCESS_TOKEN", "tok-1");
+
+        E2BSandboxConfig config = E2BSandboxConfig.fromEnvironment(
+                SandboxSpec.builder().providerId("e2b").build(), env);
+
+        Assert.assertEquals("e2b", config.getProviderId());
+        Assert.assertEquals("env-key", config.getApiKey());
+        Assert.assertEquals("e2b.test", config.getApiDomain());
+        Assert.assertEquals("https://api.e2b.test", config.getApiUrl());
+        Assert.assertEquals("custom-tpl", config.getTemplateId());
+        Assert.assertEquals(Integer.valueOf(3000), config.getEnvdPort());
+        Assert.assertEquals(Integer.valueOf(120), config.getTimeoutSeconds());
+        Assert.assertEquals("tok-1", config.getEnvdAccessToken());
+        Assert.assertEquals("https://3000-sid123.e2b.test", config.buildSandboxHost("sid123"));
+        Assert.assertTrue("deleteOnClose defaults to true", config.isDeleteOnClose());
+        Assert.assertTrue("useShellWrap defaults to true", config.isUseShellWrap());
+    }
+
+    @Test
+    public void defaultsShouldUseCanonicalE2BHost() {
+        E2BSandboxConfig config = E2BSandboxConfig.builder().apiKey("k").build();
+        Assert.assertEquals(E2BSandboxConfig.DEFAULT_DOMAIN, config.getApiDomain());
+        Assert.assertEquals("https://api." + E2BSandboxConfig.DEFAULT_DOMAIN, config.getApiUrl());
+        Assert.assertEquals(Integer.valueOf(E2BSandboxConfig.DEFAULT_ENVD_PORT), config.getEnvdPort());
+        Assert.assertEquals(Integer.valueOf(E2BSandboxConfig.DEFAULT_TIMEOUT_SECONDS), config.getTimeoutSeconds());
+        Assert.assertEquals("https://49983-abc.e2b.app", config.buildSandboxHost("abc"));
+    }
+
+    @Test
+    public void sandboxUrlOverrideShouldWinOverDerivedHost() {
+        E2BSandboxConfig config = E2BSandboxConfig.builder()
+                .apiKey("k")
+                .sandboxUrl("https://my-proxy.example/box")
+                .build();
+        Assert.assertEquals("https://my-proxy.example/box", config.buildSandboxHost("abc"));
+    }
+
+    @Test
+    public void specConfigShouldOverrideEnvAndReadImageAsTemplate() {
+        Map<String, String> env = new LinkedHashMap<String, String>();
+        env.put("E2B_API_KEY", "env-key");
+        env.put("E2B_TEMPLATE_ID", "env-tpl");
+
+        SandboxSpec spec = SandboxSpec.builder()
+                .providerId("e2b")
+                .image("spec-image")
+                .config("apiKey", "spec-key")
+                .config("envdPort", Integer.valueOf(49983))
+                .config("timeoutSeconds", Integer.valueOf(90))
+                .config("useShellWrap", "false")
+                .config("deleteOnClose", "false")
+                .config("readTimeoutMillis", "5000")
+                .build();
+
+        E2BSandboxConfig config = E2BSandboxConfig.fromEnvironment(spec, env);
+
+        Assert.assertEquals("spec-key", config.getApiKey());
+        Assert.assertEquals("spec-image", config.getTemplateId());
+        Assert.assertEquals(Integer.valueOf(90), config.getTimeoutSeconds());
+        Assert.assertFalse(config.isUseShellWrap());
+        Assert.assertFalse(config.isDeleteOnClose());
+        Assert.assertEquals(5000L, config.getReadTimeoutMillis());
+    }
+
+    @Test
+    public void missingApiKeyShouldBeNull() {
+        E2BSandboxConfig config = E2BSandboxConfig.fromEnvironment(
+                SandboxSpec.builder().providerId("e2b").build(), new LinkedHashMap<String, String>());
+        Assert.assertNull(config.getApiKey());
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxLiveSmokeTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxLiveSmokeTest.java
@@ -1,0 +1,64 @@
+package io.github.lnyocly.agent.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+import io.github.lnyocly.ai4j.agent.sandbox.e2b.E2BSandboxProvider;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Live smoke test against the real E2B control + execution API. Skipped unless
+ * {@code E2B_API_KEY} is set in the environment.
+ */
+@Category(LiveProviderTest.class)
+public class E2BSandboxLiveSmokeTest {
+
+    @Test
+    public void liveCreateExecuteCloseShouldWorkWhenE2bEnvIsConfigured() throws Exception {
+        String apiKey = System.getenv("E2B_API_KEY");
+        Assume.assumeTrue("Skip E2B live smoke: E2B_API_KEY is required",
+                apiKey != null && !apiKey.trim().isEmpty());
+
+        SandboxSession session = null;
+        try {
+            session = new E2BSandboxProvider().createSession(SandboxSpec.builder()
+                    .providerId("e2b")
+                    .config("templateID", "base")
+                    .config("timeoutSeconds", Integer.valueOf(300))
+                    .config("readTimeoutMillis", Long.valueOf(60000L))
+                    .build());
+
+            Assert.assertEquals("e2b", session.getProviderId());
+            Assert.assertEquals(SandboxStatus.RUNNING, session.getStatus());
+
+            SandboxResult result = session.execute(SandboxCommand.builder()
+                    .commandId("e2b-live-smoke")
+                    .command("printf ai4j-e2b-live-ok")
+                    .timeoutMillis(Long.valueOf(30000L))
+                    .build());
+
+            Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+            Assert.assertNotNull(result.getStdout());
+            Assert.assertTrue("stdout should contain marker: " + result.getStdout(),
+                    result.getStdout().contains("ai4j-e2b-live-ok"));
+
+            // Non-zero exit must also propagate (Connect end.exitCode).
+            SandboxResult failing = session.execute(SandboxCommand.builder()
+                    .commandId("e2b-live-fail")
+                    .command("sh -c 'exit 7'")
+                    .build());
+            Assert.assertEquals(Integer.valueOf(7), failing.getExitCode());
+        } finally {
+            if (session != null) {
+                session.close();
+                Assert.assertEquals(SandboxStatus.CLOSED, session.getStatus());
+            }
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxProviderTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/e2b/E2BSandboxProviderTest.java
@@ -1,0 +1,192 @@
+package io.github.lnyocly.agent.e2b;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+import io.github.lnyocly.ai4j.agent.sandbox.e2b.E2BSandboxConfig;
+import io.github.lnyocly.ai4j.agent.sandbox.e2b.E2BSandboxProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Offline integration test for {@link E2BSandboxProvider} against an in-process HTTP harness,
+ * covering the create -> execute (Connect) -> delete lifecycle and the request frames the client
+ * emits.
+ */
+public class E2BSandboxProviderTest {
+
+    @Test
+    public void createExecuteDeleteShouldSpeakConnectAgainstLocalHost() throws Exception {
+        E2BLocalHttpServer server = E2BLocalHttpServer.start();
+        try {
+            String stdoutB64 = Base64.getEncoder().encodeToString("ai4j-e2b-ok\n".getBytes(StandardCharsets.UTF_8));
+            server.enqueueJson(201, "{\"sandboxID\":\"e2b-unit-1\",\"clientID\":\"c1\","
+                    + "\"envdVersion\":\"0.6.4\",\"templateID\":\"base\",\"alias\":\"base\"}")
+                    .enqueue(200, "application/connect+json", connectFrames(
+                            frame(0x00, "{\"event\":{\"start\":{\"pid\":11}}}"),
+                            frame(0x00, "{\"event\":{\"data\":{\"stdout\":\"" + stdoutB64 + "\"}}}"),
+                            frame(0x00, "{\"event\":{\"end\":{\"exitCode\":0,\"exited\":true}}}"),
+                            frame(0x02, "{}")))
+                    .enqueue(204, null, new byte[0]);
+
+            E2BSandboxProvider provider = new E2BSandboxProvider(config(server, true));
+            SandboxSession session = provider.createSession(SandboxSpec.builder()
+                    .providerId("e2b")
+                    .image("base")
+                    .build());
+
+            Assert.assertEquals("e2b", session.getProviderId());
+            Assert.assertEquals("e2b-unit-1", session.getSessionId());
+            Assert.assertEquals(SandboxStatus.RUNNING, session.getStatus());
+
+            SandboxResult result = session.execute(SandboxCommand.builder()
+                    .commandId("cmd-e2b-1")
+                    .command("echo ai4j-e2b-ok")
+                    .workingDirectory("/code")
+                    .timeoutMillis(2000L)
+                    .environment("LANG", "C")
+                    .build());
+
+            Assert.assertEquals("cmd-e2b-1", result.getCommandId());
+            Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+            Assert.assertEquals("ai4j-e2b-ok\n", result.getStdout());
+            Assert.assertEquals(2, result.getEvents().size());
+
+            session.close();
+            Assert.assertEquals(SandboxStatus.CLOSED, session.getStatus());
+
+            // create
+            Assert.assertEquals("POST", server.record(0).method);
+            Assert.assertEquals("/sandboxes", server.record(0).path);
+            Assert.assertEquals("unit-key", server.record(0).apiKey);
+            Assert.assertTrue(server.record(0).bodyUtf8().contains("\"templateID\":\"base\""));
+            Assert.assertTrue(server.record(0).bodyUtf8().contains("\"timeout\""));
+
+            // execute (Connect framed request)
+            E2BLocalHttpServer.RequestRecord exec = server.record(1);
+            Assert.assertEquals("POST", exec.method);
+            Assert.assertEquals("/process.Process/Start", exec.path);
+            Assert.assertEquals("application/connect+json", exec.contentType);
+            Assert.assertEquals("Bearer unit-key", exec.authorization);
+            Assert.assertEquals("request must be a single Connect envelope (flags 0x00)", 0x00, exec.body[0] & 0xFF);
+            String execJson = envelopePayload(exec.body);
+            Assert.assertTrue("shell-wrap should run via sh -c", execJson.contains("\"cmd\":\"sh\""));
+            Assert.assertTrue(execJson.contains("\"args\":[\"-c\",\"echo ai4j-e2b-ok\"]"));
+            Assert.assertTrue(execJson.contains("\"cwd\":\"/code\""));
+            Assert.assertTrue(execJson.contains("\"envs\":{\"LANG\":\"C\"}"));
+            Assert.assertTrue(execJson.contains("\"stdin\":false"));
+
+            // delete
+            Assert.assertEquals("DELETE", server.record(2).method);
+            Assert.assertEquals("/sandboxes/e2b-unit-1", server.record(2).path);
+            Assert.assertEquals("unit-key", server.record(2).apiKey);
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    public void stdinShouldBePipedThroughShellWrap() throws Exception {
+        E2BLocalHttpServer server = E2BLocalHttpServer.start();
+        try {
+            server.enqueueJson(201, "{\"sandboxID\":\"e2b-unit-2\",\"clientID\":\"c2\","
+                    + "\"envdVersion\":\"0.6.4\",\"templateID\":\"base\"}")
+                    .enqueue(200, "application/connect+json", connectFrames(
+                            frame(0x00, "{\"event\":{\"end\":{\"exitCode\":0,\"exited\":true}}}"),
+                            frame(0x02, "{}")));
+
+            E2BSandboxProvider provider = new E2BSandboxProvider(config(server, true));
+            SandboxSession session = provider.createSession(SandboxSpec.builder().providerId("e2b").build());
+            session.execute(SandboxCommand.builder()
+                    .commandId("cmd-stdin")
+                    .command("cat")
+                    .stdin("hello stdin")
+                    .build());
+
+            String execJson = envelopePayload(server.record(1).body);
+            Assert.assertTrue("stdin must be piped via printf", execJson.contains("printf '%s' 'hello stdin'"));
+            Assert.assertTrue(execJson.contains("| ( cat )"));
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    public void deleteOnCloseFalseShouldKeepSandbox() throws Exception {
+        E2BLocalHttpServer server = E2BLocalHttpServer.start();
+        try {
+            server.enqueueJson(201, "{\"sandboxID\":\"e2b-unit-3\",\"clientID\":\"c3\","
+                    + "\"envdVersion\":\"0.6.4\",\"templateID\":\"base\"}");
+            E2BSandboxProvider provider = new E2BSandboxProvider(config(server, false));
+            SandboxSession session = provider.createSession(SandboxSpec.builder().providerId("e2b").build());
+            session.close();
+            Assert.assertEquals(SandboxStatus.CLOSED, session.getStatus());
+            Assert.assertEquals("only the create call should have happened", 1, server.records().size());
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    public void createSessionShouldFailWhenApiKeyMissing() {
+        E2BSandboxConfig config = E2BSandboxConfig.builder()
+                .apiUrl("http://127.0.0.1:1")
+                .sandboxUrl("http://127.0.0.1:1")
+                .build();
+        E2BSandboxProvider provider = new E2BSandboxProvider(config);
+        try {
+            provider.createSession(SandboxSpec.builder().providerId("e2b").build());
+            Assert.fail("expected missing API key to fail");
+        } catch (Exception expected) {
+            Assert.assertTrue(expected.getMessage().contains("E2B API key is required"));
+        }
+    }
+
+    private static E2BSandboxConfig config(E2BLocalHttpServer server, boolean deleteOnClose) {
+        return E2BSandboxConfig.builder()
+                .apiKey("unit-key")
+                .apiUrl(server.baseUrl())
+                .sandboxUrl(server.baseUrl())
+                .templateId("base")
+                .timeoutSeconds(Integer.valueOf(60))
+                .deleteOnClose(Boolean.valueOf(deleteOnClose))
+                .connectTimeoutMillis(Long.valueOf(3000L))
+                .readTimeoutMillis(Long.valueOf(3000L))
+                .startTimeoutMillis(Long.valueOf(3000L))
+                .pollIntervalMillis(Long.valueOf(1L))
+                .build();
+    }
+
+    private static byte[] frame(int flags, String json) throws IOException {
+        byte[] payload = json.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(payload.length + 5);
+        out.write(flags & 0xFF);
+        out.write((payload.length >>> 24) & 0xFF);
+        out.write((payload.length >>> 16) & 0xFF);
+        out.write((payload.length >>> 8) & 0xFF);
+        out.write(payload.length & 0xFF);
+        out.write(payload, 0, payload.length);
+        return out.toByteArray();
+    }
+
+    private static byte[] connectFrames(byte[]... frames) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] f : frames) {
+            out.write(f);
+        }
+        return out.toByteArray();
+    }
+
+    private static String envelopePayload(byte[] frame) {
+        int length = ((frame[1] & 0xFF) << 24) | ((frame[2] & 0xFF) << 16)
+                | ((frame[3] & 0xFF) << 8) | (frame[4] & 0xFF);
+        return new String(frame, 5, length, StandardCharsets.UTF_8);
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxClientTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/E2BSandboxClientTest.java
@@ -1,0 +1,145 @@
+package io.github.lnyocly.ai4j.agent.sandbox.e2b;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure unit tests for the E2B Connect wire helpers {@link E2BSandboxClient#buildProcessFrame} and
+ * {@link E2BSandboxClient#parseConnectStream}. These assert against the exact frame format
+ * confirmed against the live E2B envd host (1 byte flags + big-endian uint32 length + JSON).
+ */
+public class E2BSandboxClientTest {
+
+    @Test
+    public void buildProcessFrameShouldProduceConnectEnvelopeWithStdinFalse() throws Exception {
+        Map<String, String> envs = new LinkedHashMap<String, String>();
+        envs.put("FOO", "bar");
+        List<String> args = Arrays.asList("-c", "echo hi");
+        byte[] frame = E2BSandboxClient.buildProcessFrame("sh", args, envs, "/code");
+
+        // flag byte = 0x00
+        Assert.assertEquals(0x00, frame[0] & 0xFF);
+        // big-endian uint32 length == remaining bytes
+        int declared = ((frame[1] & 0xFF) << 24) | ((frame[2] & 0xFF) << 16)
+                | ((frame[3] & 0xFF) << 8) | (frame[4] & 0xFF);
+        Assert.assertEquals(frame.length - 5, declared);
+
+        String json = new String(frame, 5, declared, StandardCharsets.UTF_8);
+        Assert.assertTrue("payload must wrap cmd under process", json.contains("\"process\""));
+        Assert.assertTrue(json.contains("\"cmd\":\"sh\""));
+        Assert.assertTrue(json.contains("\"cwd\":\"/code\""));
+        Assert.assertTrue(json.contains("\"envs\":{\"FOO\":\"bar\"}"));
+        Assert.assertTrue("stdin must be false", json.contains("\"stdin\":false"));
+    }
+
+    @Test
+    public void parseConnectStreamShouldAggregateStartDataEndAndExitCode() throws Exception {
+        String stdoutB64 = Base64.getEncoder().encodeToString("out-line\n".getBytes(StandardCharsets.UTF_8));
+        String stderrB64 = Base64.getEncoder().encodeToString("err-line\n".getBytes(StandardCharsets.UTF_8));
+        byte[] stream = concat(
+                frame(0x00, "{\"event\":{\"start\":{\"pid\":1274}}}"),
+                frame(0x00, "{\"event\":{\"data\":{\"stdout\":\"" + stdoutB64 + "\"}}}"),
+                frame(0x00, "{\"event\":{\"data\":{\"stderr\":\"" + stderrB64 + "\"}}}"),
+                frame(0x00, "{\"event\":{\"end\":{\"exitCode\":7,\"exited\":true,\"status\":\"exit status 7\"}}}"),
+                frame(0x02, "{}"));
+
+        E2BProcessResult result = E2BSandboxClient.parseConnectStream(new ByteArrayInputStream(stream));
+
+        Assert.assertEquals(Long.valueOf(1274L), result.getPid());
+        Assert.assertEquals(Integer.valueOf(7), result.getExitCode());
+        Assert.assertTrue("exited should be true", result.isExited());
+        Assert.assertEquals("out-line\n", result.getStdout());
+        Assert.assertEquals("err-line\n", result.getStderr());
+        Assert.assertNull("no protocol error on a normal command exit", result.getError());
+    }
+
+    @Test
+    public void parseConnectStreamShouldHandleZeroExitAndChunkedOutput() throws Exception {
+        String part1 = Base64.getEncoder().encodeToString("hello ".getBytes(StandardCharsets.UTF_8));
+        String part2 = Base64.getEncoder().encodeToString("e2b".getBytes(StandardCharsets.UTF_8));
+        byte[] stream = concat(
+                frame(0x00, "{\"event\":{\"start\":{\"pid\":3}}}"),
+                frame(0x00, "{\"event\":{\"data\":{\"stdout\":\"" + part1 + "\"}}}"),
+                frame(0x00, "{\"event\":{\"data\":{\"stdout\":\"" + part2 + "\"}}}"),
+                frame(0x00, "{\"event\":{\"end\":{\"exitCode\":0,\"exited\":true}}}"),
+                frame(0x02, "{}"));
+
+        E2BProcessResult result = E2BSandboxClient.parseConnectStream(new ByteArrayInputStream(stream));
+
+        Assert.assertEquals("hello e2b", result.getStdout());
+        Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+        Assert.assertTrue(result.isExited());
+    }
+
+    @Test
+    public void parseConnectStreamShouldSurfaceConnectErrorTrailer() throws Exception {
+        // The end-of-stream trailer (flags 0x02) carries a Connect protocol error.
+        byte[] stream = frame(0x02,
+                "{\"error\":{\"code\":\"unimplemented\",\"message\":\"unary request has zero messages\"}}");
+
+        E2BProcessResult result = E2BSandboxClient.parseConnectStream(new ByteArrayInputStream(stream));
+
+        Assert.assertEquals("unary request has zero messages", result.getError());
+        Assert.assertFalse("protocol error must not be reported as a clean exit", result.isExited());
+        Assert.assertNull(result.getExitCode());
+    }
+
+    @Test
+    public void parseConnectStreamShouldDeriveZeroExitCodeFromStatusWhenExitCodeAbsent() throws Exception {
+        // Real E2B envd omits the numeric exitCode on a clean exit and only sends
+        // "status":"exit status 0"; non-zero exits include the exitCode field instead.
+        byte[] stream = concat(
+                frame(0x00, "{\"event\":{\"start\":{\"pid\":5}}}"),
+                frame(0x00, "{\"event\":{\"data\":{\"stdout\":\"" + Base64.getEncoder().encodeToString("ok".getBytes(StandardCharsets.UTF_8)) + "\"}}}"),
+                frame(0x00, "{\"event\":{\"end\":{\"exited\":true,\"status\":\"exit status 0\"}}}"),
+                frame(0x02, "{}"));
+
+        E2BProcessResult result = E2BSandboxClient.parseConnectStream(new ByteArrayInputStream(stream));
+
+        Assert.assertEquals("clean exit must map to exitCode 0", Integer.valueOf(0), result.getExitCode());
+        Assert.assertTrue(result.isExited());
+        Assert.assertEquals("ok", result.getStdout());
+        Assert.assertNull(result.getError());
+    }
+
+    @Test
+    public void parseConnectStreamShouldTolerateEmptyTrailerAndPlainTermination() throws Exception {
+        byte[] stream = concat(
+                frame(0x00, "{\"event\":{\"end\":{\"exitCode\":0,\"exited\":true}}}"),
+                frame(0x02, "{}"));
+        E2BProcessResult result = E2BSandboxClient.parseConnectStream(new ByteArrayInputStream(stream));
+        Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+        Assert.assertTrue(result.isExited());
+        Assert.assertNull(result.getError());
+    }
+
+    private static byte[] frame(int flags, String json) throws IOException {
+        byte[] payload = json.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(payload.length + 5);
+        out.write(flags & 0xFF);
+        out.write((payload.length >>> 24) & 0xFF);
+        out.write((payload.length >>> 16) & 0xFF);
+        out.write((payload.length >>> 8) & 0xFF);
+        out.write(payload.length & 0xFF);
+        out.write(payload, 0, payload.length);
+        return out.toByteArray();
+    }
+
+    private static byte[] concat(byte[]... parts) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] part : parts) {
+            out.write(part);
+        }
+        return out.toByteArray();
+    }
+}

--- a/coding-agent-harness/planning/modules/agent-runtime/module_plan.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/module_plan.md
@@ -32,7 +32,7 @@
 | T-P2-A-SANDBOX-SPI-MODEL-C9C66766 | P2-A Sandbox SPI model | handoff | coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-20-p2-a-sandbox-spi-model-c9c66766/task_plan.md | T-P1-C-CLI-RUN-AGENT-BLUEPRINT-YAML-377E1F25 |
 | T-P2-B-AGENTSESSION-SANDBOX-BINDING-E8175553 | P2-B AgentSession sandbox binding | handoff | coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-20-p2-b-agentsession-sandbox-binding-e8175553/task_plan.md | T-P2-A-SANDBOX-SPI-MODEL-C9C66766 |
 | T-P2-C-DAYTONA-SANDBOX-PROVIDER-7263B5B5 | P2-C Daytona sandbox provider | handoff | coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-c-daytona-sandbox-provider-7263b5b5/task_plan.md | T-P2-B-AGENTSESSION-SANDBOX-BINDING-E8175553 |
-| T-P2-D-E2B-SANDBOX-PROVIDER-7DFDB7C6 | P2-D E2B sandbox provider | reserved | coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/task_plan.md | T-P2-C-DAYTONA-SANDBOX-PROVIDER-7263B5B5 |
+| T-P2-D-E2B-SANDBOX-PROVIDER-7DFDB7C6 | P2-D E2B sandbox provider | review | coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/task_plan.md | T-P2-C-DAYTONA-SANDBOX-PROVIDER-7263B5B5 |
 
 ## 活跃任务
 
@@ -47,6 +47,7 @@
 | `2026-06-20-p1-c-cli-run-agent-blueprint-yaml-377e1f25` | implementation-verified | coordinator | `mvn -pl ai4j-cli -am "-Dtest=AgentBlueprintRunCommandTest,Ai4jCliTest" -DskipTests=false -DfailIfNoTests=false test`; `mvn -pl ai4j-cli -am -DskipTests=false test`; `npm --prefix docs-site run build` | P1-C adds top-level `ai4j-cli run <agent.yaml>` and host-side provider/profile resolution with no-token/no-real-sandbox boundaries; task-review/PR pending. |
 | `2026-06-09-ai4j-extension-runtime-adapter-wave-3-e94c61c5` | review-pending | coordinator | `mvn -pl ai4j-agent -am -Dtest=ExtensionAgentToolsTest -DfailIfNoTests=false -DskipTests=false test` | Historical active item; no changes in this P0-A branch. |
 | `2026-06-23-messages-model-client-0f5bad51` | review | coordinator | `tasks/2026-06-23-messages-model-client-0f5bad51/progress.md` | agent 层 MessagesModelClient 委托 IMessagesService（原生 Anthropic 线协议）；worktree feature/anthropic-native-surface |
+| `2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` | review | coordinator | `tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/progress.md` | E2B sandbox provider：Connect server-streaming 执行 + X-API-Key/Bearer 双鉴权；15 离线 + live 烟测全绿；branch feat/e2b-sandbox-provider |
 
 ## 验证
 

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/brief.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/brief.md
@@ -10,42 +10,50 @@
 
 ## 一句话结果
 
-用一句话说明这个任务完成后会产生什么具体结果。
+agent sandbox SPI 多一个可用的 E2B provider：通过 E2B control API 创建/销毁沙箱，经 Connect
+server-streaming `process.Process/Start` 执行命令，行为对齐 Daytona。
 
 ## 完成后能得到什么
 
-用 100-300 字说明这个任务完成后，用户、项目或下一轮 agent 能直接拿到什么结果。
-说明这个结果能用于什么决策、交付、验证或继续开发。聚焦可用结果，不要展开实现过程，
-除非实现方式本身就是交付物。
+agent runtime / 用户可以用 `new E2BSandboxProvider().createSession(spec)` 拿到一个能 `execute`
+任意 shell 命令、返回 stdout/stderr/exitCode 的隔离沙箱会话，并在 `close()` 时销毁。这把
+P2 阶段的沙箱能力从单 provider（Daytona）扩展到双 provider，验证了 SPI 对第二种执行后端
+（Connect 流式协议 + base64 输出 + exitCode 在 status 字符串里）的覆盖能力。
 
 ## 交付物
 
-- 可见产物：
-- 修改位置：
-- 验证证据：
+- 可见产物：`ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/`（7 个源文件）。
+- 修改位置：仅 `ai4j-agent/**` 新增文件；无既有文件改动。
+- 验证证据：15 离线测试 + 1 live 烟测（E2B_API_KEY）全绿；ai4j-agent 全模块 148 测试 0 失败。
 
 ## 第一眼应该看什么
 
-写明人或下一轮 agent 打开任务后，应该先读哪些文件、证据或生成产物。
+1. `findings.md` — Connect 协议 live 实测结论（请求/响应帧格式、exitCode 陷阱、auth）。
+2. `ai4j-agent/.../sandbox/e2b/E2BSandboxClient.java` — `buildProcessFrame` / `parseConnectStream`。
+3. `progress.md` — 实现与验证证据。
 
 ## 边界
 
-- 范围内：本任务允许修改的文件、行为、文档或验证内容。
-- 范围外：不能顺手塞进来的工作。
-- 停止条件：遇到不确定性、风险或缺少权限时，必须回到 coordinator 或用户确认。
+- 范围内：E2B provider 源码 + 测试；E2B API 实测确认协议。
+- 范围外：cancel（SendSignal）、listArtifacts（filesystem）、create labels/metadata；core/CLI/starter 改动。
+- 停止条件：协议/auth 不确定时必须 live 实测确认，不得臆测。
 
 ## 完成判断
 
-列出 3-5 条能证明目标结果已经达成的具体条件。完整执行计划保留在 `task_plan.md`。
+1. E2BSandboxProvider 实现 SandboxProvider，createSession 返回能 execute 的 E2BSandboxSession。
+2. Connect 帧编/解码有纯单测覆盖（含 exit=0 走 status 解析）。
+3. 本地 HTTP 集成测试覆盖 create→execute→delete 请求结构。
+4. live 烟测真实跑通（exit 0 与非零 exit 7 都验证）。
+5. ai4j-agent 全模块回归无回归。
 
 ## 执行合同
 
 - Owner：coordinator
-- 生命周期状态：未开始
+- 生命周期状态：进行中（实现完成，待 PR 评审）
 - 必需文件：`INDEX.md`、`task_plan.md`、`execution_strategy.md`、`visual_map.md`、
   `progress.md`、`findings.md`、`review.md`
 - 完成条件：验证证据必须记录到 `progress.md`
 
 ## 当前下一步
 
-写明开始实现前的第一个具体动作。
+开 PR `feat/e2b-sandbox-provider` → main，跑 CI，评审后合并并推进任务到 已完成。

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/execution_strategy.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/execution_strategy.md
@@ -2,69 +2,56 @@
 
 ## Subagent Authorization
 
-任务开始时先读这一段，并向用户说明当前授权状态。这里是授权记录，不是执行沙箱。
-
 | Role | Status | Permission | Authorized By | Authorized At | Scope | Worktree / Branch | Reuse |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | reviewer subagent | allowed by default | read-only | harness task policy | task creation | current task review | n/a | allowed within this task |
-| worker subagent | not authorized | write only after user approval | pending | pending | pending | pending | allowed only within approved task/scope |
+| worker subagent | not used | n/a | n/a | n/a | n/a | n/a | n/a |
+
+单 provider 增量，coordinator 直接实现，未拆 worker subagent。
 
 ## Subagent Delegation Decision
 
-任务开始时，coordinator 必须根据用户目标主动做这个判断，即使用户完全没有提到 subagent。
-不要假设用户知道 subagent 或 worker 是什么。如果分工有帮助，用白话说明收益，并向用户申请一次授权。
-可以直接对用户说 subagent 或 worker subagent；关键规则是 agent 不能等用户主动提出 subagent。
-如果任务已经明显拆成互不重叠的独立切片，implementation 前就应判断为 `ask-user`。如果还不知道精确文件路径，先确认路径，然后立刻申请独立执行助手授权。
-
 | Question | Decision | Reason | Next Action |
 | --- | --- | --- | --- |
-| Should a reviewer subagent be used? | yes / no | [为什么需要或不需要 reviewer] | 如果 yes，直接调用只读 reviewer，不需要额外申请。 |
-| Would a worker subagent materially help? | no / ask-user / already-authorized | [并行切片、独立实现、专项调查，或说明为什么不需要] | 如果 ask-user，直接问：“这个任务适合拆给 worker subagent 并行处理。是否授权我派一个 worker subagent，只修改 [scope]，只在 [worktree/branch] 内执行，我负责协调和最终审查？” |
+| Should a reviewer subagent be used? | yes | 外部协议实现，PR 评审时调用只读 reviewer | PR 评审时调用 |
+| Would a worker subagent materially help? | no | 单 provider、依赖明确、无并行切片 | n/a |
 
 ## User Authorization Decision
 
-如果上方 worker 决策是 `ask-user`，implementation 必须暂停，直到这里记录用户答案。
-已解决状态只能是 `authorized`、`denied` 或 `not-needed`。选择 `ask-user` 后不得继续保持 `pending`。
-
 | Gate | State | Decided By | Decided At | Scope | Worktree / Branch | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| worker subagent | pending | pending | pending | pending | pending | 只有直接问过用户后才能填写。 |
+| worker subagent | not-needed | coordinator | 2026-06-23 | n/a | n/a | 单切片无需 worker |
 
 ## 决策表
 
 | 决策 | 选择 | 说明 |
 | --- | --- | --- |
-| 主执行者 | coordinator | coordinator 负责编排顺序、冲突判断和最终收口。 |
-| Subagent 模式 | none / reviewer-only / worker-worktree | 选择能满足任务的最小协作模式。 |
-| 审查模型 | self-check / predefined verifier / adversarial review | 说明为什么该审查层级足够。 |
-| Worktree 策略 | same checkout / dedicated worktree | 会改代码的 subagent 必须使用独立 worktree，并提交 handoff commit。 |
-| 冲突控制 | coordinator owns shared files | subagent 不得直接编辑 coordinator 管理的全局表或共享文件，除非获得明确锁。 |
-| 证据深度 | L0 / L1 / L2 / L3 | 按变更风险匹配证据深度。 |
+| 主执行者 | coordinator | 单 provider 增量，coordinator 全程实现与验证。 |
+| Subagent 模式 | reviewer-only | PR 评审时用只读 reviewer。 |
+| 审查模型 | self-check + PR reviewer | 协议已逐字节 live 实测，self-check 充分；PR 再过 reviewer。 |
+| Worktree 策略 | same checkout | 单分支 feat/e2b-sandbox-provider，无并行写。 |
+| 冲突控制 | n/a | 纯新增文件，无共享文件冲突。 |
+| 证据深度 | L2 | 纯单测(L1) + live 端到端烟测(L2)。 |
 
 ## 子代理 / Worker 合同
 
-如使用 subagent 或 worker，在这里写清楚输入包、写入范围、handoff 格式和最终集成 owner。
-
 | 角色 | 输入包 | 写入范围 | 交接要求 | 负责人 |
 | --- | --- | --- | --- | --- |
-| reviewer / worker / n/a | C-001 | read-only / path list / n/a | report / commit SHA / n/a | coordinator |
+| reviewer（PR 时） | C-001..C-003 | read-only | report | coordinator |
 
 ## 证据计划
 
 | 证据层级 | 计划命令或检查 | 记录位置 | 完成条件 |
 | --- | --- | --- | --- |
-| L0 | [静态检查 / 小范围自检] | `progress.md` | [通过标准] |
-| L1 | [单元测试 / targeted check] | `progress.md` 或 `artifacts/INDEX.md` | [通过标准] |
-| L2 | [集成 / 浏览器 / 真实数据冒烟] | `artifacts/INDEX.md` | [通过标准] |
-| L3 | [发布前 / 生产等价验证 / 外部审查] | `review.md` 与 walkthrough | [通过标准] |
+| L0 | `git diff --check` | progress.md | 无 whitespace error ✅ |
+| L1 | `mvn -pl ai4j-agent -am -Dtest=E2B* test` | progress.md | 15 离线测试全绿 ✅ |
+| L2 | `-Plive-provider-tests -Dtest=E2BSandboxLiveSmokeTest` | progress.md | live create/execute/delete 全绿 ✅ |
+| L2 | `mvn -pl ai4j-agent -am test` | progress.md | 148 测试无回归 ✅ |
 
 ## 暂停 / 升级条件
 
-- 所需工作超出已批准写入范围。
-- 共享表需要更新，但没有 coordinator lock。
-- 实际风险高于原计划，证据深度需要升级。
-- reviewer 发现会改变范围或方案的 P0/P1/P2 问题。
-- 环境无法提供关键证据，继续执行会变成猜测。
+- 协议/auth 不确定时 live 实测确认（已做）。
+- 范围外能力（cancel/filesystem/labels）记为 deferred，不扩大本轮范围。
 
 ## Module Preset Strategy
 
@@ -72,5 +59,3 @@
 | --- | --- |
 | Module Key | agent-runtime |
 | Module Plan | coding-agent-harness/planning/modules/agent-runtime/module_plan.md |
-
-Keep shared module decisions in the module plan or module context files. Keep task-specific evidence in this task directory.

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/findings.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/findings.md
@@ -4,21 +4,73 @@
 
 ## 研究发现
 
-### [发现主题 1]
+### F-001 envd 端口与 host（预研错误已修正）
 
-- 背景：[为什么需要调查这个问题]
-- 发现：[查到了什么事实，证据来自哪里]
-- 影响：[这会如何改变计划、范围、实现或验证]
-- 后续：[需要继续跟进的动作；如无写“无”]
+- 背景：预研笔记写 envd 端口 3000，需实测确认。
+- 发现：实测 **49983**。E2B python-sdk `connection_config.py`：`envd_port = 49983`，
+  `get_host = "{port}-{sandboxID}.{domain}"`。执行 host `https://49983-{sandboxID}.e2b.app`。
+- 影响：实现以 49983 为默认；记忆已修正。
+- 后续：无。
+
+### F-002 create 响应不含 envdAccessToken
+
+- 背景：预研笔记写响应含 envdAccessToken。
+- 发现：实测此 key/流程**不含**；响应只有 `{sandboxID, clientID, envdVersion, templateID, alias}`。
+  执行 host 用 API key 作 Bearer 即可（实测通过）。
+- 影响：执行 auth 用 `Authorization: Bearer {apiKey}`；保留 envdAccessToken 前向兼容。
+- 后续：无。
+
+### F-003 鉴权分离
+
+- 背景：control API 与执行 host 是否同一鉴权。
+- 发现：control 用 `X-API-Key`（Bearer 单用会间歇 401）；执行 host 用 `Authorization: Bearer {apiKey}`。
+- 影响：Client 对两类请求分别设 header。
+- 后续：无。
+
+### F-004 Connect 请求帧唯一正确形式
+
+- 背景：`process.Process/Start` 是 Connect server-streaming，请求帧格式需实测。
+- 发现：请求体必须是**单个 envelope** `0x00 + BE uint32 len + JSON`，CT `application/connect+json`。
+  其他形式全报错（flags=EOS / 多帧 / 裸 JSON）。
+- 影响：`buildProcessFrame` 固定此格式。
+- 后续：无。
+
+### F-005 Connect 响应帧与 exitCode 陷阱（关键）
+
+- 背景：响应事件结构与 exitCode 取值需实测。
+- 发现：响应逐帧 envelope。`start(pid)` / `data(stdout|stderr, base64)` / `end` / EOS trailer(flags 0x02, `{}`)。
+  **exit=0 时 `end` 省略数字 exitCode，只给 `"status":"exit status 0"`**；非零才带 exitCode 数字。
+  错误 trailer = `flags=2` 载荷 `{"error":{...}}`。
+- 影响：`parseConnectStream` exitCode 字段优先、否则从 status 解析尾部整数（带回归单测）。
+- 后续：无。
+
+### F-006 探测环境陷阱
+
+- 背景：初期用 curl + python 混合实测，间歇出现 "zero messages"。
+- 发现：native Python `/tmp/` = `C:\tmp\`，MSYS bash/curl `/tmp/` 不同挂载点 → curl 读不到 python 写的文件 → 发空 body。
+  改全用 python urllib 实测后协议完全确定。是环境问题，非协议问题。
+- 影响：实测结论可信。
+- 后续：无。
+
+### F-007 SPI 对齐结论
+
+- 背景：E2B 与 Daytona 差异是否需要改 SPI。
+- 发现：E2B 无 attach/start 轮询（create 后立即可用）、无 toolbox proxy、执行用 Connect 流式。
+  映射到同一 SandboxSession/SandboxResult 即可，**无需改 SPI**。
+- 影响：纯新增，零既有文件改动。
+- 后续：无。
 
 ## 技术决策
 
 | 决策 | 选择 | 原因 | 替代方案 | 状态 |
 | --- | --- | --- | --- | --- |
-| [决策 1] | [选了什么] | [为什么这样选] | [未采用的方案] | proposed / accepted / superseded |
+| 命令执行方式 | 默认 `sh -c` 包装 | 匹配 Daytona shell 语义，支持管道/重定向/多语句 | 直接 exec（tokenize） | accepted（提供 useShellWrap=false 逃生口） |
+| stdin 支持 | `printf '%s' '<stdin>' \| ( cmd )` 管道 | 避免 Connect bidi 流式 stdin 的额外复杂度，保留退出码 | Connect 客户端流式 stdin | accepted（v1） |
+| exit=0 取值 | status 字符串解析回退 | envd 实测在 exit=0 省略数字 exitCode | 假定 exitCode 总在 | accepted |
+| cancel/listArtifacts | 返回 false / 空 | v1 范围外，SendSignal/filesystem 未接 | 接 SendSignal/filesystem API | deferred |
 
 ## 待确认问题
 
 | 问题 | 当前判断 | Owner | 截止点 |
 | --- | --- | --- | --- |
-| [问题] | [当前可用判断] | [负责人] | [什么时候必须确认] |
+| create 是否支持 labels/metadata 字段 | 未确认，v1 不发 | coordinator | 后续接 filesystem/labels 时确认 |

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/lesson_candidates.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/lesson_candidates.md
@@ -14,7 +14,7 @@
 | Closeout token | pending |
 | Source task | 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 |
 | Owner | coordinator |
-| Last updated | 2026-06-21 |
+| Last updated | 2026-06-23 |
 
 ## Schema
 
@@ -46,10 +46,11 @@
 
 | ID | Row Status | Title | Scope | Module Key | Detail Artifact | Boundary Reason | Why It Might Matter | Review Decision | Promotion Target | Conflict Check | Required Standard Update | Follow-up Task |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| LC-20260623-001 | ready-for-review | 外部协议实现必须 live 实测，预研笔记会过时/有误 | task | agent-runtime | n/a | 本任务预研笔记错 3 处（envd 端口、envdAccessToken、exitCode） | 新 provider 接外部协议时，逐字节实测比照搬文档/笔记可靠；预研结论要标记可证伪 | pending-human-review | n/a | 无 | 无 | n/a |
 
 ## No-Candidate Reason
 
-尚未判定。只有人工审查接受本任务没有可复用候选时，才填写这里。
+有候选 LC-20260623-001 待人工判定。
 
 ## Promotion Notes
 

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/progress.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/progress.md
@@ -1,41 +1,58 @@
 # P2-D E2B sandbox provider - 进度
 
-## 状态：未开始
-
-`## 状态` 是受控机器字段，只能使用以下值之一：
-
-- `未开始`
-- `计划中`
-- `进行中`
-- `审查中`
-- `已阻塞`
-- `已完成`
-
-不要把 `计划审阅中`、`等待 coordinator pass`、`本地审查就绪` 等细粒度协作状态写入本字段。
-这些状态应记录到进度记录、残余或协调者交接中。
+## 状态：进行中
 
 ## 进度记录
 
-证据使用 `type:path:summary` 格式。
+### [2026-06-23 20:50] - live protocol probe
 
-允许的 `type`：`command`, `diff`, `fixture`, `screenshot`, `review`, `report`。
+- 做了什么：用提供的 E2B key live 实测 control + envd 接口，确认 Connect 协议细节。
+  - create `POST /sandboxes` + `X-API-Key` → `{sandboxID, clientID, envdVersion, templateID, alias}`（**无 envdAccessToken**）。
+  - envd 端口 **49983**（不是预研笔记里的 3000）；执行 host `https://49983-{sid}.e2b.app`。
+  - 请求帧唯一正确形式：`0x00 + BE uint32 len + JSON`，`Content-Type: application/connect+json` + `Authorization: Bearer {apiKey}`。
+  - 响应帧：`start(pid)` / `data(stdout|stderr, base64)` / `end` / EOS trailer(flags 0x02)。
+  - **exitCode 陷阱**：exit=0 时 `end` 省略数字 exitCode，只给 `"status":"exit status 0"`；非零退出才带数字 exitCode。
+- 验证结果：create 201、execute 200、delete 204 全部实测成功；stdout base64 解码正确。
+- 下一步：实现 provider。
+- 证据：见 `findings.md`（协议实测结论）；command:G:\My_Project\java\ai4j-sdk:live E2B create/execute/delete verified
 
-证据较长或数量较多时，不要粘贴全文；放入 `artifacts/INDEX.md` 并在这里引用 ID。
+### [2026-06-23 21:10] - implementation
 
-### [YYYY-MM-DD HH:MM] - [阶段名称]
+- 做了什么：在 `ai4j-agent/.../sandbox/e2b/` 新增 7 个源文件：
+  - `E2BSandboxConfig`（fromEnvironment + spec.config 覆盖 + buildSandboxHost）。
+  - `E2BSandboxClient`（create/delete REST 用 X-API-Key；execute Connect：`buildProcessFrame` + `parseConnectStream` 逐帧读 + base64 解码 + exitCode 字段/status 回退）。
+  - `E2BSandboxProvider`（createSession → createSandbox → Session）。
+  - `E2BSandboxSession`（命令默认 `sh -c` 包装；stdin 经 `printf '%s' '...' | ( cmd )` 管道；env 合并；close → delete）。
+  - `E2BCreateSandboxResponse` / `E2BProcessResult` / `E2BApiException`。
+- 验证结果：`mvn -pl ai4j-agent -am compile` BUILD SUCCESS。
+- 下一步：写测试。
 
-- 做了什么：[具体操作]
-- 验证结果：[运行了什么检查，结果如何]
-- 下一步：[下一步动作]
-- 证据：[type:path:summary]
+### [2026-06-23 21:25] - tests
+
+- 做了什么：新增 5 个测试文件。
+  - `E2BSandboxClientTest`（6）：纯帧 buildProcessFrame / parseConnectStream，含 chunked 输出、Connect 错误 trailer、exit=0 走 status 解析。
+  - `E2BSandboxProviderTest`（4）：本地 HTTP 集成 create→execute→delete，校验请求帧结构与 shell-wrap/stdin 管道；deleteOnClose=false 不删；缺 key 报错。
+  - `E2BSandboxConfigTest`（5）：env 默认值、image→template、spec.config 覆盖、sandboxUrl 覆盖。
+  - `E2BLocalHttpServer`：支持二进制 Connect 帧的离线 HTTP 桩。
+  - `E2BSandboxLiveSmokeTest`（1，@Category Live）：真实 create→execute(exit 0 + 非零 7)→close。
+- 验证结果：
+  - 修复 1 个 bug：envd 在 exit=0 时省略 exitCode → 加 status 字符串解析回退（带回归单测）。
+  - 离线 15 测试全绿；live 烟测 1 测试全绿（9.6s，真实沙箱）。
+  - ai4j-agent 全模块回归：148 tests，0 failures / 0 errors / 0 skipped。
+  - `git diff --check` 无 whitespace error。
+- 证据：
+  - command:G:\My_Project\java\ai4j-sdk:15 offline + 1 live E2B tests pass, ai4j-agent 148 tests pass
+  - command:G:\My_Project\java\ai4j-sdk:E2B_API_KEY=... mvn -pl ai4j-agent -am -Plive-provider-tests -Dtest=E2BSandboxLiveSmokeTest test -> BUILD SUCCESS
 
 ## 残余
 
-- [遗留问题；如无写“无”]
+- cancel() 返回 false（process.Process/SendSignal 未接）；listArtifacts() 空（filesystem API 未接）；
+  create 不发 labels/metadata（字段名未确认）。均记为 v1 范围外，后续任务再接。
+- live 烟测用的 key `e2b_c8c7...` 应在合入后轮换（已出现在会话历史里）。
 
 ## 协调者交接（Coordinator，启用模块并行时填写）
 
-- Global sync status：pending-coordinator-pass / synced / n/a
-- Registry update needed：[module key, step, status, branch, updated / 不适用]
-- Harness Ledger update needed：[task plan path, review path, closeout status / 不适用]
-- 负责人：coordinator / 不适用
+- Global sync status：pending-coordinator-pass
+- Registry update needed：agent-runtime, T-P2-D, review, feat/e2b-sandbox-provider, updated
+- Harness Ledger update needed：closeout 后 `harness governance rebuild --apply`
+- 负责人：coordinator

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/review.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/review.md
@@ -4,106 +4,102 @@
 
 | Reviewer | Type | Scope |
 | --- | --- | --- |
-| [name] | self / subagent / external / human | [审查范围] |
+| coordinator | self | E2B provider 源码、Connect 协议正确性、SPI 对齐、测试覆盖、回归 |
+| reviewer subagent | subagent | 待 PR 评审时调用（只读） |
 
 ## 审查范围
 
-- 审查类型：adversarial / security / regression / architecture / release / other
-- 范围内：[文件、模块、行为、运行目标]
-- 范围外：[明确不审查的内容；如无写“无”]
-- 来源材料：[task plan、diff、commit、PR、测试输出、运行证据]
+- 审查类型：adversarial / regression / architecture
+- 范围内：`ai4j-agent/.../sandbox/e2b/**`、E2B Connect 协议编解码、live 烟测证据、ai4j-agent 回归
+- 范围外：core/CLI/starter（未改动）；cancel/filesystem（v1 范围外，见 findings）
+- 来源材料：task plan、diff、live 实测帧、测试输出、ai4j-agent 全模块回归
 
 ## Agent Review Submission（Agent 提交审查）
 
-本节由 agent 或 coordinator 在审查材料包准备好时填写。它只表示“提交待审”，不表示人工批准。
-
 | Field | Value |
 | --- | --- |
-| Submission ID | [由 task-review 生成] |
-| Submitted At | [timestamp] |
-| Submitted By | [agent 或 coordinator 身份] |
+| Submission ID | self-review-1（待 task-review 生成） |
+| Submitted At | 2026-06-23 |
+| Submitted By | coordinator |
 | Task Key | 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 |
-| Materials Checklist Hash | [由 task-review 生成；只作信息记录，不作为手工门禁] |
-| Evidence Summary | [测试、diff、运行和审查材料证据] |
-| Open Findings Count | [数字] |
-| Scanner Version | [生成时的 scanner 版本] |
+| Materials Checklist Hash | 待生成 |
+| Evidence Summary | 15 离线 + 1 live 测试全绿；ai4j-agent 148 测试 0 失败；live 实测 create/execute(exit 0 + 7)/delete |
+| Open Findings Count | 0 |
+| Scanner Version | n/a（手工 self-review） |
 
 ### Material Checklist（材料清单）
 
 | Material | Required? | Status | Evidence |
 | --- | --- | --- | --- |
-| Brief | yes / no | present / missing / incomplete | [路径或原因] |
-| Task plan | yes / no | present / missing / incomplete | [路径或原因] |
-| Progress and evidence | yes / no | present / missing / incomplete | [路径或原因] |
-| Visual map | yes / no | present / missing / incomplete | [路径或原因] |
-| Lesson candidate decision | yes / no | present / missing / incomplete | [路径或原因] |
-| Walkthrough or closeout link | yes / no | present / missing / incomplete | [路径或原因] |
-
-Scanner 会根据必需文件、章节、证据和这个严格提交块派生 `materialsReady`。如果材料未齐，任务应进入缺材料队列，而不是人工审查确认队列。
-如果存在开放的 P0/P1/P2 阻塞发现，任务应进入阻塞队列，而不是人工审查确认队列。
+| Brief | yes | present | brief.md |
+| Task plan | yes | present | task_plan.md |
+| Progress and evidence | yes | present | progress.md |
+| Visual map | yes | present | visual_map.md |
+| Lesson candidate decision | yes | present | lesson_candidates.md |
+| Walkthrough or closeout link | yes | present | walkthrough.md |
 
 ## 信心挑战（Confidence Challenge）
 
-直接回答：你是否对当前计划、实现和策略有 100% 信心？
+- Verdict：yes
+- 100% 依据：Connect 协议逐字节 live 实测确认（请求帧、响应帧、exitCode 陷阱）；纯单测覆盖编解码；本地 HTTP 集成覆盖请求结构；live 烟测覆盖端到端（含非零退出）。
+- Fix loop count：1（实现后 live 烟测发现 exit=0 省略 exitCode → 加 status 解析 + 回归单测 → 复测通过）
+- 当前结论：实现与验证完成，可提交 PR。
 
-- Verdict：yes / no
-- 如果不是 100%，剩余漏洞或证据缺口：
-  - [风险 / 漏洞 / 未验证假设；如无写“无”]
-- Fix loop count：[已经执行几轮 review -> fix -> evidence -> review]
-- 当前结论：[为什么现在可以继续、暂停或收口]
-
-## 重要发现（Material Findings，表头供 checker 解析）
+## 重要发现（Material Findings）
 
 | ID | Severity | Finding | Evidence Checked | Required Action | Open | Disposition | Blocks Release | Follow-up |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 
-不要保留示例 finding。若没有重要发现，只保留表头，并补全下面的无重要发现声明。
-
-允许的 `Severity`：`P0`, `P1`, `P2`, `P3`。
-允许的 `Open`：`yes`, `no`。
-允许的 `Disposition`：`open`, `mitigated`, `closed`, `deferred`, `accepted-risk`, `not-reproducible`, `out-of-scope`。
-允许的 `Blocks Release`：`yes`, `no`。
+本轮已检查上述证据，未发现阻塞目标的重要发现。
 
 ## 非阻塞备注（Non-Material Notes）
 
-- [不阻塞本轮目标但值得记录的问题；如无写“无”]
+- v1 范围外：cancel（SendSignal）、listArtifacts（filesystem）、create labels/metadata —— 见 findings.md 决策表。
+- live 用的 E2B key 出现在会话历史，合入后建议轮换。
 
 ## 已检查证据（Evidence Checked）
 
 | Evidence ID | Type | Path | Summary |
 | --- | --- | --- | --- |
-| E-001 | command / diff / fixture / screenshot / review / report | PUBLIC:path 或 PRIVATE:path 或 TARGET:path 或 EXTERNAL:path 或 URL:https://example.com | [检查了什么，结论是什么] |
+| E-001 | command | TARGET:ai4j-agent | `mvn -pl ai4j-agent -am test` → 148 tests 0 failures |
+| E-002 | command | TARGET:ai4j-agent | `E2B_API_KEY=... -Plive-provider-tests -Dtest=E2BSandboxLiveSmokeTest` → live exit 0 + exit 7 全绿 |
+| E-003 | diff | TARGET:ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/e2b/ | 7 源文件，Connect 编解码 + SPI 实现 |
+| E-004 | review | PRIVATE:findings.md | Connect 协议逐项 live 实测确认 |
+| E-005 | command | TARGET:. | `git diff --check` 无 whitespace error |
 
 ## 无重要发现声明
 
-[如果没有重要发现，明确写：本轮已检查上述证据，未发现阻塞目标的重要发现。]
+本轮已检查上述证据，未发现阻塞目标的重要发现。
 
 ## 残余风险
 
 | Risk | Owner | Accepted? | Follow-up |
 | --- | --- | --- | --- |
-| [风险] | [负责人] | yes / no | [后续路径或“无”] |
+| cancel/listArtifacts/create-labels 未实现 | coordinator | yes | 后续任务接 SendSignal/filesystem |
+| E2B key 泄露在会话历史 | user | no | 合入后轮换 key |
 
 ## Lifecycle Queue Routing（生命周期队列路由）
 
 | Queue | Applies? | Reason | Exit condition |
 | --- | --- | --- | --- |
-| Review | yes / no | 已提交审查材料包，且可等待人工确认。 | 人工确认或退回。 |
-| Missing Materials | yes / no | 必需文件、章节、证据或 review submission 缺失 / 不完整。 | Agent 补齐材料并重新提交审查。 |
-| Blocked | yes / no | 存在 open blocking finding、非法状态转换、审计失败或需要人工 waiver。 | blocker 被修复、关闭或明确豁免。 |
-| Lessons | yes / no | Lesson candidate 需要拒绝、留在任务内、dry-run promotion 或创建沉淀任务。 | 人工决定候选路由；除非明确批准，promotion 仍是单独维护任务。 |
-| Confirmed / Finalized | yes / no | 已有人工确认；可能仍待结项或治理收口。 | Closeout、ledger 和 lesson routing 都完成。 |
-| Soft-deleted / Superseded | yes / no | 任务有 tombstone、superseded-by 或 archive 状态；duplicate / abandoned 等语义写在 `Reason`。 | reopen 或作为只读审计历史保留。 |
+| Review | yes | self-review 完成，提交 PR 待评审 | PR 评审通过 / 退回 |
+| Missing Materials | no | 必需文件齐全 | — |
+| Blocked | no | 无 open blocking finding | — |
+| Lessons | no | 候见 lesson_candidates.md | — |
+| Confirmed / Finalized | no | 待 PR 合并后收口 | — |
+| Soft-deleted / Superseded | no | — | — |
 
 ## 后续路由（Follow-Up Routing）
 
-- 任务计划：[是否需要更新，路径或“无”]
-- Progress：[对应 `progress.md` 条目]
-- 发现记录：[是否需要写入 `findings.md`]
-- Regression SSoT：[新增 / 调整 / 无]
-- Lessons：[checked-created: L-YYYY-MM-DD-NNN / checked-candidate: LC-YYYYMMDD-NNN / queued-promotion: LC-YYYYMMDD-NNN / checked-none: 一句话原因]
-- 收口记录：[收口时引用路径]
+- 任务计划：已填，无需更新
+- Progress：progress.md 末条
+- 发现记录：findings.md F-001..F-007
+- Regression SSoT：新增 `mvn -pl ai4j-agent -am -Plive-provider-tests -Dtest=E2BSandboxLiveSmokeTest`
+- Lessons：checked-candidate: LC-20260623-001（Connect 协议 live 实测优先于预研笔记）
+- 收口记录：PR 合并后写入
 
 ## 最终信心依据（Final Confidence Basis）
 
-[说明最终信心来自哪些证据、审查层级和已关闭发现。发布前最终审查不能只依赖 self-only。]
+信心来自：(1) Connect 协议逐字节 live 实测；(2) 纯单测覆盖编解码与 exitCode 陷阱；(3) 本地 HTTP
+集成覆盖请求结构；(4) live 烟测端到端验证 exit 0 与非零 7；(5) ai4j-agent 全模块 148 测试无回归。
+发布前最终审查待 PR 评审（非 self-only）。

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/task_plan.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/task_plan.md
@@ -9,81 +9,90 @@ Task Package Index: required
 
 ## 目标
 
-[用一句话说明本任务完成后应达到的状态。]
+为 agent sandbox SPI 增加一个 E2B provider，能创建/销毁 E2B 沙箱并通过 Connect server-streaming
+`process.Process/Start` 执行命令，行为与 Daytona provider 对齐。
 
 ## 范围
 
-- 做什么：[本轮允许修改或交付的内容]
-- 不做什么：[明确排除的内容，避免执行中扩大范围]
-- 主要风险：[当前已知的技术、产品、协作或验证风险]
+- 做什么：在 `ai4j-agent/.../sandbox/e2b/` 下新增 provider（Config/Client/Provider/Session + 3 个
+  DTO/异常），实现 create→execute→delete 全链路；镜像 Daytona SPI 与测试结构；离线单测 + live 烟测。
+- 不做什么：不接 `process.Process/SendSignal`（cancel 返回 false）；不接 filesystem API
+  （listArtifacts 返回空）；不在 create 请求里发 labels/metadata（字段未确认）；不改 core/CLI/starter。
+- 主要风险：Connect 协议帧格式与 auth 是通过 live 实测确认的，envd 侧行为以实测为准。
 
 ## 预算选择
 
 选择预算：complex
 
-选择理由：[为什么本任务适合这个预算]
+选择理由：新增一个完整 provider，含非平凡的外部协议（Connect 帧编解码、base64、exitCode 陷阱），
+需要对齐 Daytona SPI 并自测；不属于简单增量。
 
 ## 上下文包（Context Packet）
 
 | ID | 类型 | 路径 | 为什么需要 | 使用者 |
 | --- | --- | --- | --- | --- |
-| C-001 | public-doc / private-plan / external / code | PUBLIC:path 或 PRIVATE:path 或 TARGET:path 或 EXTERNAL:path 或 URL:https://example.com | [说明这份上下文如何影响任务] | coordinator / reviewer / worker |
+| C-001 | code | TARGET:ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/daytona/ | Daytona provider 作为 SPI/测试模板 | worker |
+| C-002 | external | URL:https://github.com/e2b-dev/E2B (python-sdk connection_config.py) | 确认 envd 端口 49983、host 格式、auth | worker |
+| C-003 | private-plan | PRIVATE:coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/findings.md | Connect 协议实测结论 | worker/reviewer |
 
 ## 步骤
 
-1. [步骤 1]
-2. [步骤 2]
-3. [步骤 3]
+1. live 探测 E2B control + envd 接口，确认 Connect 请求帧/响应帧/auth/exitCode 语义。
+2. 实现 E2BSandboxConfig（fromEnvironment + spec.config 覆盖）。
+3. 实现 E2BSandboxClient（create/delete REST + execute Connect 编解码）。
+4. 实现 E2BSandboxProvider/E2BSandboxSession（命令→ sh -c 包装 + stdin 管道 + env 合并）。
+5. 离线单测（纯帧 + 本地 HTTP 集成）+ live 烟测；ai4j-agent 全模块回归。
 
 ## 验收标准
 
-- [ ] [标准 1]
-- [ ] [标准 2]
-- [ ] [标准 3]
+- [x] `ai4j-agent/.../sandbox/e2b/` 7 个源文件，实现 SandboxProvider + SandboxSession SPI。
+- [x] Connect 帧编码/解码有纯单测覆盖（含 exit=0 经 status 解析的陷阱）。
+- [x] 本地 HTTP 集成测试覆盖 create→execute→delete 与请求帧结构。
+- [x] live 烟测（E2B_API_KEY 存在时）真实创建沙箱、执行命令、验证 exitCode（含非零 7），并销毁。
+- [x] `mvn -pl ai4j-agent -am test` 全绿，无回归。
 
 ## 工作树（Worktree）
 
-- 路径：[worktree 路径，例如 `.worktrees/feat/xxx`]
-- 分支：[分支名]
-- Worker owner：[coordinator / subagent id / 不适用]
-- Worker handoff commit required：[yes / no / 不适用]
-- Coordinator integration branch：[分支名 / 不适用]
-- 未使用 worktree 的原因：[说明]
+- 路径：主工作区（未用 worktree）
+- 分支：`feat/e2b-sandbox-provider`（基于 main `a6c196c`）
+- Worker owner：coordinator
+- Worker handoff commit required：yes
+- Coordinator integration branch：`feat/e2b-sandbox-provider`
+- 未使用 worktree 的原因：单 provider 增量，无并行写冲突。
 
 ## 长程任务判定
 
-- 是否属于长程任务：[是 / 否]
-- 若是，合同文件：`long-running-task-contract.md`
-- 连续执行权限：[已授权 / 未授权 / 不适用]
-- Stop Condition 摘要：[一句话说明什么时候必须停]
+- 是否属于长程任务：否
+- 连续执行权限：不适用
+- Stop Condition 摘要：不适用
 
 ## 审查判定
 
-- 是否需要对抗性审查：[是 / 否]
-- 若是，报告文件：`review.md`
-- Reviewer：[self / subagent / external / human / 不适用]
-- No-finding 要求：[例如 reviewer 无重要发现 / 不适用]
+- 是否需要对抗性审查：是（外部协议实现）
+- 报告文件：`review.md`
+- Reviewer：self + subagent（待 PR 评审）
+- No-finding 要求：reviewer 无重要协议/安全发现
 
 ## 关联
 
-- 相关 Regression Gate：[引用]
-- 审查报告：[路径 / 不适用]
+- 相关 Regression Gate：`mvn -pl ai4j-agent -am test`；live profile `-Plive-provider-tests`
+- 审查报告：`review.md`
 - Generated Ledger：由 lifecycle CLI / `harness governance rebuild` 重建
-- 前置任务：[引用；如无写“无”]
+- 前置任务：`2026-06-21-p2-c-daytona-sandbox-provider-7263b5b5`（handoff）
 
 ## 模块关联（启用模块并行时填写）
 
-- Module：[module key，例如 reader / graph / 不适用]
-- Step：[step ID，例如 RDR-02 / 不适用]
-- Module Plan：[link to module_plan.md / 不适用]
+- Module：agent-runtime
+- Step：T-P2-D-E2B-SANDBOX-PROVIDER-7DFDB7C6
+- Module Plan：coding-agent-harness/planning/modules/agent-runtime/module_plan.md
 
 ## 协调者交接（Coordinator，启用模块并行时填写）
 
-- Global sync owner：coordinator / 不适用
-- Global sync status：pending-coordinator-pass / synced / n/a
-- Registry update needed：[module key, step, status, branch, updated / 不适用]
-- Harness Ledger update needed：[task plan path, review path, closeout status / 不适用]
-- Closeout / Regression update needed：[路径或 n/a]
+- Global sync owner：coordinator
+- Global sync status：pending-coordinator-pass
+- Registry update needed：agent-runtime, T-P2-D, review, feat/e2b-sandbox-provider, updated
+- Harness Ledger update needed：本 task_plan + review + closeout 状态
+- Closeout / Regression update needed：progress.md
 
 ## Module Preset
 
@@ -95,7 +104,7 @@ This module task was created through the `module` preset.
 
 ## Module Context Entry Points
 
-Read these module-level entry points before changing shared module behavior. Continue into narrower context only when the task surface requires it.
+Read these module-level entry points before changing shared module behavior. Continue into narrower context only if the task surface requires it.
 
 | Reference | Path | Why / When |
 | --- | --- | --- |

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/visual_map.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/visual_map.md
@@ -23,10 +23,10 @@ flowchart LR
 
 | Phase ID | Kind | Depends On | State | Completion | Output | Required Evidence | Exit Command | Actor | Evidence Status | Blocking Risk | Owner / Handoff |
 | --- | --- | --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- |
-| INIT-01 | init | none | planned | 0 | 任务计划和执行策略已确认 | `task_plan.md`; `execution_strategy.md` | `harness task-start 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` | agent | missing | none | coordinator |
-| EXEC-01 | execution | INIT-01 | planned | 0 | 有边界的实现、文档切片和验证证据 | diff、commands、worker handoff 或 artifact path | `harness task-phase 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 EXEC-01 --state done --completion 100 --evidence present` | agent | missing | [risk] | [owner] |
-| GATE-01 | gate | EXEC-01 | planned | 0 | Agent Review Submission | `review.md`、progress update、lesson routing | `harness task-review 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 --message "<summary>"` | agent | missing | [risk] | coordinator |
-| GATE-02 | gate | GATE-01 | planned | 0 | Human Review Confirmation | review packet 和人工确认 | `harness review-confirm 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 --confirm 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` | human | missing | Agent 不能代办人工确认 | human |
+| INIT-01 | init | none | done | 100 | 任务计划和执行策略已确认 | `task_plan.md`; `execution_strategy.md` | `harness task-start 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` | agent | present | none | coordinator |
+| EXEC-01 | execution | INIT-01 | done | 100 | E2B provider 7 源文件 + 5 测试文件 + live 验证 | diff、test commands、progress.md | `harness task-phase 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 EXEC-01 --state done --completion 100 --evidence present` | agent | present | 范围外能力 deferred | coordinator |
+| GATE-01 | gate | EXEC-01 | review | 100 | Agent Review Submission | `review.md`、progress update、lesson routing | `harness task-review 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 --message "<summary>"` | agent | present | 待 PR reviewer | coordinator |
+| GATE-02 | gate | GATE-01 | planned | 0 | Human/PR Review Confirmation | review packet 和 PR 确认 | `harness review-confirm 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6 --confirm 2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` | human | missing | PR 评审未完成 | human |
 
 允许的 `State`：`planned`, `in_progress`, `review`, `blocked`, `done`, `skipped`。
 

--- a/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/walkthrough.md
+++ b/coding-agent-harness/planning/modules/agent-runtime/tasks/2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6/walkthrough.md
@@ -2,40 +2,47 @@
 
 ## 摘要
 
-待收口。
+为 agent sandbox SPI 新增 E2B provider：通过 E2B control API（`X-API-Key`）创建/销毁沙箱，
+经 Connect server-streaming `process.Process/Start`（`Authorization: Bearer`）执行命令。
+行为对齐 Daytona，零既有文件改动。实现 + live 烟测完成，待 PR 评审。
 
 ## 范围
 
 | 范围 | 详情 |
 | --- | --- |
-| 变更模块 | pending |
-| 新增文件 | pending |
-| 删除文件 | pending |
-| 不在范围内 | pending |
+| 变更模块 | ai4j-agent |
+| 新增文件 | ai4j-agent/src/main/java/.../sandbox/e2b/（7 源文件）；ai4j-agent/src/test/.../（5 测试文件） |
+| 删除文件 | 无 |
+| 不在范围内 | cancel(SendSignal)、listArtifacts(filesystem)、create labels/metadata；core/CLI/starter |
 
 ## 验证
 
 | 检查 | 命令或过程 | 结果 | 证据 |
 | --- | --- | --- | --- |
-| pending | pending | not run | pending |
+| 离线单测 | `mvn -pl ai4j-agent -am -Dtest=E2B* test` | 15 测试全绿 | progress.md |
+| live 烟测 | `-Plive-provider-tests -Dtest=E2BSandboxLiveSmokeTest`（E2B_API_KEY） | exit 0 + exit 7 全绿 | progress.md |
+| 全模块回归 | `mvn -pl ai4j-agent -am test` | 148 测试 0 失败 | progress.md |
+| diff 卫生 | `git diff --check` | 无 whitespace error | progress.md |
 
 ## 审查结论
 
 | 来源 | 重要发现 | 处理 | 证据 |
 | --- | --- | --- | --- |
-| pending | pending | pending | `review.md` |
+| coordinator self-review | 无阻塞发现 | v1 范围外能力记 deferred | `review.md` |
+| PR reviewer | 待 PR | pending | `review.md` |
 
 ## 残余风险
 
 | 风险 | Owner | 是否接受 | 跟进 |
 | --- | --- | --- | --- |
-| pending | owner | pending | pending |
+| cancel/listArtifacts/create-labels 未实现 | coordinator | yes | 后续任务 |
+| E2B key 泄露在会话历史 | user | no | 合入后轮换 |
 
 ## 经验沉淀反思
 
 | 问题 | 答案 |
 | --- | --- |
-| 是否完成经验候选检查？ | pending |
+| 是否完成经验候选检查？ | 是，LC-20260623-001（外部协议实现须 live 实测） |
 | 经验候选详情文件 | `lesson_candidates.md` |
 
 ## 收口链接
@@ -45,3 +52,4 @@
 | 任务计划 | `task_plan.md` |
 | 审查记录 | `review.md` |
 | 进度记录 | `progress.md` |
+| 分支 | `feat/e2b-sandbox-provider` |


### PR DESCRIPTION
## What

Adds a second agent sandbox provider (`e2b`) alongside Daytona. Creates/deletes E2B sandboxes via the control API (`X-API-Key`) and runs commands against the per-sandbox envd host (`Authorization: Bearer`) using the Connect server-streaming `process.Process/Start` RPC.

Task: `2026-06-21-p2-d-e2b-sandbox-provider-7dfdb7c6` (P2-D).

## Why

P2-A defined a protocol-neutral sandbox SPI; P2-C shipped one provider (Daytona). This adds a second backend with a fundamentally different execution wire format (Connect streaming envelopes, base64 output, exitCode carried in a status string) to validate the SPI generalizes — and to give agent runtimes a real E2B option.

## How

- \`E2BSandboxClient.buildProcessFrame\` — single Connect envelope \`0x00 + BE uint32 len + JSON\`.
- \`E2BSandboxClient.parseConnectStream\` — reads frames (\`start(pid)\` / \`data(stdout|stderr, base64)\` / \`end\` / EOS-trailer). \`exitCode\` taken from \`end.exitCode\`, **falling back to the \`"exit status N"\` status string** because envd omits the numeric exitCode on a clean (0) exit.
- \`E2BSandboxSession\` — wraps the command in \`sh -c\` (matches Daytona shell semantics), pipes optional \`stdin\` via \`printf '%s' '...' | ( cmd )\` to preserve the exit code, merges env.
- \`E2BSandboxConfig\` — \`fromEnvironment\` (\`E2B_API_KEY\`/\`E2B_DOMAIN\`/\`E2B_TEMPLATE_ID\`/\`E2B_ENVD_PORT\`/\`E2B_TIMEOUT\`/\`E2B_SANDBOX_URL\`/\`E2B_ACCESS_TOKEN\`) + \`spec.config\` overrides; sandbox host \`https://49983-<sid>.e2b.app\`.

Connect protocol details were confirmed byte-for-byte against the live E2B API (see \`findings.md\`); the prior research notes had three errors (envd port 3000→49983, envdAccessToken present→absent, exitCode always present→omitted on 0).

## Scope

- In: \`ai4j-agent/**\` only (7 new source files + 5 test files).
- Out (v1, deferred): \`cancel()\` via \`process.Process/SendSignal\` (returns false); \`listArtifacts()\` (empty); \`create\` labels/metadata. No core/CLI/starter changes.

## Verification

- 15 offline tests: pure Connect frame codec + local-HTTP integration (create→execute→delete, request-frame structure, shell-wrap, stdin pipe, deleteOnClose).
- 1 live smoke test (gated on \`E2B_API_KEY\`): real create → execute (exit 0 and non-zero exit 7) → close/destroy.
- \`mvn -pl ai4j-agent -am test\` → **148 tests, 0 failures**; \`git diff --check\` clean.

## Risk

- The E2B API key used for live testing appears in session history; rotate after merge.
- v1 scope gaps documented in \`findings.md\` / \`walkthrough.md\`.

## Reviewer focus

- \`E2BSandboxClient.parseConnectStream\` — Connect frame parsing + exitCode fallback.
- \`E2BSandboxSession.resolveCommand\` — shell-wrap + stdin-pipe correctness.
- Auth split (control \`X-API-Key\` vs execution \`Authorization: Bearer\`).