### PR TITLE
feat(agent): tamper-evident hash-chained session event log (Phase 4)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/ChainVerification.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/ChainVerification.java
@@ -1,0 +1,30 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+/**
+ * Result of {@link HashChainedEventLog#verifyChain()}.
+ *
+ * <p>{@code valid} is true iff every link's stored hash matches a recomputation from the genesis
+ * hash. {@code firstBrokenIndex} is the 0-based position of the first tampered/reordered link, or
+ * -1 when the chain is intact.</p>
+ */
+public final class ChainVerification {
+
+    public static final ChainVerification INTACT = new ChainVerification(true, -1);
+
+    private final boolean valid;
+    private final int firstBrokenIndex;
+
+    ChainVerification(boolean valid, int firstBrokenIndex) {
+        this.valid = valid;
+        this.firstBrokenIndex = firstBrokenIndex;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    /** First broken link index (0-based), or -1 if the chain is intact. */
+    public int getFirstBrokenIndex() {
+        return firstBrokenIndex;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/HashChainedEventLog.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/session/HashChainedEventLog.java
@@ -1,0 +1,155 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.event.AgentEvent;
+import io.github.lnyocly.ai4j.agent.event.AgentListener;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tamper-evident, hash-chained {@link AgentSessionEventLog}. Each appended event is sealed into a
+ * link: {@code hash = sha256(prevHash || "|" || canonical(event))}, where {@code prevHash} is the
+ * previous link's hash (genesis for the first). {@link #verifyChain()} recomputes the chain from
+ * genesis and reports the first link whose stored hash no longer matches — so any after-the-fact
+ * edit, deletion, or reordering of a logged event is detectable.
+ *
+ * <p>Drop-in replacement for {@link InMemoryAgentSessionEventLog}: implements the same
+ * {@link AgentSessionEventLog} + {@link AgentListener} surface, so it can be registered wherever the
+ * in-memory log is used, and the chain makes the recorded tool/model/sandbox events auditable.</p>
+ */
+public class HashChainedEventLog implements AgentSessionEventLog, AgentListener {
+
+    private static final String GENESIS_HASH = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    static final class Link {
+        final AgentSessionEvent event;
+        final String prevHash;
+        final String hash;
+
+        Link(AgentSessionEvent event, String prevHash, String hash) {
+            this.event = event;
+            this.prevHash = prevHash;
+            this.hash = hash;
+        }
+    }
+
+    private final List<Link> links = new ArrayList<Link>();
+    private final AtomicLong sequence = new AtomicLong();
+
+    @Override
+    public synchronized void append(AgentEvent event) {
+        if (event == null) {
+            return;
+        }
+        long seq = sequence.incrementAndGet();
+        AgentSessionEvent wrapped = new AgentSessionEvent(seq, System.currentTimeMillis(), event);
+        String prevHash = links.isEmpty() ? GENESIS_HASH : links.get(links.size() - 1).hash;
+        String hash = computeHash(prevHash, event);
+        links.add(new Link(wrapped, prevHash, hash));
+    }
+
+    @Override
+    public void onEvent(AgentEvent event) {
+        append(event);
+    }
+
+    @Override
+    public synchronized List<AgentSessionEvent> getEvents() {
+        List<AgentSessionEvent> copy = new ArrayList<AgentSessionEvent>(links.size());
+        for (Link link : links) {
+            if (link != null && link.event != null) {
+                copy.add(link.event.copy());
+            }
+        }
+        return copy;
+    }
+
+    /** Returns the stored hash of each link, in order (the chain itself). */
+    public synchronized List<String> getChainHashes() {
+        List<String> hashes = new ArrayList<String>(links.size());
+        for (Link link : links) {
+            hashes.add(link.hash);
+        }
+        return hashes;
+    }
+
+    /**
+     * Recomputes the chain from genesis and compares to the stored hashes.
+     */
+    public synchronized ChainVerification verifyChain() {
+        String prevHash = GENESIS_HASH;
+        for (int i = 0; i < links.size(); i++) {
+            Link link = links.get(i);
+            String expected = computeHash(prevHash, link.event.getEvent());
+            if (!expected.equals(link.hash) || !prevHash.equals(link.prevHash)) {
+                return new ChainVerification(false, i);
+            }
+            prevHash = link.hash;
+        }
+        return ChainVerification.INTACT;
+    }
+
+    /**
+     * Replaces the event payload at {@code index} WITHOUT resealing the link, simulating an
+     * after-the-fact edit. The next {@link #verifyChain()} must report this index as broken.
+     */
+    synchronized void tamperEvent(int index, AgentEvent replacement) {
+        if (index < 0 || index >= links.size()) {
+            throw new IndexOutOfBoundsException("link index " + index);
+        }
+        Link existing = links.get(index);
+        AgentSessionEvent tampered = new AgentSessionEvent(
+                existing.event.getSequence(), existing.event.getRecordedAtEpochMs(), replacement);
+        links.set(index, new Link(tampered, existing.prevHash, existing.hash));
+    }
+
+    @Override
+    public synchronized void restore(List<AgentSessionEvent> restoredEvents) {
+        links.clear();
+        sequence.set(0);
+        if (restoredEvents == null) {
+            return;
+        }
+        for (AgentSessionEvent event : restoredEvents) {
+            if (event == null) {
+                continue;
+            }
+            AgentSessionEvent copy = event.copy();
+            String prevHash = links.isEmpty() ? GENESIS_HASH : links.get(links.size() - 1).hash;
+            String hash = computeHash(prevHash, copy.getEvent());
+            links.add(new Link(copy, prevHash, hash));
+            if (copy.getSequence() > sequence.get()) {
+                sequence.set(copy.getSequence());
+            }
+        }
+    }
+
+    @Override
+    public synchronized void clear() {
+        links.clear();
+        sequence.set(0);
+    }
+
+    /** hash = sha256(prevHash || "|" || canonical(event)) as lowercase hex. */
+    static String computeHash(String prevHash, AgentEvent event) {
+        String canonical = JSON.toJSONString(event);
+        String input = prevHash + "|" + canonical;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/HashChainedEventLogTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/session/HashChainedEventLogTest.java
@@ -1,0 +1,93 @@
+package io.github.lnyocly.ai4j.agent.session;
+
+import io.github.lnyocly.ai4j.agent.event.AgentEvent;
+import io.github.lnyocly.ai4j.agent.event.AgentEventType;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link HashChainedEventLog}: a fresh chain verifies intact; tampering an event (or its
+ * order) is detected at the first broken link; restore reseals deterministically.
+ */
+public class HashChainedEventLogTest {
+
+    private static AgentEvent ev(String id) {
+        return AgentEvent.builder()
+                .eventId(id)
+                .runId("run-1")
+                .sessionId("sess-1")
+                .turnId("turn-1")
+                .type(AgentEventType.TOOL_CALL)
+                .step(1)
+                .message("m-" + id)
+                .build();
+    }
+
+    @Test
+    public void freshChainVerifiesIntact() {
+        HashChainedEventLog log = new HashChainedEventLog();
+        log.append(ev("1"));
+        log.append(ev("2"));
+        log.append(ev("3"));
+
+        ChainVerification v = log.verifyChain();
+        assertTrue("untampered chain must verify", v.isValid());
+        assertEquals(-1, v.getFirstBrokenIndex());
+        assertEquals(3, log.getChainHashes().size());
+        // link hashes are distinct and non-trivial
+        assertNotEquals(log.getChainHashes().get(0), log.getChainHashes().get(1));
+        assertEquals(64, log.getChainHashes().get(0).length());
+    }
+
+    @Test
+    public void tamperingAnEventIsDetectedAtThatIndex() {
+        HashChainedEventLog log = new HashChainedEventLog();
+        log.append(ev("1"));
+        log.append(ev("2"));
+        log.append(ev("3"));
+        // simulate an after-the-fact edit of link 1 without resealing
+        log.tamperEvent(1, ev("TAMPERED"));
+
+        ChainVerification v = log.verifyChain();
+        assertFalse("tampered chain must not verify", v.isValid());
+        assertEquals("first broken link must be the tampered one", 1, v.getFirstBrokenIndex());
+    }
+
+    @Test
+    public void restoreRebuildsChainAndVerifiesIntact() {
+        HashChainedEventLog log1 = new HashChainedEventLog();
+        log1.append(ev("1"));
+        log1.append(ev("2"));
+        List<AgentSessionEvent> events = log1.getEvents();
+
+        HashChainedEventLog log2 = new HashChainedEventLog();
+        log2.restore(events);
+        assertTrue("restored chain reseals deterministically", log2.verifyChain().isValid());
+        // determinism: same events -> same chain hashes
+        assertEquals(log1.getChainHashes(), log2.getChainHashes());
+    }
+
+    @Test
+    public void appendingAsAgentListenerWorks() {
+        HashChainedEventLog log = new HashChainedEventLog();
+        log.onEvent(ev("1")); // via AgentListener surface
+        log.onEvent(ev("2"));
+        assertTrue(log.verifyChain().isValid());
+        assertEquals(2, log.getEvents().size());
+    }
+
+    @Test
+    public void clearResetsTheChain() {
+        HashChainedEventLog log = new HashChainedEventLog();
+        log.append(ev("1"));
+        log.clear();
+        assertEquals(0, log.getEvents().size());
+        assertTrue(log.verifyChain().isValid());
+    }
+}


### PR DESCRIPTION
Task `2026-06-24-tamper-evident-hash-chained-session-event-log-98f15dcd`. Phase 4 (final) of the observability/recovery/replay roadmap: audit tamper-evidence.

## What

- **HashChainedEventLog** — drop-in `AgentSessionEventLog` (+ `AgentListener`) that seals each event into a SHA-256 chain: `hash = sha256(prevHash || "|" || canonical(event))`. Same surface as `InMemoryAgentSessionEventLog`, registerable wherever it is.
- **ChainVerification** `{valid, firstBrokenIndex}` — `verifyChain()` recomputes from genesis and reports the first link whose stored hash no longer matches, so any after-the-fact edit, deletion, or reordering of a logged event is detectable.

## Why

Everything the agent logs (tool calls, model steps, sandbox decisions) becomes a defensible, tamper-evident audit trail — the `审计与回溯` capability. Pure crypto, no external dependency, no runtime change.

## Verification

5 tests: intact chain; tamper detected at the edited index; deterministic restore (same events → same chain); AgentListener surface; clear. ai4j-agent full module **171 tests, 0 failures**. `git diff --check` clean.

## Scope note

Explicit human-approval-decision events are not yet emitted by the permission flow (it raises `AgentApprovalRequiredException`), so adding them is a separate runtime change. Everything currently logged is now tamper-evident.