### PR TITLE
docs(core-sdk): document E2B provider + third Messages model-access line

### DIFF
--- a/docs-site/docs/agent/sandbox-spi.md
+++ b/docs-site/docs/agent/sandbox-spi.md
@@ -8,7 +8,7 @@ sidebar_position: 9
 
 > Agent 已经决定要执行 shell、文件、浏览器或项目命令时，宿主如何把这次执行交给一个真实的隔离环境，并拿回 stdout、stderr、artifact 和事件？
 
-P2-A 提供 Java 8 SPI 和数据模型；P2-B 把非敏感 sandbox 摘要绑定到 `AgentSession`；P2-C 已提供首个真实 provider：Daytona。你仍然可以把同一套 SPI 接到 CubeSandbox、Docker/K8s、E2B、公司内部 VM/microVM 或自己的远端执行平台。
+P2-A 提供 Java 8 SPI 和数据模型；P2-B 把非敏感 sandbox 摘要绑定到 `AgentSession`；P2-C 已提供首个真实 provider：Daytona；P2-D 已提供第二个真实 provider：E2B。你仍然可以把同一套 SPI 接到 CubeSandbox、Docker/K8s、公司内部 VM/microVM 或自己的远端执行平台。
 
 ## 1. 它不是什么
 
@@ -219,7 +219,7 @@ mvn -pl ai4j-agent -am "-Dtest=AgentSandboxSpiModelTest" -DskipTests=false -Dfai
 
 ### AI4J 会官方内置很多 provider 吗？
 
-不会内置一堆 provider。更稳的路径是：AI4J 提供小而稳定的 SPI，并保留少量官方验证过的真实 provider。Daytona 是首个官方真实 provider；E2B、CubeSandbox、Docker/K8s、内部平台等可以继续由插件、业务方或后续独立任务接入。
+不会内置一堆 provider。更稳的路径是：AI4J 提供小而稳定的 SPI，并保留少量官方验证过的真实 provider。Daytona 与 E2B 是当前两个官方真实 provider；CubeSandbox、Docker/K8s、内部平台等可以继续由插件、业务方或后续独立任务接入。
 
 ### 每个用户应该一个 sandbox，还是共享一个？
 
@@ -322,11 +322,104 @@ mvn -pl ai4j-agent -am "-Dtest=DaytonaSandboxProviderTest" -DskipTests=false -Df
 mvn -pl ai4j-agent -am -P live-provider-tests "-Dtest=DaytonaSandboxLiveSmokeTest" -DskipTests=false -DfailIfNoTests=false test
 ```
 
-## 12. 下一步
+## 12. P2-D：E2B provider
+
+P2-D 在通用 SPI 之上新增了第二个真实可用的 E2B 接入：
+
+```text
+io.github.lnyocly.ai4j.agent.sandbox.e2b
+```
+
+E2B 的执行模型与 Daytona 不同：它通过 E2B 控制 API（`X-API-Key`）创建/销毁沙箱，再通过每个沙箱的执行 host（`Authorization: Bearer`）用 Connect server-streaming `process.Process/Start` 协议执行命令。这些协议细节都被 provider 封装，使用者只需要 `SandboxSession.execute(...)`。
+
+核心类：
+
+| 类型 | 作用 |
+| --- | --- |
+| `E2BSandboxProvider` | `SandboxProvider` 实现，`providerId=e2b`。 |
+| `E2BSandboxConfig` | 从环境变量和 `SandboxSpec.config` 读取 E2B 连接、模板、超时和清理配置。 |
+| `E2BSandboxClient` | Java 8 `HttpURLConnection` 客户端：control API（create/delete）+ Connect 帧编解码（`buildProcessFrame` / `parseConnectStream`）。 |
+| `E2BSandboxSession` | 把 `SandboxCommand` 映射为 `sh -c` 执行（可选 stdin 管道），返回 `SandboxResult`。 |
+
+### 最小使用
+
+推荐把密钥放在环境变量里，不要写进代码、YAML 或日志：
+
+```bash
+export E2B_API_KEY="e2b_..."
+# 可选；不传时使用 SDK 默认值（域名 e2b.app / 模板 base / 执行端口 49983）
+```
+
+Java 侧只声明 provider、模板和非敏感策略：
+
+```java
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.e2b.E2BSandboxProvider;
+
+SandboxSession session = new E2BSandboxProvider().createSession(
+        SandboxSpec.builder()
+                .providerId("e2b")
+                .config("templateID", "base")
+                .config("timeoutSeconds", Integer.valueOf(300))
+                .build());
+
+try {
+    SandboxResult result = session.execute(SandboxCommand.builder()
+            .command("printf ai4j-e2b-ok")
+            .timeoutMillis(30000L)
+            .build());
+    System.out.println(result.getExitCode());   // 0
+    System.out.println(result.getStdout());     // ai4j-e2b-ok
+} finally {
+    session.close();   // 默认销毁沙箱
+}
+```
+
+### 配置来源
+
+| 配置 | 来源 | 说明 |
+| --- | --- | --- |
+| `E2B_API_KEY` / `apiKey` | env / `SandboxSpec.config` | E2B API key；生产用法优先 env。 |
+| `E2B_DOMAIN` / `apiDomain` | env / config | E2B 域名，默认 `e2b.app`。 |
+| `E2B_API_URL` / `apiUrl` | env / config | 控制 API 地址；不传时派生为 `https://api.<domain>`。 |
+| `E2B_TEMPLATE_ID` / `templateId` / `templateID` / `image` | env / config / spec | 模板，默认 `base`。 |
+| `E2B_ENVD_PORT` / `envdPort` | env / config | 执行 host 端口，默认 `49983`。 |
+| `E2B_TIMEOUT` / `timeoutSeconds` | env / config | 沙箱存活秒数，默认 `300`。 |
+| `E2B_SANDBOX_URL` / `sandboxUrl` | env / config | 可选；覆盖派生的执行 host（例如走自建代理）。 |
+| `E2B_ACCESS_TOKEN` / `envdAccessToken` | env / config | 可选；secure 流程的 envd 访问令牌（走 `X-Access-Token`）。不传时用 API key 作 Bearer。 |
+| `useShellWrap` | config | 是否用 `sh -c` 包装命令，默认 `true`。 |
+| `deleteOnClose` | config | `close()` 时是否删除沙箱，默认 `true`。 |
+| `env` | config | 注入的非敏感环境变量。 |
+| `connectTimeoutMillis`、`readTimeoutMillis` | config | HTTP 超时。 |
+
+### 执行模型与边界
+
+- 命令默认包成 `sh -c <command>`，支持管道、重定向、多语句（与 Daytona 的 shell 语义对齐）。
+- `SandboxCommand.stdin` 非空时，通过 `printf '%s' '<stdin>' | ( <command> )` 管道喂入并保留退出码。`useShellWrap=false` 时改为按空白拆分直接 exec（不支持 stdin）。
+- stdout / stderr 是 base64 流式输出；exit code 取自 Connect `end.exitCode`，退出码为 0 时从 `"exit status N"` 状态字符串解析。
+- `cancel(...)` 暂时返回 `false`（process `SendSignal` 未接）；`listArtifacts()` 暂时为空（filesystem API 未接）。
+- Live smoke 属于 `live-provider-opt-in`，通过 `-P live-provider-tests` 显式运行，并且只从环境变量读取密钥。
+
+本地确定性回归：
+
+```bash
+mvn -pl ai4j-agent -am "-Dtest=E2BSandboxClientTest,E2BSandboxProviderTest,E2BSandboxConfigTest" -DskipTests=false -DfailIfNoTests=false test
+```
+
+真实 E2B 冒烟（需要环境变量）：
+
+```bash
+mvn -pl ai4j-agent -am -P live-provider-tests "-Dtest=E2BSandboxLiveSmokeTest" -DskipTests=false -DfailIfNoTests=false test
+```
+
+## 13. 下一步
 
 推荐后续顺序：
 
 1. P2-B：已把 `SandboxSpec` / `SandboxSession` 的非敏感摘要绑定到 `AgentSession` snapshot / event log。
-2. P2-C：已落地 Daytona 官方真实 provider，并保留 provider registry / 插件贡献 provider 的后续扩展空间。
+2. P2-C / P2-D：已落地 Daytona 与 E2B 两个官方真实 provider，并保留 provider registry / 插件贡献 provider 的后续扩展空间。
 3. P3：已让 `ai4j-coding` 的 `bash exec` 根据 sandbox binding 路由执行；file/git/browser/project runner 仍应按边界继续拆小切片。
 4. P4：在 CLI/TUI 中显示 `/sandbox status`、provider、workspace、最近执行位置和 artifact。

--- a/docs-site/docs/core-sdk/model-access/overview.md
+++ b/docs-site/docs/core-sdk/model-access/overview.md
@@ -6,10 +6,14 @@
 
 - `platform/openai/chat/entity/ChatCompletion.java`
 - `platform/openai/response/entity/ResponseRequest.java`
+- `platform/anthropic/chat/entity/AnthropicChatCompletion.java`
 - `platform/openai/chat/OpenAiChatService.java`
 - `platform/openai/response/OpenAiResponsesService.java`
+- `platform/anthropic/chat/AnthropicMessagesService.java`
+- `platform/anthropic/chat/AnthropicChatService.java`
 - `listener/SseListener.java`
 - `listener/ResponseSseListener.java`
+- `service/IMessagesService.java`
 - `service/factory/AiService.java`
 
 ## 1. 这一章在 Core SDK 里的位置
@@ -44,7 +48,7 @@
 
 ## 3. 这章最先要分清的边界
 
-第一次进入这一章，最重要的不是先看某个 provider，而是先分清 AI4J 内部有两条不同的模型访问主线：
+第一次进入这一章，最重要的不是先看某个 provider，而是先分清 AI4J 内部有三条不同的模型访问主线，分别对应三族原生协议：
 
 ### `Chat`
 
@@ -59,6 +63,13 @@
 - 更贴近结构化 response item / event 心智
 - provider 覆盖更聚焦
 - 更适合 runtime 侧状态消费
+
+### `Messages`
+
+- 以 Anthropic Messages 协议为中心（顶层 `system`、`content blocks`、`tool_use` / `tool_result`、`thinking`）
+- `IMessagesService` 是原生一等公民：Anthropic 格式进、Anthropic 格式出，零 OpenAI 转换
+- 同时有一个统一适配器 `AnthropicChatService`（实现 `IChatService`），把 OpenAI Chat 请求翻译成 Anthropic Messages，让只想用 `IChatService` 的上层无感接入
+- 适合需要原生 Anthropic 语义（thinking、content blocks）或使用 coding-plan key（智谱 / Minimax 的 Anthropic 端点）的场景
 
 很多后续差异，包括 streaming、多模态、工具解析方式，本质上都从这里分叉。
 
@@ -88,6 +99,7 @@
 
 - `Chat` 是更广覆盖的默认主线
 - `Responses` 是更结构化、但 provider 覆盖更聚焦的主线
+- `Messages`（Anthropic 格式）原生覆盖 Anthropic 端点；智谱、Minimax 的 **coding-plan key** 也走 Anthropic 格式端点，因此通过 `Messages` 或其统一适配器 `AnthropicChatService` 接入
 
 这不是文档叙述偏好，而是当前工厂实现给出的事实。
 
@@ -109,7 +121,7 @@ AI4J 的请求对象策略不是简单追求字段最少，而是把主语义固
 
 所以读这一章时，要把“本地注册字段”和“最终 provider 字段”分开理解。
 
-## 6. 两条主线都不是单纯文本接口
+## 6. 三条主线都不是单纯文本接口
 
 `Chat` 不是“只会返回一条字符串”：
 
@@ -121,7 +133,9 @@ AI4J 的请求对象策略不是简单追求字段最少，而是把主语义固
 - 非流式会返回完整 `Response`
 - 流式时 `ResponseSseListener` 会同时聚合 `events`、`outputText`、`reasoningSummary`、`functionArguments` 和最终 `response`
 
-这意味着两条主线都已经足以支撑中等复杂度运行时，只是适合的消费方式不同。
+`Messages` 同样不只是文本：content blocks 里会带 `thinking`（映射成统一 `reasoningContent` / agent `reasoningText` / 流式 `onReasoningDelta`）、`tool_use` / `tool_result`，统一适配器还能自动跑 tool loop 并把结果回传成 `tool_result`。
+
+这意味着三条主线都已经足以支撑中等复杂度运行时，只是适合的消费方式不同。
 
 ## 7. 多模态也属于这一层，而不是 Tool 或 MCP
 
@@ -144,9 +158,10 @@ AI4J 把图文输入纳入了统一会话抽象：
 
 1. [Chat](/docs/core-sdk/model-access/chat)
 2. [Responses](/docs/core-sdk/model-access/responses)
-3. [Chat vs Responses](/docs/core-sdk/model-access/chat-vs-responses)
-4. [Streaming](/docs/core-sdk/model-access/streaming)
-5. [Multimodal](/docs/core-sdk/model-access/multimodal)
+3. [Messages](/docs/core-sdk/model-access/messages)
+4. [Chat vs Responses](/docs/core-sdk/model-access/chat-vs-responses)
+5. [Streaming](/docs/core-sdk/model-access/streaming)
+6. [Multimodal](/docs/core-sdk/model-access/multimodal)
 6. [Request and Response Conventions](/docs/core-sdk/model-access/request-and-response-conventions)
 
 ## 9. 这一页的结论


### PR DESCRIPTION
Fills the doc gaps for recently-shipped features (the high-ROI slice of roadmap #6 'docs completeness'; a full pass over the 250-page site is out of scope for one PR).

## What

- **agent/sandbox-spi.md** — add a P2-D E2B provider section (parallel to the existing Daytona §11): execution model (Connect `process.Process/Start`), config/env table, `sh -c` + stdin-pipe behavior, the exitCode-from-status note, and regression commands. Fix two stale references that still listed E2B as a *future* option.
- **core-sdk/model-access/overview.md** — the chapter landing page framed everything as 'two lines' (Chat + Responses) and never mentioned the **third** Messages/Anthropic protocol family shipped this cycle. Added it throughout: source anchors, the three-line framing, provider coverage (incl. coding-plan keys via the Anthropic endpoint), and the reading-order list.

## Why

E2B was just merged (PR #142) with zero docs, and `sandbox-spi.md` was stale (calling E2B 'future'). The model-access overview — the entry point to the chapter — omitted the Messages/Anthropic surface entirely, so readers couldn't discover it. Both are recently-shipped features; documenting them is the highest-value docs work.

## Verification

`npm --prefix docs-site run build` → SUCCESS (no broken markdown/links).

## Scope

Docs only (2 markdown files). No code changes. The broader 250-page completeness pass remains a separate, larger effort.