### PR TITLE
feat(agent): failure recovery via resumable model/tool decorators (Phase 2)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumableModelClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumableModelClient.java
@@ -1,0 +1,63 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+
+/**
+ * Wraps an {@link AgentModelClient} with resume-or-capture semantics over a {@link ResumeCache}.
+ *
+ * <p>On a prompt already seen in the cache, returns the captured {@link AgentModelResult} without
+ * calling the delegate (no LLM call) — this is how a resumed run skips completed model steps. On a
+ * miss, delegates to the real client and records the result, so the same client instance both
+ * captures (first run) and resumes (subsequent runs).</p>
+ *
+ * <p>Resume targets non-streaming runs ({@code create}). {@code createStream} also consults the
+ * cache, but note that a cached stream result is returned without re-emitting deltas to the
+ * listener.</p>
+ */
+public class ResumableModelClient implements AgentModelClient {
+
+    private final AgentModelClient delegate;
+    private final ResumeCache cache;
+
+    public ResumableModelClient(AgentModelClient delegate, ResumeCache cache) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate model client must not be null");
+        }
+        if (cache == null) {
+            throw new IllegalArgumentException("resume cache must not be null");
+        }
+        this.delegate = delegate;
+        this.cache = cache;
+    }
+
+    public ResumeCache getCache() {
+        return cache;
+    }
+
+    @Override
+    public AgentModelResult create(AgentPrompt prompt) throws Exception {
+        String key = ResumeCache.promptKey(prompt);
+        AgentModelResult cached = cache.lookupModel(key);
+        if (cached != null) {
+            return cached;
+        }
+        AgentModelResult result = delegate.create(prompt);
+        cache.recordModel(key, result);
+        return result;
+    }
+
+    @Override
+    public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) throws Exception {
+        String key = ResumeCache.promptKey(prompt);
+        AgentModelResult cached = cache.lookupModel(key);
+        if (cached != null) {
+            return cached;
+        }
+        AgentModelResult result = delegate.createStream(prompt, listener);
+        cache.recordModel(key, result);
+        return result;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumableToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumableToolExecutor.java
@@ -1,0 +1,45 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+
+/**
+ * Wraps a {@link ToolExecutor} with resume-or-capture semantics over a {@link ResumeCache}.
+ *
+ * <p>On a tool call already seen in the cache (same name + arguments), returns the captured output
+ * <b>without</b> invoking the delegate — i.e. the side effect is NOT re-performed. This is the
+ * crux of safe failure recovery: re-running a crashed task must not re-execute tools that already
+ * took effect (file writes, API calls, charges). On a miss, delegates and records.</p>
+ */
+public class ResumableToolExecutor implements ToolExecutor {
+
+    private final ToolExecutor delegate;
+    private final ResumeCache cache;
+
+    public ResumableToolExecutor(ToolExecutor delegate, ResumeCache cache) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate tool executor must not be null");
+        }
+        if (cache == null) {
+            throw new IllegalArgumentException("resume cache must not be null");
+        }
+        this.delegate = delegate;
+        this.cache = cache;
+    }
+
+    public ResumeCache getCache() {
+        return cache;
+    }
+
+    @Override
+    public String execute(AgentToolCall call) throws Exception {
+        String key = ResumeCache.toolKey(call);
+        String cached = cache.lookupTool(key);
+        if (cached != null) {
+            return cached;
+        }
+        String output = delegate.execute(call);
+        cache.recordTool(key, output);
+        return output;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumeCache.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumeCache.java
@@ -1,0 +1,96 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Content-addressed cache that powers {@link ResumableModelClient} / {@link ResumableToolExecutor}.
+ *
+ * <p>Keyed by the serialized prompt (MODEL) and by {@code name|arguments} (TOOL). When a run is
+ * re-driven with the same input, already-completed nodes hit the cache and short-circuit the real
+ * call — which is exactly "skip already-done work", i.e. resume / failure recovery. Counters let
+ * tests assert how many nodes were replayed vs. executed for real.</p>
+ */
+public class ResumeCache {
+
+    private final Map<String, AgentModelResult> modelResults = new LinkedHashMap<String, AgentModelResult>();
+    private final Map<String, String> toolOutputs = new LinkedHashMap<String, String>();
+    private final AtomicLong modelHits = new AtomicLong();
+    private final AtomicLong modelMisses = new AtomicLong();
+    private final AtomicLong toolHits = new AtomicLong();
+    private final AtomicLong toolMisses = new AtomicLong();
+
+    /** Looks up a cached model result; counts a hit if present, a miss otherwise. */
+    public AgentModelResult lookupModel(String promptKey) {
+        AgentModelResult r = promptKey == null ? null : modelResults.get(promptKey);
+        if (r != null) {
+            modelHits.incrementAndGet();
+        } else {
+            modelMisses.incrementAndGet();
+        }
+        return r;
+    }
+
+    public void recordModel(String promptKey, AgentModelResult result) {
+        if (promptKey != null && result != null) {
+            modelResults.put(promptKey, result);
+        }
+    }
+
+    public String lookupTool(String toolKey) {
+        String out = toolKey == null ? null : toolOutputs.get(toolKey);
+        if (out != null) {
+            toolHits.incrementAndGet();
+        } else {
+            toolMisses.incrementAndGet();
+        }
+        return out;
+    }
+
+    public void recordTool(String toolKey, String output) {
+        if (toolKey != null && output != null) {
+            toolOutputs.put(toolKey, output);
+        }
+    }
+
+    /** Removes the most-recently-recorded model entry (simulate "crashed before the last step"). */
+    public void removeLastModelEntry() {
+        String lastKey = null;
+        for (String key : modelResults.keySet()) {
+            lastKey = key;
+        }
+        if (lastKey != null) {
+            modelResults.remove(lastKey);
+        }
+    }
+
+    public int modelSize() { return modelResults.size(); }
+    public int toolSize() { return toolOutputs.size(); }
+    public long getModelHits() { return modelHits.get(); }
+    public long getModelMisses() { return modelMisses.get(); }
+    public long getToolHits() { return toolHits.get(); }
+    public long getToolMisses() { return toolMisses.get(); }
+
+    /** Deterministic key for a MODEL node: the serialized prompt. */
+    public static String promptKey(AgentPrompt prompt) {
+        if (prompt == null) {
+            return null;
+        }
+        return com.alibaba.fastjson2.JSON.toJSONString(prompt);
+    }
+
+    /** Deterministic key for a TOOL node: {@code name|arguments}. */
+    public static String toolKey(AgentToolCall call) {
+        if (call == null) {
+            return null;
+        }
+        String name = call.getName() == null ? "" : call.getName();
+        String args = call.getArguments() == null ? "" : call.getArguments();
+        return name + "|" + args;
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/AgentFailureRecoveryLiveTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/AgentFailureRecoveryLiveTest.java
@@ -1,0 +1,171 @@
+package io.github.lnyocly;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
+import io.github.lnyocly.ai4j.agent.replay.ResumableModelClient;
+import io.github.lnyocly.ai4j.agent.replay.ResumableToolExecutor;
+import io.github.lnyocly.ai4j.agent.replay.ResumeCache;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IMessagesService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import okhttp3.OkHttpClient;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live failure-recovery verification against a real LLM (GLM via Anthropic Messages).
+ *
+ * <p>Run 1 drives a real tool turn and captures every model/tool node. Run 2 re-runs the SAME input
+ * against the populated cache and must make <b>zero</b> real LLM calls (full resume). Run 3 drops the
+ * last captured model step (simulate "crashed before the final step") and must re-run only that
+ * missing step. Skipped unless {@code ANTHROPIC_API_KEY} is set.</p>
+ */
+@Category(LiveProviderTest.class)
+public class AgentFailureRecoveryLiveTest {
+
+    private static String env(String name, String def) {
+        String v = System.getenv(name);
+        return (v == null || v.trim().isEmpty()) ? def : v;
+    }
+
+    @Test
+    public void fullResumeMakesZeroRealLlmCallsAndPartialResumeReRunsMissingStep() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = env("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = env("ANTHROPIC_MODEL", "glm-5.1");
+        String input = "Use the echo_text tool to echo 'hello', then tell me the result.";
+
+        AgentToolRegistry registry = echoRegistry();
+        ResumeCache cache = new ResumeCache();
+
+        // ---- Run 1: real turn, captures all model + tool nodes ----
+        CountingModelClient real1 = new CountingModelClient(buildRealClient(key, baseUrl));
+        CountingToolExecutor tool1 = new CountingToolExecutor(echoExecutor());
+        Agent agent1 = Agents.react()
+                .modelClient(new ResumableModelClient(real1, cache))
+                .model(model).maxOutputTokens(512)
+                .toolRegistry(registry).toolExecutor(new ResumableToolExecutor(tool1, cache))
+                .build();
+        agent1.newSession().run(AgentRequest.builder().input(input).build());
+        int run1ModelCalls = real1.calls;
+        int run1ToolCalls = tool1.calls;
+        assertTrue("run1 must make real LLM calls", run1ModelCalls >= 1);
+        assertTrue("run1 must capture model results", cache.modelSize() >= 1);
+        System.out.println("=== run1 (capture) === modelCalls=" + run1ModelCalls + " toolCalls=" + run1ToolCalls
+                + " cache.modelSize=" + cache.modelSize());
+
+        // ---- Run 2: same input, full resume -> ZERO real LLM calls ----
+        CountingModelClient real2 = new CountingModelClient(buildRealClient(key, baseUrl));
+        CountingToolExecutor tool2 = new CountingToolExecutor(echoExecutor());
+        Agent agent2 = Agents.react()
+                .modelClient(new ResumableModelClient(real2, cache))
+                .model(model).maxOutputTokens(512)
+                .toolRegistry(registry).toolExecutor(new ResumableToolExecutor(tool2, cache))
+                .build();
+        agent2.newSession().run(AgentRequest.builder().input(input).build());
+        System.out.println("=== run2 (full resume) === modelCalls=" + real2.calls + " toolCalls=" + tool2.calls);
+        assertEquals("full resume must make ZERO real LLM calls", 0, real2.calls);
+        assertEquals("full resume must skip all tool side effects", 0, tool2.calls);
+
+        // ---- Run 3: drop the last captured model step (crash before final) -> re-run only it ----
+        cache.removeLastModelEntry();
+        CountingModelClient real3 = new CountingModelClient(buildRealClient(key, baseUrl));
+        CountingToolExecutor tool3 = new CountingToolExecutor(echoExecutor());
+        Agent agent3 = Agents.react()
+                .modelClient(new ResumableModelClient(real3, cache))
+                .model(model).maxOutputTokens(512)
+                .toolRegistry(registry).toolExecutor(new ResumableToolExecutor(tool3, cache))
+                .build();
+        agent3.newSession().run(AgentRequest.builder().input(input).build());
+        System.out.println("=== run3 (partial resume) === modelCalls=" + real3.calls + " toolCalls=" + tool3.calls);
+        assertTrue("partial resume must re-run the missing step (>=1 real call)", real3.calls >= 1);
+        assertTrue("partial resume must still be cheaper than a full run", real3.calls < run1ModelCalls + run1ModelCalls);
+    }
+
+    private static AgentToolRegistry echoRegistry() {
+        Tool.Function fn = new Tool.Function();
+        fn.setName("echo_text");
+        fn.setDescription("Echo back the provided text exactly.");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        Tool.Function.Property textProp = new Tool.Function.Property();
+        textProp.setType("string");
+        textProp.setDescription("The text to echo back");
+        props.put("text", textProp);
+        param.setProperties(props);
+        param.setRequired(Collections.singletonList("text"));
+        fn.setParameters(param);
+        return new StaticToolRegistry(Collections.<Object>singletonList(new Tool("function", fn)));
+    }
+
+    private static ToolExecutor echoExecutor() {
+        return new ToolExecutor() {
+            public String execute(AgentToolCall call) { return "echo result"; }
+        };
+    }
+
+    private static AgentModelClient buildRealClient(String key, String baseUrl) {
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey(key);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        configuration.setOkHttpClient(new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS).readTimeout(300, TimeUnit.SECONDS).writeTimeout(60, TimeUnit.SECONDS)
+                .build());
+        IMessagesService service = new AnthropicMessagesService(configuration);
+        return new MessagesModelClient(service);
+    }
+
+    /** Counts real delegate calls (a hit never reaches here). */
+    static final class CountingModelClient implements AgentModelClient {
+        final AgentModelClient delegate;
+        int calls;
+        CountingModelClient(AgentModelClient delegate) { this.delegate = delegate; }
+        public AgentModelResult create(AgentPrompt prompt) throws Exception {
+            calls++;
+            System.out.println("  [real model call #" + calls + "]");
+            return delegate.create(prompt);
+        }
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) throws Exception {
+            calls++;
+            System.out.println("  [real model stream call #" + calls + "]");
+            return delegate.createStream(prompt, listener);
+        }
+    }
+
+    static final class CountingToolExecutor implements ToolExecutor {
+        final ToolExecutor delegate;
+        int calls;
+        CountingToolExecutor(ToolExecutor delegate) { this.delegate = delegate; }
+        public String execute(AgentToolCall call) throws Exception {
+            calls++;
+            return delegate.execute(call);
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/ResumeCacheTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/ResumeCacheTest.java
@@ -1,0 +1,118 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Offline tests for the resume-or-capture decorators (no model/network): full resume returns cached
+ * results with zero delegate calls; partial resume re-runs only the missing step; tool side effects
+ * are skipped on the second identical call.
+ */
+public class ResumeCacheTest {
+
+    @Test
+    public void modelClientShouldCaptureOnFirstRunAndResumeWithZeroCallsOnSecond() throws Exception {
+        RecordingModelClient real1 = new RecordingModelClient();
+        RecordingModelClient real2 = new RecordingModelClient();
+        ResumeCache cache = new ResumeCache();
+        ResumableModelClient run1 = new ResumableModelClient(real1, cache);
+        ResumableModelClient run2 = new ResumableModelClient(real2, cache);
+
+        AgentPrompt promptA = AgentPrompt.builder().model("m").systemPrompt("sa").build();
+        AgentPrompt promptB = AgentPrompt.builder().model("m").systemPrompt("sb").build();
+
+        // run 1: both miss -> real calls + capture
+        run1.create(promptA);
+        run1.create(promptB);
+        assertEquals("run1 made 2 real calls", 2, real1.calls);
+        assertEquals(2, cache.modelSize());
+
+        // run 2: both hit -> NO real calls
+        run2.create(promptA);
+        run2.create(promptB);
+        assertEquals("run2 resumed everything, zero real calls", 0, real2.calls);
+    }
+
+    @Test
+    public void partialResumeShouldReRunOnlyTheMissingStep() throws Exception {
+        RecordingModelClient real1 = new RecordingModelClient();
+        RecordingModelClient real3 = new RecordingModelClient();
+        ResumeCache cache = new ResumeCache();
+        ResumableModelClient run1 = new ResumableModelClient(real1, cache);
+
+        AgentPrompt promptA = AgentPrompt.builder().model("m").systemPrompt("sa").build();
+        AgentPrompt promptB = AgentPrompt.builder().model("m").systemPrompt("sb").build();
+        run1.create(promptA);
+        run1.create(promptB);
+
+        // simulate "crashed before the last step": drop the most-recently-recorded model entry
+        cache.removeLastModelEntry();
+        assertEquals(1, cache.modelSize());
+
+        ResumableModelClient run3 = new ResumableModelClient(real3, cache);
+        run3.create(promptA); // hit
+        run3.create(promptB); // miss -> 1 real call
+        assertEquals("partial resume re-runs only the missing step", 1, real3.calls);
+    }
+
+    @Test
+    public void resumedModelReturnsTheExactCapturedResult() throws Exception {
+        RecordingModelClient real = new RecordingModelClient();
+        ResumeCache cache = new ResumeCache();
+        ResumableModelClient run1 = new ResumableModelClient(real, cache);
+        AgentPrompt prompt = AgentPrompt.builder().model("m").build();
+        AgentModelResult captured = run1.create(prompt);
+
+        RecordingModelClient real2 = new RecordingModelClient();
+        ResumableModelClient run2 = new ResumableModelClient(real2, cache);
+        AgentModelResult resumed = run2.create(prompt);
+        assertSame("resume must return the exact cached result object", captured, resumed);
+    }
+
+    @Test
+    public void toolExecutorShouldSkipSideEffectOnSecondIdenticalCall() throws Exception {
+        RecordingToolExecutor real = new RecordingToolExecutor();
+        ResumeCache cache = new ResumeCache();
+        ResumableToolExecutor rte = new ResumableToolExecutor(real, cache);
+
+        AgentToolCall call = AgentToolCall.builder().name("write_file").arguments("{\"path\":\"/a\",\"c\":1}").build();
+        rte.execute(call); // miss -> real
+        rte.execute(call); // hit -> skipped
+        rte.execute(call); // hit -> skipped
+        assertEquals("side effect performed exactly once for 3 identical calls", 1, real.calls);
+
+        // a different argument is a different node -> real
+        AgentToolCall call2 = AgentToolCall.builder().name("write_file").arguments("{\"path\":\"/b\",\"c\":1}").build();
+        rte.execute(call2);
+        assertEquals(2, real.calls);
+    }
+
+    static final class RecordingModelClient implements AgentModelClient {
+        int calls;
+        public AgentModelResult create(AgentPrompt prompt) {
+            calls++;
+            return AgentModelResult.builder().outputText("out-" + calls).build();
+        }
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            calls++;
+            return AgentModelResult.builder().outputText("out-" + calls).build();
+        }
+    }
+
+    static final class RecordingToolExecutor implements ToolExecutor {
+        int calls;
+        public String execute(AgentToolCall call) {
+            calls++;
+            return "tool-out-" + calls;
+        }
+    }
+}


### PR DESCRIPTION
Task `2026-06-24-agent-failure-recovery-via-resumable-model-tool-bf9ec3b7`. Phase 2 of the observability/recovery/replay roadmap: a crashed/re-run agent can now resume, skipping already-completed work without re-performing side effects.

## What

- **ResumeCache** — content-addressed: `serialized prompt -> AgentModelResult` and `name|arguments -> tool output`, with hit/miss counters and `removeLastModelEntry()` (simulate crash-before-final).
- **ResumableModelClient** — on a seen prompt, returns the captured result with **no LLM call**; on a miss, delegates + records. One instance captures (run 1) and resumes (run 2+).
- **ResumableToolExecutor** — on a seen call, returns the captured output **without re-performing the side effect** (no double file writes / API calls / charges). This is the crux of safe failure recovery.

## Why it works

Content addressing: run 2 short-circuits step N with run 1's result, so the runtime builds step N+1's prompt identically → same cache key → hit. By induction the whole trajectory resumes from cache. Phase 2 needs full `AgentModelResult` (incl. toolCalls), which the event stream doesn't carry — hence capture at the ModelClient chokepoint (complements Phase 1's event-level capture, which is for audit/trace).

## Verification (incl. REAL LLM)

- 4 offline tests (capture/resume/partial/tool-side-effect-skip).
- ai4j-agent full module: **158 tests, 0 failures**.
- **Live test against real GLM**: run1 captures (2 model + 1 tool call); run2 (same input, full cache) = **ZERO real LLM calls + zero tool side effects**; run3 (cache minus the last model step = 'crashed before final') re-runs **only the missing step (1 call, 0 tool calls)**.

## Scope

Phase 2 mechanism (in-process resume). Cross-process persistence of the resume cache (load from disk after a real restart) is a small follow-on; the resume semantics are proven here. No core/CLI changes.