### PR TITLE
feat(agent): durable session stores (File + JDBC) + resume cache persistence (Phase 3)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumeCache.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/ResumeCache.java
@@ -1,9 +1,15 @@
 package io.github.lnyocly.ai4j.agent.replay;
 
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
 import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -75,6 +81,54 @@ public class ResumeCache {
     public long getModelMisses() { return modelMisses.get(); }
     public long getToolHits() { return toolHits.get(); }
     public long getToolMisses() { return toolMisses.get(); }
+
+    /**
+     * Persists the cache to a JSON file so failure recovery can resume across a real process
+     * restart (run 1 captures + saves; after restart, run 2 loads + resumes).
+     */
+    public void saveToJson(Path path) throws IOException {
+        if (path == null) {
+            throw new IllegalArgumentException("path must not be null");
+        }
+        JSONObject obj = new JSONObject();
+        obj.put("modelResults", modelResults);
+        obj.put("toolOutputs", toolOutputs);
+        if (path.getParent() != null) {
+            Files.createDirectories(path.getParent());
+        }
+        Files.write(path, JSON.toJSONString(obj).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Loads a cache previously written by {@link #saveToJson(Path)}; empty cache if the file is absent. */
+    public static ResumeCache loadFromJson(Path path) throws IOException {
+        ResumeCache cache = new ResumeCache();
+        if (path == null || !Files.isRegularFile(path)) {
+            return cache;
+        }
+        JSONObject obj = JSON.parseObject(new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
+        if (obj == null) {
+            return cache;
+        }
+        JSONObject models = obj.getJSONObject("modelResults");
+        if (models != null) {
+            for (String key : models.keySet()) {
+                AgentModelResult r = models.getObject(key, AgentModelResult.class);
+                if (r != null) {
+                    cache.modelResults.put(key, r);
+                }
+            }
+        }
+        JSONObject tools = obj.getJSONObject("toolOutputs");
+        if (tools != null) {
+            for (String key : tools.keySet()) {
+                String out = tools.getString(key);
+                if (out != null) {
+                    cache.toolOutputs.put(key, out);
+                }
+            }
+        }
+        return cache;
+    }
 
     /** Deterministic key for a MODEL node: the serialized prompt. */
     public static String promptKey(AgentPrompt prompt) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/FileAgentSessionStore.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/FileAgentSessionStore.java
@@ -1,0 +1,123 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import com.alibaba.fastjson2.JSON;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * File-based {@link AgentSessionStore}: each {@link AgentSessionSnapshot} is one JSON file under a
+ * base directory. Zero external dependency (filesystem only) — the lightweight, no-database default
+ * for checkpoint/resume. {@link JdbcAgentSessionStore} is the shared-DB alternative.
+ *
+ * <p>The session id is sanitized to a filesystem-safe name (UUIDs and typical ids are unchanged).
+ * This makes {@code save}/{@code load}/{@code delete} round-trip deterministically.</p>
+ */
+public class FileAgentSessionStore implements AgentSessionStore {
+
+    private static final String SUFFIX = ".json";
+
+    private final Path baseDir;
+
+    public FileAgentSessionStore(Path baseDir) {
+        if (baseDir == null) {
+            throw new IllegalArgumentException("baseDir must not be null");
+        }
+        this.baseDir = baseDir;
+        try {
+            Files.createDirectories(this.baseDir);
+        } catch (IOException e) {
+            throw new RuntimeException("failed to create session store directory " + baseDir, e);
+        }
+    }
+
+    public FileAgentSessionStore(String baseDir) {
+        this(Paths.get(baseDir));
+    }
+
+    @Override
+    public void save(AgentSessionSnapshot snapshot) {
+        if (snapshot == null || snapshot.getSessionId() == null) {
+            return;
+        }
+        Path file = pathFor(snapshot.getSessionId());
+        try {
+            Files.write(file, JSON.toJSONString(snapshot).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException("failed to save session snapshot " + snapshot.getSessionId(), e);
+        }
+    }
+
+    @Override
+    public AgentSessionSnapshot load(String sessionId) {
+        if (sessionId == null) {
+            return null;
+        }
+        Path file = pathFor(sessionId);
+        if (!Files.isRegularFile(file)) {
+            return null;
+        }
+        try {
+            String json = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+            if (json.trim().isEmpty()) {
+                return null;
+            }
+            return JSON.parseObject(json, AgentSessionSnapshot.class);
+        } catch (IOException e) {
+            throw new RuntimeException("failed to load session snapshot " + sessionId, e);
+        }
+    }
+
+    @Override
+    public boolean delete(String sessionId) {
+        if (sessionId == null) {
+            return false;
+        }
+        try {
+            return Files.deleteIfExists(pathFor(sessionId));
+        } catch (IOException e) {
+            throw new RuntimeException("failed to delete session snapshot " + sessionId, e);
+        }
+    }
+
+    @Override
+    public List<String> listSessionIds() {
+        List<String> ids = new ArrayList<String>();
+        if (!Files.isDirectory(baseDir)) {
+            return ids;
+        }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(baseDir, "*" + SUFFIX)) {
+            for (Path entry : stream) {
+                String name = entry.getFileName().toString();
+                ids.add(name.substring(0, name.length() - SUFFIX.length()));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("failed to list session ids in " + baseDir, e);
+        }
+        return ids;
+    }
+
+    private Path pathFor(String sessionId) {
+        return baseDir.resolve(safeName(sessionId) + SUFFIX);
+    }
+
+    private static String safeName(String sessionId) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < sessionId.length(); i++) {
+            char c = sessionId.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                    || c == '.' || c == '-' || c == '_') {
+                sb.append(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        return sb.length() == 0 ? "anon" : sb.toString();
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStore.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStore.java
@@ -1,0 +1,204 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import com.alibaba.fastjson2.JSON;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Durable, JDBC-backed {@link AgentSessionStore}. Stores each {@link AgentSessionSnapshot} as one
+ * JSON row keyed by session id, so sessions survive process restarts and long tasks can resume.
+ *
+ * <p>Mirrors the connection handling of {@code JdbcAgentMemory}: a {@link DataSource} or a
+ * {@code jdbcUrl} (optional username/password). Schema initialization is on by default.</p>
+ */
+public class JdbcAgentSessionStore implements AgentSessionStore {
+
+    private final DataSource dataSource;
+    private final String jdbcUrl;
+    private final String username;
+    private final String password;
+    private final String tableName;
+
+    public JdbcAgentSessionStore(JdbcAgentSessionStoreConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("config is required");
+        }
+        this.dataSource = config.getDataSource();
+        this.jdbcUrl = trimToNull(config.getJdbcUrl());
+        this.username = trimToNull(config.getUsername());
+        this.password = config.getPassword();
+        this.tableName = validIdentifier(config.getTableName(), "ai4j_agent_session");
+        if (this.dataSource == null && this.jdbcUrl == null) {
+            throw new IllegalArgumentException("dataSource or jdbcUrl is required");
+        }
+        if (config.isInitializeSchema()) {
+            initializeSchema();
+        }
+    }
+
+    public JdbcAgentSessionStore(String jdbcUrl) {
+        this(JdbcAgentSessionStoreConfig.builder().jdbcUrl(jdbcUrl).build());
+    }
+
+    @Override
+    public void save(AgentSessionSnapshot snapshot) {
+        if (snapshot == null || snapshot.getSessionId() == null) {
+            return;
+        }
+        String sessionId = snapshot.getSessionId();
+        String json = JSON.toJSONString(snapshot);
+        Connection connection = null;
+        try {
+            connection = openConnection();
+            // upsert: delete then insert (portable across H2/MySQL/Postgres/SQLite)
+            try (PreparedStatement delete = connection.prepareStatement(
+                    "delete from " + tableName + " where session_id = ?")) {
+                delete.setString(1, sessionId);
+                delete.executeUpdate();
+            }
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "insert into " + tableName + " (session_id, snapshot_json, updated_at) values (?, ?, ?)")) {
+                insert.setString(1, sessionId);
+                insert.setString(2, json);
+                insert.setLong(3, System.currentTimeMillis());
+                insert.executeUpdate();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("failed to save session snapshot " + sessionId, e);
+        } finally {
+            close(connection);
+        }
+    }
+
+    @Override
+    public AgentSessionSnapshot load(String sessionId) {
+        if (sessionId == null) {
+            return null;
+        }
+        Connection connection = null;
+        try {
+            connection = openConnection();
+            try (PreparedStatement select = connection.prepareStatement(
+                    "select snapshot_json from " + tableName + " where session_id = ?")) {
+                select.setString(1, sessionId);
+                try (ResultSet rs = select.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    String json = rs.getString("snapshot_json");
+                    if (json == null || json.trim().isEmpty()) {
+                        return null;
+                    }
+                    return JSON.parseObject(json, AgentSessionSnapshot.class);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("failed to load session snapshot " + sessionId, e);
+        } finally {
+            close(connection);
+        }
+    }
+
+    @Override
+    public boolean delete(String sessionId) {
+        if (sessionId == null) {
+            return false;
+        }
+        Connection connection = null;
+        try {
+            connection = openConnection();
+            try (PreparedStatement stmt = connection.prepareStatement(
+                    "delete from " + tableName + " where session_id = ?")) {
+                stmt.setString(1, sessionId);
+                return stmt.executeUpdate() > 0;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("failed to delete session snapshot " + sessionId, e);
+        } finally {
+            close(connection);
+        }
+    }
+
+    @Override
+    public List<String> listSessionIds() {
+        List<String> ids = new ArrayList<String>();
+        Connection connection = null;
+        try {
+            connection = openConnection();
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery("select session_id from " + tableName)) {
+                while (rs.next()) {
+                    ids.add(rs.getString("session_id"));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("failed to list session ids", e);
+        } finally {
+            close(connection);
+        }
+        return ids;
+    }
+
+    private void initializeSchema() {
+        Connection connection = null;
+        try {
+            connection = openConnection();
+            try (Statement stmt = connection.createStatement()) {
+                stmt.executeUpdate("create table if not exists " + tableName + " ("
+                        + "session_id varchar(255) not null primary key, "
+                        + "snapshot_json clob, "
+                        + "updated_at bigint)");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("failed to initialize session store schema", e);
+        } finally {
+            close(connection);
+        }
+    }
+
+    private Connection openConnection() throws Exception {
+        if (dataSource != null) {
+            return dataSource.getConnection();
+        }
+        if (username != null) {
+            return DriverManager.getConnection(jdbcUrl, username, password);
+        }
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    private static void close(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception ignored) {
+                // best-effort
+            }
+        }
+    }
+
+    private static String validIdentifier(String value, String fallback) {
+        String text = trimToNull(value);
+        if (text == null) {
+            return fallback;
+        }
+        if (!text.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+            throw new IllegalArgumentException("invalid table identifier: " + text);
+        }
+        return text;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStoreConfig.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStoreConfig.java
@@ -1,0 +1,67 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import io.github.lnyocly.ai4j.agent.memory.JdbcAgentMemoryConfig;
+
+import javax.sql.DataSource;
+
+/**
+ * Configuration for {@link JdbcAgentSessionStore}. Mirrors {@link JdbcAgentMemoryConfig}: supply
+ * either a {@link DataSource} or a {@code jdbcUrl} (plus optional credentials). Schema init is on
+ * by default so the store is usable out of the box against a fresh database.
+ */
+public final class JdbcAgentSessionStoreConfig {
+
+    private DataSource dataSource;
+    private String jdbcUrl;
+    private String username;
+    private String password;
+    private String tableName = "ai4j_agent_session";
+    private boolean initializeSchema = true;
+
+    public static JdbcAgentSessionStoreConfig builder() {
+        return new JdbcAgentSessionStoreConfig();
+    }
+
+    public JdbcAgentSessionStoreConfig dataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig jdbcUrl(String jdbcUrl) {
+        this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig tableName(String tableName) {
+        if (tableName != null && !tableName.trim().isEmpty()) {
+            this.tableName = tableName.trim();
+        }
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig initializeSchema(boolean initializeSchema) {
+        this.initializeSchema = initializeSchema;
+        return this;
+    }
+
+    public JdbcAgentSessionStoreConfig build() {
+        return this;
+    }
+
+    public DataSource getDataSource() { return dataSource; }
+    public String getJdbcUrl() { return jdbcUrl; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public String getTableName() { return tableName; }
+    public boolean isInitializeSchema() { return initializeSchema; }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/ResumeCachePersistenceTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/ResumeCachePersistenceTest.java
@@ -1,0 +1,42 @@
+package io.github.lnyocly.ai4j.agent.replay;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Round-trip tests for {@link ResumeCache#saveToJson} / {@link ResumeCache#loadFromJson}: a cache
+ * saved to disk and loaded into a fresh instance (simulating a restart) must preserve its entries
+ * so failure recovery can resume across process boundaries.
+ */
+public class ResumeCachePersistenceTest {
+
+    @Test
+    public void saveAndLoadRoundTripsModelAndToolEntries() throws Exception {
+        ResumeCache cache = new ResumeCache();
+        cache.recordModel("prompt-key-1", AgentModelResult.builder().outputText("out-1").build());
+        cache.recordTool("echo|{\"text\":\"hi\"}", "echo result");
+
+        Path tmp = Files.createTempFile("resume-cache-", ".json");
+        tmp.toFile().deleteOnExit();
+        cache.saveToJson(tmp);
+
+        // fresh instance loaded from disk = "restart"
+        ResumeCache loaded = ResumeCache.loadFromJson(tmp);
+        AgentModelResult r = loaded.lookupModel("prompt-key-1");
+        assertEquals("out-1", r.getOutputText());
+        assertEquals("echo result", loaded.lookupTool("echo|{\"text\":\"hi\"}"));
+    }
+
+    @Test
+    public void loadAbsentFileReturnsEmptyCache() throws Exception {
+        ResumeCache loaded = ResumeCache.loadFromJson(Paths.get("no-such-resume-cache.json"));
+        assertEquals(0, loaded.modelSize());
+        assertEquals(0, loaded.toolSize());
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/FileAgentSessionStoreTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/FileAgentSessionStoreTest.java
@@ -1,0 +1,60 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Round-trip tests for {@link FileAgentSessionStore}. A new store instance on the same directory
+ * stands in for a process restart — the snapshot must survive it, with no database required.
+ */
+public class FileAgentSessionStoreTest {
+
+    private AgentSessionSnapshot snapshot(String id, long createdAt) {
+        AgentSessionSnapshot snap = new AgentSessionSnapshot();
+        snap.setMetadata(new AgentSessionMetadata(id, createdAt, createdAt + 1,
+                new LinkedHashMap<String, Object>()));
+        return snap;
+    }
+
+    @Test
+    public void saveAndLoadSurvivesNewStoreInstance() throws Exception {
+        Path dir = Files.createTempDirectory("ai4j-file-store-");
+        new FileAgentSessionStore(dir).save(snapshot("sess-1", 100L));
+
+        // new store instance on the same dir = "restart"
+        AgentSessionSnapshot loaded = new FileAgentSessionStore(dir).load("sess-1");
+        assertNotNull(loaded);
+        assertEquals("sess-1", loaded.getSessionId());
+        assertEquals(100L, loaded.getMetadata().getCreatedAtEpochMs());
+    }
+
+    @Test
+    public void loadReturnsNullForUnknownSession() throws Exception {
+        Path dir = Files.createTempDirectory("ai4j-file-store-");
+        assertNull(new FileAgentSessionStore(dir).load("no-such-session"));
+    }
+
+    @Test
+    public void saveIsUpsertAndDeleteAndListWork() throws Exception {
+        Path dir = Files.createTempDirectory("ai4j-file-store-");
+        FileAgentSessionStore store = new FileAgentSessionStore(dir);
+        store.save(snapshot("s1", 1L));
+        store.save(snapshot("s1", 9L)); // upsert (overwrite)
+        store.save(snapshot("s2", 2L));
+
+        assertEquals(2, store.listSessionIds().size());
+        assertEquals("upsert must overwrite, not duplicate", 9L, store.load("s1").getMetadata().getCreatedAtEpochMs());
+
+        assertTrue(store.delete("s1"));
+        assertEquals(1, store.listSessionIds().size());
+        assertNull("deleted session must not load", store.load("s1"));
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStoreTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/JdbcAgentSessionStoreTest.java
@@ -1,0 +1,61 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * H2 round-trip tests for {@link JdbcAgentSessionStore}. A new store instance on the same jdbc URL
+ * stands in for a process restart — the snapshot must survive it.
+ */
+public class JdbcAgentSessionStoreTest {
+
+    private String jdbcUrl(String suffix) {
+        return "jdbc:h2:mem:ai4j_session_store_" + suffix + ";MODE=MYSQL;DB_CLOSE_DELAY=-1";
+    }
+
+    private AgentSessionSnapshot snapshot(String id, long createdAt) {
+        AgentSessionSnapshot snap = new AgentSessionSnapshot();
+        snap.setMetadata(new AgentSessionMetadata(id, createdAt, createdAt + 1,
+                new LinkedHashMap<String, Object>()));
+        return snap;
+    }
+
+    @Test
+    public void saveAndLoadSurvivesNewStoreInstance() {
+        String url = jdbcUrl("persist");
+        new JdbcAgentSessionStore(url).save(snapshot("sess-1", 100L));
+
+        // new store instance = "restart"
+        AgentSessionSnapshot loaded = new JdbcAgentSessionStore(url).load("sess-1");
+        assertNotNull(loaded);
+        assertEquals("sess-1", loaded.getSessionId());
+        assertEquals(100L, loaded.getMetadata().getCreatedAtEpochMs());
+    }
+
+    @Test
+    public void loadReturnsNullForUnknownSession() {
+        assertNull(new JdbcAgentSessionStore(jdbcUrl("miss")).load("no-such-session"));
+    }
+
+    @Test
+    public void saveIsUpsertAndDeleteAndListWork() {
+        String url = jdbcUrl("upsert");
+        JdbcAgentSessionStore store = new JdbcAgentSessionStore(url);
+        store.save(snapshot("s1", 1L));
+        store.save(snapshot("s1", 9L)); // upsert: same id, new content
+        store.save(snapshot("s2", 2L));
+
+        assertEquals(2, store.listSessionIds().size());
+        assertEquals("upsert must replace, not duplicate", 9L, store.load("s1").getMetadata().getCreatedAtEpochMs());
+
+        assertTrue(store.delete("s1"));
+        assertEquals(1, store.listSessionIds().size());
+        assertNull("deleted session must not load", store.load("s1"));
+    }
+}


### PR DESCRIPTION
Task `2026-06-24-agent-durable-session-store-jdbc-resume-cache-pe-2cc9cf5d`. Phase 3 of the observability/recovery/replay roadmap: checkpoint/resume that survives process restarts.

## What

Two durable `AgentSessionStore` impls (SPI stays backend-neutral) + resume-cache persistence:

- **FileAgentSessionStore** — one JSON file per snapshot under a base dir. Zero external dependency (filesystem only) → the lightweight no-DB default. Fills the real gap: agent-runtime core previously had only InMemory (the CLI had file stores, but core did not).
- **JdbcAgentSessionStore** + Config — one JSON row per snapshot keyed by session id. Uses only JDK `javax.sql`/`java.sql` (users bring their own driver; H2 is test-scope) → for shared/multi-instance production DBs.
- **ResumeCache.saveToJson / loadFromJson** — persist the resume cache so Phase 2 failure recovery works across a real process restart (run 1 captures + saves; after restart, run 2 loads + resumes).

## Why File + JDBC both

Answered an explicit design question: JDBC is not required. File is the lighter default most users want; JDBC is for prod/shared DB. The SPI is neutral, so both are offered. Neither forces a dependency on SDK consumers.

## Verification

- 8 tests: File round-trip; JDBC round-trip across a NEW store instance (= restart); ResumeCache save/load round-trip + absent-file.
- ai4j-agent full module: **166 tests, 0 failures**. `git diff --check` clean.

## Scope

Phase 3 durability. No core/CLI changes beyond the new store impls.