### PR TITLE
feat(cli): add ai4j/ai4j.bat launchers for the fat jar

### DIFF
--- a/ai4j-cli/src/main/distribution/bin/ai4j
+++ b/ai4j-cli/src/main/distribution/bin/ai4j
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# ai4j — launcher for the ai4j CLI fat jar.
+#
+# Responsibilities (and only these — see docs-site coding-agent/install-and-release
+# section 8): locate java, locate the fat jar, forward all arguments, keep the
+# stable command name `ai4j`. It deliberately does NOT hardcode provider/model/
+# secrets or parse configuration — that is Ai4jCli's job.
+#
+# Optional overrides:
+#   AI4J_JAR        explicit path to ai4j-cli-*-jar-with-dependencies.jar
+#   JAVA_HOME       JRE/JDK home (otherwise `java` from PATH)
+#   AI4J_JAVA_OPTS  extra JVM flags (heap, system properties, ...)
+#
+set -e
+
+# Resolve this script's real directory, following symlinks.
+PRG="$0"
+while [ -h "$PRG" ]; do
+  ls=$(ls -ld "$PRG")
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG="$(dirname "$PRG")/$link"
+  fi
+done
+BIN_DIR=$(cd "$(dirname "$PRG")" > /dev/null 2>&1 && pwd)
+
+# Locate the fat jar: explicit override, then ../lib/, then alongside the launcher.
+if [ -n "$AI4J_JAR" ]; then
+  JAR="$AI4J_JAR"
+else
+  JAR=""
+  for d in "$BIN_DIR/../lib" "$BIN_DIR"; do
+    match=$(ls "$d"/ai4j-cli-*-jar-with-dependencies.jar 2>/dev/null | head -n 1)
+    if [ -n "$match" ]; then
+      JAR="$match"
+      break
+    fi
+  done
+fi
+if [ -z "$JAR" ] || [ ! -f "$JAR" ]; then
+  echo "ai4j: cannot find ai4j-cli fat jar. Set AI4J_JAR or place" \
+       "ai4j-cli-*-jar-with-dependencies.jar next to this launcher or in ../lib/." >&2
+  exit 1
+fi
+
+# Locate java.
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  JAVACMD="$JAVA_HOME/bin/java"
+else
+  JAVACMD="java"
+fi
+
+exec "$JAVACMD" $AI4J_JAVA_OPTS $JAVA_OPTS -jar "$JAR" "$@"

--- a/ai4j-cli/src/main/distribution/bin/ai4j.bat
+++ b/ai4j-cli/src/main/distribution/bin/ai4j.bat
@@ -1,0 +1,40 @@
+@echo off
+rem
+rem ai4j -- launcher for the ai4j CLI fat jar (Windows).
+rem
+rem Responsibilities (see docs-site coding-agent/install-and-release section 8):
+rem locate java, locate the fat jar, forward all arguments, keep the stable
+rem command name `ai4j`. Does NOT hardcode provider/model/secrets or parse
+rem configuration.
+rem
+rem Optional overrides:
+rem   AI4J_JAR        explicit path to ai4j-cli-*-jar-with-dependencies.jar
+rem   JAVA_HOME       JRE/JDK home (otherwise `java` from PATH)
+rem   AI4J_JAVA_OPTS  extra JVM flags (heap, system properties, ...)
+setlocal enabledelayedexpansion
+
+set "BIN_DIR=%~dp0"
+if "%BIN_DIR:~-1%"=="\" set "BIN_DIR=%BIN_DIR:~0,-1%"
+
+rem Locate the fat jar: explicit override, then ..\lib\, then alongside the launcher.
+set "JAR=%AI4J_JAR%"
+if defined JAR goto run
+for %%F in ("%BIN_DIR%\..\lib\ai4j-cli-*-jar-with-dependencies.jar") do if exist "%%F" ( set "JAR=%%F" & goto run )
+for %%F in ("%BIN_DIR%\ai4j-cli-*-jar-with-dependencies.jar") do if exist "%%F" ( set "JAR=%%F" & goto run )
+:run
+if not defined JAR (
+  echo ai4j: cannot find ai4j-cli fat jar. Set AI4J_JAR or place 1>&2
+  echo        ai4j-cli-*-jar-with-dependencies.jar next to this launcher or in ..\lib\. 1>&2
+  exit /b 1
+)
+if not exist "%JAR%" (
+  echo ai4j: jar not found: %JAR% 1>&2
+  exit /b 1
+)
+
+rem Locate java.
+set "JAVACMD=java"
+if defined JAVA_HOME if exist "%JAVA_HOME%\bin\java.exe" set "JAVACMD=%JAVA_HOME%\bin\java.exe"
+
+"%JAVACMD%" %AI4J_JAVA_OPTS% %JAVA_OPTS% -jar "%JAR%" %*
+endlocal

--- a/docs-site/docs/coding-agent/install-and-release.md
+++ b/docs-site/docs/coding-agent/install-and-release.md
@@ -72,22 +72,28 @@ manifest 主类当前是：
 
 这一点同样重要。
 
-根据当前 `ai4j-cli` 模块内容，仓库里还没有现成的：
+根据当前 `ai4j-cli` 模块内容，仓库里**已经提供**的：
 
-- Windows `.cmd` / `.bat` launcher
-- Unix `ai4j` shell launcher
-- 多平台压缩包生成脚本
+- Unix `ai4j` shell launcher（`ai4j-cli/src/main/distribution/bin/ai4j`）
+- Windows `ai4j.bat` launcher（`ai4j-cli/src/main/distribution/bin/ai4j.bat`）
+
+这两个 launcher 遵守第 8 节的职责边界：只定位 `java`、定位 fat jar、转发参数、保持稳定命令名 `ai4j`，不写死 provider/model/secrets，也不在脚本层解析配置。
+
+仍然**没有现成**的：
+
+- 自动产出 `bin/` + `lib/` 多平台压缩包的 assembly（launcher 目前是源码形态，需手动按下面的 bin/lib 布局放置，或用 `AI4J_JAR` 直接指）
 - checksums 资产生成逻辑
-- repo 内建 installer
+- repo 内建 installer（`curl|sh` 一键安装等）
 
-也就是说，当前“可分发”主要还是：
+也就是说，当前“可分发”现在已经是：
 
 - Maven artifact
 - 可直接 `java -jar` 的 fat jar
+- 两个平台 launcher（源码）
 
-而不是：
+而还**不是**：
 
-- 开箱即装的多平台 CLI 套件
+- 开箱即装、自带更新机制的多平台 CLI 套件
 
 ## 4. 当前最稳的构建命令
 
@@ -142,27 +148,58 @@ mvn -pl ai4j-cli -am -DskipTests package
 
 基于现有源码，最稳的安装方式仍然是：
 
-1. 用户机器上先有可用的 Java 运行时
+1. 用户机器上先有可用的 Java 运行时（JDK 8+）
 2. 拿到 `ai4j-cli-<version>-jar-with-dependencies.jar`
-3. 用 `java -jar ...` 直接运行
 
-例如：
+下面两种方式都真实可用。
+
+### 6.1 用 launcher（推荐）
+
+构建 fat jar 后，按 `bin/` + `lib/` 布局放置 launcher 和 jar：
+
+```text
+ai4j-cli-<version>/
+  bin/
+    ai4j          # 来自 ai4j-cli/src/main/distribution/bin/ai4j
+    ai4j.bat      # 来自 ai4j-cli/src/main/distribution/bin/ai4j.bat
+  lib/
+    ai4j-cli-<version>-jar-with-dependencies.jar
+```
+
+launcher 会自动找到 `../lib/` 下的 fat jar，于是可以直接：
+
+```bash
+./ai4j code --model gpt-5-mini
+```
+
+Windows 下用 `ai4j.bat`。也可以不按布局放，直接用环境变量指 jar：
+
+```bash
+export AI4J_JAR=/path/to/ai4j-cli-2.3.0-jar-with-dependencies.jar
+ai4j --help
+```
+
+launcher 支持的可选覆盖：`AI4J_JAR`（显式指 jar）、`JAVA_HOME`（指定 JRE）、`AI4J_JAVA_OPTS` / `JAVA_OPTS`（JVM 参数）。它不会写死 provider/model/secrets，也不解析配置——那些都交给 `Ai4jCli`。
+
+### 6.2 直接 `java -jar`（最简，无 launcher）
+
+不想用 launcher 时，直接跑 fat jar 也完全可行：
 
 ```powershell
 java -jar .\ai4j-cli-2.3.0-jar-with-dependencies.jar code --model gpt-5-mini
 ```
 
-这不是最优雅的终端安装体验，但它是当前源码已经真实支持、且最不依赖额外包装的方式。
+两种方式都是当前源码真实支持的；launcher 只是省掉每次敲长 jar 名，并在升级版本时不用改命令。
 
 ## 7. 如果你要做正式 release，最少还缺什么
 
-如果你的目标是“给外部用户稳定安装”，在现有 fat jar 之外，至少还建议补齐：
+如果你的目标是“给外部用户稳定安装”，在现有 fat jar + launcher 之外，至少还建议补齐：
 
-- 平台 launcher
+- ~~平台 launcher~~（已提供：`ai4j-cli/src/main/distribution/bin/ai4j(.bat)`）
 - release checksum
 - 最小示例配置
 - 版本化 release notes
-- 平台压缩包
+- 自动产出 `bin/` + `lib/` 平台压缩包的 assembly
 
 一个更像产品的 release 结构通常至少会是：
 


### PR DESCRIPTION
Roadmap item #4 (one-command install) — **minimal version**. The repo builds a self-runnable fat jar but had no command launcher, so users had to type the full jar path every time.

## What

- **ai4j-cli/src/main/distribution/bin/ai4j** (Unix, executable) and **ai4j.bat** (Windows) launchers.
- They follow the contract the install-and-release doc already specs (section 8): locate java (`JAVA_HOME` or PATH), locate the fat jar (`AI4J_JAR` override → `../lib/` → alongside), forward all args, keep the stable name `ai4j`. **No** hardcoded provider/model/secrets, **no** config parsing — that stays in `Ai4jCli`.
- **docs-site/docs/coding-agent/install-and-release.md**: the doc itself previously listed the launchers as *missing* (section 3) and *still to build* (section 7). Updated sections 3/6/7 to reflect they now exist, and documented the `bin/` + `lib/` install layout + the `AI4J_JAR` override.

## Verification

- `mvn -pl ai4j-cli -am -DskipTests package` → BUILD SUCCESS (2.3.0 fat jar, 204 MB).
- Launcher tested 3 ways: `AI4J_JAR` override → prints full `--help` (exit 0); `bin/`+`lib/` auto-discovery → prints `--help` (exit 0); missing jar → clean error (exit 1).
- `npm --prefix docs-site run build` → SUCCESS.
- `ai4j` committed with executable bit (100755).

## Scope / deliberately out

Hosting/release pipeline (GitHub Releases, `curl|sh`, checksums, auto-generated `bin/lib` distro zip, Homebrew/scoop) is **not** included — the doc marks those as future work, and shipping an installer is premature until the CLI UX itself is polished (roadmap #5). This PR delivers the launcher layer the doc already contracts.