### PR TITLE
feat(agent): node I/O capture + node-level replay (Phase 1)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/InMemoryIoCaptureSink.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/InMemoryIoCaptureSink.java
@@ -1,0 +1,68 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * In-memory {@link IoCaptureSink}. Keeps the original input/output objects so
+ * {@link NodeReplayer#replayModelLive} can re-invoke the model with the real captured prompt.
+ */
+public class InMemoryIoCaptureSink implements IoCaptureSink {
+
+    private final List<NodeIoRecord> records = Collections.synchronizedList(new ArrayList<NodeIoRecord>());
+
+    @Override
+    public void capture(NodeIoRecord record) {
+        if (record != null) {
+            records.add(record);
+        }
+    }
+
+    @Override
+    public List<NodeIoRecord> records() {
+        synchronized (records) {
+            return new ArrayList<NodeIoRecord>(records);
+        }
+    }
+
+    @Override
+    public List<NodeIoRecord> records(NodeIoRecord.NodeType type) {
+        List<NodeIoRecord> out = new ArrayList<NodeIoRecord>();
+        synchronized (records) {
+            for (NodeIoRecord r : records) {
+                if (r.getNodeType() == type) {
+                    out.add(r);
+                }
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public NodeIoRecord find(String nodeId) {
+        if (nodeId == null) {
+            return null;
+        }
+        synchronized (records) {
+            for (NodeIoRecord r : records) {
+                if (nodeId.equals(r.getNodeId())) {
+                    return r;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public int size() {
+        synchronized (records) {
+            return records.size();
+        }
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureAgentListener.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureAgentListener.java
@@ -1,0 +1,160 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.event.AgentEvent;
+import io.github.lnyocly.ai4j.agent.event.AgentEventType;
+import io.github.lnyocly.ai4j.agent.event.AgentListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An {@link AgentListener} that turns the agent event stream into replayable {@link NodeIoRecord}s.
+ *
+ * <p>It reuses the events the runtime already publishes — no runtime change. MODEL nodes are
+ * paired by (runId, turnId, step): {@code MODEL_REQUEST} carries the full {@link AgentPrompt} as
+ * input, the final {@code MODEL_RESPONSE} carries the raw response as output (streaming deltas
+ * overwrite until the step ends). TOOL nodes are paired by call id: {@code TOOL_CALL} carries the
+ * {@link AgentToolCall} input, {@code TOOL_RESULT} carries the {@link AgentToolResult} output.
+ * Records are flushed to the sink on {@code STEP_END} (model) / {@code TOOL_RESULT} (tool).</p>
+ */
+public class IoCaptureAgentListener implements AgentListener {
+
+    private final IoCaptureSink sink;
+    private final Map<String, NodeIoRecord.Builder> pendingModels = new HashMap<String, NodeIoRecord.Builder>();
+    private final Map<String, NodeIoRecord.Builder> pendingTools = new HashMap<String, NodeIoRecord.Builder>();
+
+    public IoCaptureAgentListener(IoCaptureSink sink) {
+        if (sink == null) {
+            throw new IllegalArgumentException("sink must not be null");
+        }
+        this.sink = sink;
+    }
+
+    public IoCaptureSink getSink() {
+        return sink;
+    }
+
+    @Override
+    public synchronized void onEvent(AgentEvent event) {
+        if (event == null || event.getType() == null) {
+            return;
+        }
+        try {
+            switch (event.getType()) {
+                case MODEL_REQUEST:
+                    onModelRequest(event);
+                    break;
+                case MODEL_RESPONSE:
+                    onModelResponse(event);
+                    break;
+                case TOOL_CALL:
+                    onToolCall(event);
+                    break;
+                case TOOL_RESULT:
+                    onToolResult(event);
+                    break;
+                case STEP_END:
+                    flushModel(event);
+                    break;
+                default:
+                    // ignore other event types
+                    break;
+            }
+        } catch (Exception ignored) {
+            // a capture listener must never break the agent run
+        }
+    }
+
+    private void onModelRequest(AgentEvent event) {
+        String key = stepKey(event);
+        NodeIoRecord.Builder b = NodeIoRecord.builder(NodeIoRecord.NodeType.MODEL)
+                .runId(event.getRunId())
+                .sessionId(event.getSessionId())
+                .turnId(event.getTurnId())
+                .step(event.getStep())
+                .nodeId("model@" + key)
+                .inputs(event.getPayload());
+        if (event.getPayload() instanceof AgentPrompt) {
+            b.modelId(((AgentPrompt) event.getPayload()).getModel());
+        }
+        pendingModels.put(key, b);
+    }
+
+    private void onModelResponse(AgentEvent event) {
+        String key = stepKey(event);
+        NodeIoRecord.Builder b = pendingModels.get(key);
+        if (b != null) {
+            // last response wins (handles streaming deltas); keep the richest payload available
+            b.outputs(event.getPayload());
+        }
+    }
+
+    private void flushModel(AgentEvent event) {
+        String key = stepKey(event);
+        NodeIoRecord.Builder b = pendingModels.remove(key);
+        if (b != null) {
+            sink.capture(b.build());
+        }
+    }
+
+    private void onToolCall(AgentEvent event) {
+        String callId = null;
+        String toolName = null;
+        if (event.getPayload() instanceof AgentToolCall) {
+            AgentToolCall call = (AgentToolCall) event.getPayload();
+            callId = call.getCallId();
+            toolName = call.getName();
+        }
+        String key = toolKey(event, callId, toolName);
+        NodeIoRecord.Builder b = NodeIoRecord.builder(NodeIoRecord.NodeType.TOOL)
+                .runId(event.getRunId())
+                .sessionId(event.getSessionId())
+                .turnId(event.getTurnId())
+                .step(event.getStep())
+                .nodeId("tool@" + key)
+                .inputs(event.getPayload());
+        pendingTools.put(key, b);
+    }
+
+    private void onToolResult(AgentEvent event) {
+        String callId = null;
+        String toolName = null;
+        if (event.getPayload() instanceof AgentToolResult) {
+            AgentToolResult result = (AgentToolResult) event.getPayload();
+            callId = result.getCallId();
+            toolName = result.getName();
+        }
+        String key = toolKey(event, callId, toolName);
+        NodeIoRecord.Builder b = pendingTools.remove(key);
+        if (b != null) {
+            b.outputs(event.getPayload());
+            sink.capture(b.build());
+        } else {
+            // result without a paired call: capture best-effort
+            sink.capture(NodeIoRecord.builder(NodeIoRecord.NodeType.TOOL)
+                    .runId(event.getRunId())
+                    .sessionId(event.getSessionId())
+                    .turnId(event.getTurnId())
+                    .step(event.getStep())
+                    .nodeId("tool@" + key)
+                    .outputs(event.getPayload())
+                    .build());
+        }
+    }
+
+    private static String stepKey(AgentEvent event) {
+        return safe(event.getRunId()) + "|" + safe(event.getTurnId()) + "|" + event.getStep();
+    }
+
+    private static String toolKey(AgentEvent event, String callId, String toolName) {
+        String discrim = callId != null ? callId : (toolName != null ? toolName : "anon");
+        return stepKey(event) + "|" + discrim;
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureSink.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureSink.java
@@ -1,0 +1,23 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import java.io.Closeable;
+import java.util.List;
+
+/**
+ * Receives {@link NodeIoRecord}s from {@link IoCaptureAgentListener} and makes them queryable.
+ * Implementations: {@link InMemoryIoCaptureSink} (tests / live replay) and
+ * {@link JsonlIoCaptureSink} (durable audit/replay artifact).
+ */
+public interface IoCaptureSink extends Closeable {
+
+    void capture(NodeIoRecord record);
+
+    List<NodeIoRecord> records();
+
+    List<NodeIoRecord> records(NodeIoRecord.NodeType type);
+
+    /** Returns the first record whose nodeId matches, or null. */
+    NodeIoRecord find(String nodeId);
+
+    int size();
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/JsonlIoCaptureSink.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/JsonlIoCaptureSink.java
@@ -1,0 +1,150 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Durable {@link IoCaptureSink}: appends each {@link NodeIoRecord} as one JSON line. The resulting
+ * file is the audit/replay artifact — append-only, grep-able, replayable.
+ *
+ * <p>Note: records loaded back from JSON have their {@code inputs}/{@code outputs} as parsed
+ * JSON objects (not the original typed objects), so this sink is for durable storage / audit;
+ * use {@link InMemoryIoCaptureSink} when live re-invocation of the captured objects is needed.</p>
+ */
+public class JsonlIoCaptureSink implements IoCaptureSink {
+
+    private final Path path;
+    private final BufferedWriter writer;
+    private final Object lock = new Object();
+
+    public JsonlIoCaptureSink(Path path) throws IOException {
+        if (path == null) {
+            throw new IllegalArgumentException("path must not be null");
+        }
+        this.path = path;
+        if (path.getParent() != null) {
+            Files.createDirectories(path.getParent());
+        }
+        this.writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    @Override
+    public void capture(NodeIoRecord record) {
+        if (record == null) {
+            return;
+        }
+        synchronized (lock) {
+            try {
+                writer.write(JSON.toJSONString(record));
+                writer.write("\n");
+                writer.flush();
+            } catch (IOException e) {
+                throw new RuntimeException("failed to write capture record to " + path, e);
+            }
+        }
+    }
+
+    @Override
+    public List<NodeIoRecord> records() {
+        return load(path);
+    }
+
+    @Override
+    public List<NodeIoRecord> records(NodeIoRecord.NodeType type) {
+        List<NodeIoRecord> out = new ArrayList<NodeIoRecord>();
+        for (NodeIoRecord r : load(path)) {
+            if (r.getNodeType() == type) {
+                out.add(r);
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public NodeIoRecord find(String nodeId) {
+        if (nodeId == null) {
+            return null;
+        }
+        for (NodeIoRecord r : load(path)) {
+            if (nodeId.equals(r.getNodeId())) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return load(path).size();
+    }
+
+    @Override
+    public void close() {
+        synchronized (lock) {
+            try {
+                writer.close();
+            } catch (IOException ignored) {
+                // best-effort close
+            }
+        }
+    }
+
+    /** Loads all records from a JSONL file (one record per line). */
+    public static List<NodeIoRecord> load(Path path) {
+        if (path == null || !Files.isRegularFile(path)) {
+            return Collections.emptyList();
+        }
+        List<NodeIoRecord> out = new ArrayList<NodeIoRecord>();
+        try {
+            for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+                if (line == null || line.trim().isEmpty()) {
+                    continue;
+                }
+                try {
+                    JSONObject obj = JSON.parseObject(line);
+                    if (obj == null) {
+                        continue;
+                    }
+                    // NodeIoRecord has no no-arg ctor, so rebuild via the Builder; inputs/outputs
+                    // come back as parsed JSON (original typed objects don't round-trip from JSON).
+                    NodeIoRecord.NodeType type = obj.getObject("nodeType", NodeIoRecord.NodeType.class);
+                    NodeIoRecord.Builder b = NodeIoRecord.builder(type == null ? NodeIoRecord.NodeType.MODEL : type)
+                            .recordId(obj.getString("recordId"))
+                            .runId(obj.getString("runId"))
+                            .sessionId(obj.getString("sessionId"))
+                            .turnId(obj.getString("turnId"))
+                            .step(obj.getInteger("step"))
+                            .nodeId(obj.getString("nodeId"))
+                            .modelId(obj.getString("modelId"))
+                            .inputs(obj.get("inputs"))
+                            .outputs(obj.get("outputs"));
+                    Integer capturedAt = obj.getInteger("capturedAtEpochMs");
+                    if (capturedAt != null) {
+                        b.capturedAtEpochMs(capturedAt.longValue());
+                    }
+                    out.add(b.build());
+                } catch (Exception ignored) {
+                    // skip malformed line rather than failing the whole load
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("failed to read capture file " + path, e);
+        }
+        return out;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/NodeIoRecord.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/NodeIoRecord.java
@@ -1,0 +1,90 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import java.util.UUID;
+
+/**
+ * One captured node's full input/output, assembled by {@link IoCaptureAgentListener} from the
+ * agent event stream. A MODEL node pairs a {@code MODEL_REQUEST} (input = {@code AgentPrompt})
+ * with its {@code MODEL_RESPONSE} (output = raw response); a TOOL node pairs a {@code TOOL_CALL}
+ * with its {@code TOOL_RESULT}.
+ *
+ * <p>The {@code inputs}/{@code outputs} fields hold the original objects for in-memory live
+ * replay (re-invoke the model/tool with the real captured input). The serialized form written by
+ * {@link JsonlIoCaptureSink} is the durable audit/replay artifact.</p>
+ */
+public final class NodeIoRecord {
+
+    public enum NodeType { MODEL, TOOL }
+
+    private final String recordId;
+    private final String runId;
+    private final String sessionId;
+    private final String turnId;
+    private final Integer step;
+    private final NodeType nodeType;
+    private final String nodeId;
+    private final String modelId;
+    private final Object inputs;
+    private final Object outputs;
+    private final long capturedAtEpochMs;
+
+    NodeIoRecord(Builder builder) {
+        this.recordId = builder.recordId == null ? UUID.randomUUID().toString() : builder.recordId;
+        this.runId = builder.runId;
+        this.sessionId = builder.sessionId;
+        this.turnId = builder.turnId;
+        this.step = builder.step;
+        this.nodeType = builder.nodeType;
+        this.nodeId = builder.nodeId;
+        this.modelId = builder.modelId;
+        this.inputs = builder.inputs;
+        this.outputs = builder.outputs;
+        this.capturedAtEpochMs = builder.capturedAtEpochMs == null
+                ? System.currentTimeMillis() : builder.capturedAtEpochMs.longValue();
+    }
+
+    public String getRecordId() { return recordId; }
+    public String getRunId() { return runId; }
+    public String getSessionId() { return sessionId; }
+    public String getTurnId() { return turnId; }
+    public Integer getStep() { return step; }
+    public NodeType getNodeType() { return nodeType; }
+    public String getNodeId() { return nodeId; }
+    public String getModelId() { return modelId; }
+    public Object getInputs() { return inputs; }
+    public Object getOutputs() { return outputs; }
+    public long getCapturedAtEpochMs() { return capturedAtEpochMs; }
+
+    static Builder builder(NodeType type) {
+        return new Builder(type);
+    }
+
+    static final class Builder {
+        private String recordId;
+        private String runId;
+        private String sessionId;
+        private String turnId;
+        private Integer step;
+        private final NodeType nodeType;
+        private String nodeId;
+        private String modelId;
+        private Object inputs;
+        private Object outputs;
+        private Long capturedAtEpochMs;
+
+        private Builder(NodeType nodeType) { this.nodeType = nodeType; }
+
+        Builder recordId(String v) { this.recordId = v; return this; }
+        Builder runId(String v) { this.runId = v; return this; }
+        Builder sessionId(String v) { this.sessionId = v; return this; }
+        Builder turnId(String v) { this.turnId = v; return this; }
+        Builder step(Integer v) { this.step = v; return this; }
+        Builder nodeId(String v) { this.nodeId = v; return this; }
+        Builder modelId(String v) { this.modelId = v; return this; }
+        Builder inputs(Object v) { this.inputs = v; return this; }
+        Builder outputs(Object v) { this.outputs = v; return this; }
+        Builder capturedAtEpochMs(long v) { this.capturedAtEpochMs = v; return this; }
+
+        NodeIoRecord build() { return new NodeIoRecord(this); }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/NodeReplayer.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/NodeReplayer.java
@@ -1,0 +1,79 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+
+import java.util.function.Function;
+
+/**
+ * Replays a single captured {@link NodeIoRecord}.
+ *
+ * <p>Two modes for MODEL nodes:</p>
+ * <ul>
+ *   <li><b>live</b> ({@link #replayModelLive}): re-invokes the real {@link AgentModelClient} with
+ *       the captured {@link AgentPrompt}. This is a REAL model call (non-deterministic) — use it
+ *       to re-run a node, A/B different models, or reproduce a flow with fresh outputs.</li>
+ *   <li><b>mock</b> ({@link #replayModelMock}): returns a result reconstructed from the captured
+ *       output. Deterministic, no model call — use it to reproduce a past run exactly.</li>
+ * </ul>
+ *
+ * <p>For TOOL nodes, {@link #replayToolLive} re-invokes a tool via a supplied function (the SDK
+ * does not assume how tools are re-bound; the caller provides the re-invocation).</p>
+ */
+public class NodeReplayer {
+
+    /**
+     * Live-replays a MODEL node: re-invokes the model with the captured prompt.
+     * @throws IllegalArgumentException if the record is not a MODEL node with an AgentPrompt input.
+     */
+    public AgentModelResult replayModelLive(NodeIoRecord record, AgentModelClient modelClient) throws Exception {
+        requireModel(record);
+        if (modelClient == null) {
+            throw new IllegalArgumentException("modelClient must not be null");
+        }
+        Object input = record.getInputs();
+        if (!(input instanceof AgentPrompt)) {
+            throw new IllegalArgumentException(
+                    "MODEL node input is not an AgentPrompt (got " + (input == null ? "null" : input.getClass()) + ")");
+        }
+        return modelClient.create((AgentPrompt) input);
+    }
+
+    /**
+     * Deterministic/mock replay of a MODEL node: builds a result from the captured output, with
+     * no model call. Useful for exact reproduction of a past turn.
+     */
+    public AgentModelResult replayModelMock(NodeIoRecord record) {
+        requireModel(record);
+        return AgentModelResult.builder()
+                .rawResponse(record.getOutputs())
+                .build();
+    }
+
+    /**
+     * Live-replays a TOOL node by re-invoking the tool via the supplied function.
+     */
+    public AgentToolResult replayToolLive(NodeIoRecord record, Function<AgentToolCall, AgentToolResult> reinvoker) {
+        if (record == null || record.getNodeType() != NodeIoRecord.NodeType.TOOL) {
+            throw new IllegalArgumentException("record is not a TOOL node");
+        }
+        if (reinvoker == null) {
+            throw new IllegalArgumentException("reinvoker must not be null");
+        }
+        Object input = record.getInputs();
+        if (!(input instanceof AgentToolCall)) {
+            throw new IllegalArgumentException(
+                    "TOOL node input is not an AgentToolCall (got " + (input == null ? "null" : input.getClass()) + ")");
+        }
+        return reinvoker.apply((AgentToolCall) input);
+    }
+
+    private static void requireModel(NodeIoRecord record) {
+        if (record == null || record.getNodeType() != NodeIoRecord.NodeType.MODEL) {
+            throw new IllegalArgumentException("record is not a MODEL node");
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/NodeIoCaptureReplayLiveTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/NodeIoCaptureReplayLiveTest.java
@@ -1,0 +1,163 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
+import io.github.lnyocly.ai4j.agent.replay.InMemoryIoCaptureSink;
+import io.github.lnyocly.ai4j.agent.replay.IoCaptureAgentListener;
+import io.github.lnyocly.ai4j.agent.replay.NodeIoRecord;
+import io.github.lnyocly.ai4j.agent.replay.NodeReplayer;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IMessagesService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import okhttp3.OkHttpClient;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live verification of node I/O capture + replay against a real LLM (GLM via the Anthropic
+ * Messages endpoint). Runs a real agent turn with a tool, captures every MODEL/TOOL node's I/O,
+ * then <b>live-replays the MODEL node by re-invoking the real LLM</b> with the captured prompt,
+ * and re-invokes the captured tool. Skipped unless {@code ANTHROPIC_API_KEY} is set.
+ */
+@Category(LiveProviderTest.class)
+public class NodeIoCaptureReplayLiveTest {
+
+    private static String env(String name, String def) {
+        String v = System.getenv(name);
+        return (v == null || v.trim().isEmpty()) ? def : v;
+    }
+
+    @Test
+    public void liveCaptureAndReplayModelAndToolNodes() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = env("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = env("ANTHROPIC_MODEL", "glm-5.1");
+
+        // echo_text tool
+        Tool.Function fn = new Tool.Function();
+        fn.setName("echo_text");
+        fn.setDescription("Echo back the provided text exactly.");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        Tool.Function.Property textProp = new Tool.Function.Property();
+        textProp.setType("string");
+        textProp.setDescription("The text to echo back");
+        props.put("text", textProp);
+        param.setProperties(props);
+        param.setRequired(Collections.singletonList("text"));
+        fn.setParameters(param);
+        Tool tool = new Tool("function", fn);
+        AgentToolRegistry registry = new StaticToolRegistry(Collections.<Object>singletonList(tool));
+        final ToolExecutor executor = new ToolExecutor() {
+            @Override
+            public String execute(AgentToolCall call) {
+                return "echo result";
+            }
+        };
+
+        Agent agent = Agents.react()
+                .anthropicMessages(key, baseUrl)
+                .model(model)
+                .maxOutputTokens(512)
+                .toolRegistry(registry)
+                .toolExecutor(executor)
+                .build();
+
+        InMemoryIoCaptureSink sink = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener capture = new IoCaptureAgentListener(sink);
+
+        AgentResult result = agent.newSession().runStreamResult(
+                AgentRequest.builder().input("Use the echo_text tool to echo 'hello', then tell me the result.").build(),
+                capture);
+
+        System.out.println("=== capture/replay live test ===");
+        System.out.println("run outputText=" + result.getOutputText());
+        System.out.println("run toolResults=" + result.getToolResults());
+
+        List<NodeIoRecord> models = sink.records(NodeIoRecord.NodeType.MODEL);
+        List<NodeIoRecord> tools = sink.records(NodeIoRecord.NodeType.TOOL);
+        assertTrue("must capture >=1 MODEL node", models.size() >= 1);
+        assertTrue("MODEL node input must be the AgentPrompt", models.get(0).getInputs() instanceof AgentPrompt);
+        assertTrue("must capture >=1 TOOL node (echo_text)", tools.size() >= 1);
+        assertTrue("TOOL node input must be the AgentToolCall", tools.get(0).getInputs() instanceof AgentToolCall);
+
+        // --- LIVE replay of the first MODEL node: re-invoke the REAL LLM with the captured prompt ---
+        AgentModelClient replayClient = buildReplayClient(key, baseUrl);
+        AgentModelResult liveReplay = new NodeReplayer().replayModelLive(models.get(0), replayClient);
+        assertNotNull("live replay must return a result", liveReplay);
+        boolean hasOutput = (liveReplay.getOutputText() != null && !liveReplay.getOutputText().isEmpty())
+                || (liveReplay.getToolCalls() != null && !liveReplay.getToolCalls().isEmpty())
+                || liveReplay.getRawResponse() != null;
+        System.out.println("live-replay outputText=" + liveReplay.getOutputText()
+                + " toolCalls=" + (liveReplay.getToolCalls() == null ? 0 : liveReplay.getToolCalls().size()));
+        assertTrue("live replay must produce real model output (a fresh REAL LLM call)", hasOutput);
+
+        // --- replay the TOOL node: re-invoke echo with the captured call ---
+        NodeIoRecord toolRecord = tools.get(0);
+        AgentToolResult replayedTool = new NodeReplayer().replayToolLive(toolRecord,
+                new java.util.function.Function<AgentToolCall, AgentToolResult>() {
+                    @Override
+                    public AgentToolResult apply(AgentToolCall call) {
+                        try {
+                            return AgentToolResult.builder()
+                                    .name(call.getName())
+                                    .callId(call.getCallId())
+                                    .output(executor.execute(call))
+                                    .build();
+                        } catch (Exception e) {
+                            return AgentToolResult.builder()
+                                    .name(call.getName())
+                                    .callId(call.getCallId())
+                                    .output("replay error: " + e.getMessage())
+                                    .build();
+                        }
+                    }
+                });
+        assertNotNull(replayedTool);
+        assertTrue("replayed tool must carry the echo output",
+                replayedTool.getOutput() != null && replayedTool.getOutput().contains("echo"));
+    }
+
+    /** Builds an AgentModelClient identical to AgentBuilder.anthropicMessages(...) for live replay. */
+    private static AgentModelClient buildReplayClient(String key, String baseUrl) {
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey(key);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        configuration.setOkHttpClient(new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(300, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build());
+        IMessagesService service = new AnthropicMessagesService(configuration);
+        return new MessagesModelClient(service);
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/NodeIoCaptureReplayTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/NodeIoCaptureReplayTest.java
@@ -1,0 +1,197 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.event.AgentEvent;
+import io.github.lnyocly.ai4j.agent.event.AgentEventType;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Offline tests for the capture listener + replayer + JSONL sink, driven by a synthetic event
+ * stream (no model/network). Live re-invocation is verified against a fake model client.
+ */
+public class NodeIoCaptureReplayTest {
+
+    @Test
+    public void listenerShouldPairModelAndToolEventsIntoRecords() {
+        InMemoryIoCaptureSink sink = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(sink);
+
+        AgentPrompt prompt1 = AgentPrompt.builder().model("test-model").build();
+        AgentToolCall call = AgentToolCall.builder().name("echo").callId("call-1").arguments("{\"text\":\"hi\"}").build();
+        AgentToolResult toolOut = AgentToolResult.builder().name("echo").callId("call-1").output("echo:hi").build();
+        AgentPrompt prompt2 = AgentPrompt.builder().model("test-model").build();
+
+        // step 1: model request -> (tool call/result interleaved) -> model response -> step end
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 1, prompt1, "raw-resp-step1-pre"));
+        listener.onEvent(ev(AgentEventType.TOOL_CALL, 1, call, "echo"));
+        listener.onEvent(ev(AgentEventType.TOOL_RESULT, 1, toolOut, "echo:hi"));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 1, "raw-resp-step1", null));
+        listener.onEvent(ev(AgentEventType.STEP_END, 1, null, null));
+        // step 2: final model
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 2, prompt2, null));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 2, "raw-resp-step2", null));
+        listener.onEvent(ev(AgentEventType.STEP_END, 2, null, null));
+
+        List<NodeIoRecord> all = sink.records();
+        assertEquals("2 model nodes + 1 tool node", 3, all.size());
+
+        List<NodeIoRecord> models = sink.records(NodeIoRecord.NodeType.MODEL);
+        List<NodeIoRecord> tools = sink.records(NodeIoRecord.NodeType.TOOL);
+        assertEquals(2, models.size());
+        assertEquals(1, tools.size());
+
+        // MODEL step1: input is the prompt, output is the LAST model response payload (deltas overwritten)
+        NodeIoRecord m1 = sink.find("model@run-1|turn-1|1");
+        assertNotNull(m1);
+        assertTrue("model input must be the AgentPrompt", m1.getInputs() instanceof AgentPrompt);
+        assertEquals("test-model", ((AgentPrompt) m1.getInputs()).getModel());
+        assertEquals("test-model", m1.getModelId());
+        assertEquals("raw-resp-step1", m1.getOutputs());
+
+        // TOOL: input is the call, output is the result
+        NodeIoRecord t = tools.get(0);
+        assertTrue(t.getInputs() instanceof AgentToolCall);
+        assertEquals("echo", ((AgentToolCall) t.getInputs()).getName());
+        assertTrue(t.getOutputs() instanceof AgentToolResult);
+        assertEquals("echo:hi", ((AgentToolResult) t.getOutputs()).getOutput());
+    }
+
+    @Test
+    public void replayerMockShouldReturnCapturedOutputWithoutModelCall() {
+        InMemoryIoCaptureSink sink = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(sink);
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 1, AgentPrompt.builder().model("m").build(), null));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 1, "captured-raw", null));
+        listener.onEvent(ev(AgentEventType.STEP_END, 1, null, null));
+
+        NodeIoRecord record = sink.records(NodeIoRecord.NodeType.MODEL).get(0);
+        AgentModelResult mock = new NodeReplayer().replayModelMock(record);
+        assertEquals("captured-raw", mock.getRawResponse());
+    }
+
+    @Test
+    public void replayerLiveShouldReinvokeModelClientWithCapturedPrompt() throws Exception {
+        InMemoryIoCaptureSink sink = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(sink);
+        AgentPrompt prompt = AgentPrompt.builder().model("m").build();
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 1, prompt, null));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 1, "old-output", null));
+        listener.onEvent(ev(AgentEventType.STEP_END, 1, null, null));
+
+        NodeIoRecord record = sink.records(NodeIoRecord.NodeType.MODEL).get(0);
+        RecordingModelClient client = new RecordingModelClient(AgentModelResult.builder().outputText("fresh-live-output").build());
+        AgentModelResult live = new NodeReplayer().replayModelLive(record, client);
+
+        assertEquals("fresh-live-output", live.getOutputText());
+        assertTrue("live replay must re-invoke the client with the captured prompt", client.invokedPrompt != null);
+        assertEquals("m", client.invokedPrompt.getModel());
+    }
+
+    @Test
+    public void replayerLiveShouldRejectNonPromptInput() {
+        NodeIoRecord bad = NodeIoRecord.builder(NodeIoRecord.NodeType.MODEL)
+                .nodeId("model@x").inputs("not a prompt").outputs("out").build();
+        try {
+            new NodeReplayer().replayModelLive(bad, new RecordingModelClient(null));
+            Assert.fail("expected IllegalArgumentException for non-AgentPrompt input");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("AgentPrompt"));
+        }
+    }
+
+    @Test
+    public void jsonlSinkShouldPersistAndReloadRecords() throws Exception {
+        Path tmp = Files.createTempFile("ai4j-capture-", ".jsonl");
+        tmp.toFile().deleteOnExit();
+        JsonlIoCaptureSink sink = new JsonlIoCaptureSink(tmp);
+        InMemoryIoCaptureSink mem = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(sink);
+
+        // route the same events to both sinks to compare durable vs in-memory
+        IoCaptureAgentListener memListener = new IoCaptureAgentListener(mem);
+        AgentPrompt prompt = AgentPrompt.builder().model("jsonl-model").build();
+        for (AgentEvent e : new AgentEvent[]{
+                ev(AgentEventType.MODEL_REQUEST, 1, prompt, null),
+                ev(AgentEventType.MODEL_RESPONSE, 1, "raw-1", null),
+                ev(AgentEventType.STEP_END, 1, null, null)}) {
+            listener.onEvent(e);
+            memListener.onEvent(e);
+        }
+        sink.close();
+
+        // file has one JSON line
+        List<String> lines = Files.readAllLines(tmp);
+        assertEquals(1, lines.size());
+        assertTrue(lines.get(0).contains("model@run-1|turn-1|1"));
+
+        // reloaded record preserves metadata (nodeId, type, modelId); inputs/outputs are parsed JSON
+        List<NodeIoRecord> reloaded = JsonlIoCaptureSink.load(tmp);
+        assertEquals(1, reloaded.size());
+        assertEquals(NodeIoRecord.NodeType.MODEL, reloaded.get(0).getNodeType());
+        assertEquals("model@run-1|turn-1|1", reloaded.get(0).getNodeId());
+        assertEquals("jsonl-model", reloaded.get(0).getModelId());
+    }
+
+    @Test
+    public void listenerMustNeverPropagateExceptions() {
+        IoCaptureSink throwing = new IoCaptureSink() {
+            @Override public void capture(NodeIoRecord record) { throw new RuntimeException("boom"); }
+            @Override public List<NodeIoRecord> records() { return null; }
+            @Override public List<NodeIoRecord> records(NodeIoRecord.NodeType type) { return null; }
+            @Override public NodeIoRecord find(String nodeId) { return null; }
+            @Override public int size() { return 0; }
+            @Override public void close() { }
+        };
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(throwing);
+        // must not throw even though the sink explodes
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 1, AgentPrompt.builder().model("m").build(), null));
+        listener.onEvent(ev(AgentEventType.STEP_END, 1, null, null));
+    }
+
+    private static AgentEvent ev(AgentEventType type, int step, Object payload, String message) {
+        return AgentEvent.builder()
+                .eventId("evt-" + step + "-" + type)
+                .runId("run-1")
+                .sessionId("sess-1")
+                .turnId("turn-1")
+                .type(type)
+                .step(step)
+                .message(message)
+                .payload(payload)
+                .build();
+    }
+
+    private static final class RecordingModelClient implements AgentModelClient {
+        final AgentModelResult toReturn;
+        AgentPrompt invokedPrompt;
+
+        RecordingModelClient(AgentModelResult toReturn) { this.toReturn = toReturn; }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            this.invokedPrompt = prompt;
+            return toReturn;
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            this.invokedPrompt = prompt;
+            return toReturn;
+        }
+    }
+}


### PR DESCRIPTION
Task `2026-06-24-agent-node-io-capture-node-level-replay-4a61b820`. The keystone of the observability/recovery/replay roadmap: a capture/replay layer that unlocks node-level replay and is the foundation for deterministic failure recovery.

## Key finding (de-risks the design)

The runtime already publishes full I/O on the event bus — `MODEL_REQUEST` payload = the complete `AgentPrompt`, `MODEL_RESPONSE` = raw response, `TOOL_CALL`/`TOOL_RESULT` = call/result, all correlated by runId/sessionId/turnId/step. So this adds **only a consumer + replayer — zero runtime change**.

## What

New package `io.github.lnyocly.ai4j.agent.replay`:
- **NodeIoRecord** — one MODEL/TOOL node's captured input + output + correlation.
- **IoCaptureSink** + **InMemoryIoCaptureSink** (holds the real objects for live replay) + **JsonlIoCaptureSink** (durable append-only audit/replay artifact, with `load()`).
- **IoCaptureAgentListener** — pairs `MODEL_REQUEST`/`MODEL_RESPONSE` (by run+turn+step; last response wins over streaming deltas) and `TOOL_CALL`/`TOOL_RESULT` (by callId) into records; flushes on `STEP_END`/`TOOL_RESULT`. Never propagates exceptions.
- **NodeReplayer** — `replayModelLive` (re-invoke the real model with the captured prompt), `replayModelMock` (deterministic, from captured output), `replayToolLive`.

## Verification (incl. REAL LLM)

- 6 offline tests (pairing, mock/live replay with fake client, JSONL persist+reload, listener never throws).
- ai4j-agent full module: **154 tests, 0 failures**.
- **Live test against real GLM** (`anthropicMessages`, coding-plan key): runs a real tool turn → captures MODEL+TOOL nodes → **`replayModelLive` re-invokes GLM with the captured prompt (a fresh REAL call, toolCalls=1)** → replays the tool node. `git diff --check` clean.

## Scope

Phase 1 only. Idempotency/side-effect-skip (failure recovery), JDBC snapshot store (long-task resume), and hash-chain tamper-evidence (audit) are Phases 2–4, separate tasks. No core/CLI changes.

## Reviewer focus

- `IoCaptureAgentListener` pairing logic (streaming-delta last-wins; callId pairing).
- `NodeReplayer.replayModelLive` (the real-LLM re-call path).
- `JsonlIoCaptureSink.load` rebuild via Builder (NodeIoRecord has no no-arg ctor).