### PR TITLE
feat(agent): tool interceptor hooks (pi-aligned block/modify + routeTo)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -30,6 +30,7 @@ import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
@@ -63,6 +64,7 @@ public class AgentBuilder {
     private HandoffPolicy handoffPolicy;
     private final List<SubAgentDefinition> subAgentDefinitions = new ArrayList<>();
     private ToolExecutor toolExecutor;
+    private ToolInterceptor toolInterceptor;
     private CodeExecutor codeExecutor;
     private Supplier<AgentMemory> memorySupplier;
     private AgentOptions options;
@@ -246,6 +248,11 @@ public class AgentBuilder {
         return this;
     }
 
+    public AgentBuilder toolInterceptor(ToolInterceptor toolInterceptor) {
+        this.toolInterceptor = toolInterceptor;
+        return this;
+    }
+
     public AgentBuilder codeExecutor(CodeExecutor codeExecutor) {
         this.codeExecutor = codeExecutor;
         return this;
@@ -417,6 +424,7 @@ public class AgentBuilder {
                 .modelClient(modelClient)
                 .toolRegistry(resolvedToolRegistry)
                 .toolExecutor(resolvedToolExecutor)
+                .toolInterceptor(toolInterceptor)
                 .codeExecutor(resolvedCodeExecutor)
                 .memory(memory)
                 .options(resolvedOptions)

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -12,6 +12,7 @@ import io.github.lnyocly.ai4j.agent.permission.AgentExecutionEnvironment;
 import io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicy;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -26,6 +27,8 @@ public class AgentContext {
     private AgentToolRegistry toolRegistry;
 
     private ToolExecutor toolExecutor;
+
+    private ToolInterceptor toolInterceptor;
 
     private CodeExecutor codeExecutor;
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolCallDecision.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolCallDecision.java
@@ -1,0 +1,64 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+/**
+ * The verdict a {@link ToolInterceptor} returns for one tool call. Immutable; construct via the
+ * static factories.
+ */
+public final class ToolCallDecision {
+
+    public enum Type { ALLOW, BLOCK, MODIFY, ROUTE_TO }
+
+    private final Type type;
+    private final String reason;
+    private final AgentToolCall modifiedCall;
+    private final SandboxSpec sandboxSpec;
+
+    private ToolCallDecision(Type type, String reason, AgentToolCall modifiedCall, SandboxSpec sandboxSpec) {
+        this.type = type;
+        this.reason = reason;
+        this.modifiedCall = modifiedCall;
+        this.sandboxSpec = sandboxSpec;
+    }
+
+    /** Proceed with the original call. */
+    public static ToolCallDecision allow() {
+        return new ToolCallDecision(Type.ALLOW, null, null, null);
+    }
+
+    /**
+     * Veto the call. {@code reason} is fed back to the model as the tool result so it can adjust,
+     * like Claude Code's PreToolUse exit-code-2 deny.
+     */
+    public static ToolCallDecision block(String reason) {
+        return new ToolCallDecision(Type.BLOCK, reason, null, null);
+    }
+
+    /** Replace the call with {@code modifiedCall} (rewritten name/arguments) and execute that. */
+    public static ToolCallDecision modify(AgentToolCall modifiedCall) {
+        if (modifiedCall == null) {
+            throw new IllegalArgumentException("modifiedCall must not be null");
+        }
+        return new ToolCallDecision(Type.MODIFY, null, modifiedCall, null);
+    }
+
+    /**
+     * Redirect execution to a sandbox described by {@code spec}. This is the beyond-pi capability
+     * (pi/Claude Code lack a first-class sandbox SPI). v1: the decision is honored as a signal;
+     * actual sandbox execution requires a bound sandbox session on the runtime and is wired in a
+     * follow-on — until then a ROUTE_TO with no bound sandbox surfaces as a blocked result.
+     */
+    public static ToolCallDecision routeTo(SandboxSpec spec) {
+        if (spec == null) {
+            throw new IllegalArgumentException("sandboxSpec must not be null");
+        }
+        return new ToolCallDecision(Type.ROUTE_TO, null, null, spec);
+    }
+
+    public Type getType() { return type; }
+    public String getReason() { return reason; }
+    public AgentToolCall getModifiedCall() { return modifiedCall; }
+    public SandboxSpec getSandboxSpec() { return sandboxSpec; }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptor.java
@@ -1,0 +1,32 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+/**
+ * Control-flow hook that runs before a tool executes and decides what happens — the
+ * Claude-Code / pi "PreToolUse" interception capability, in-process.
+ *
+ * <p>Unlike the observe-only {@code AgentLifecycleHook} (which is fire-and-forget notification),
+ * an interceptor returns a {@link ToolCallDecision} the runtime honors:</p>
+ * <ul>
+ *   <li>{@link ToolCallDecision#allow()} — proceed.</li>
+ *   <li>{@link ToolCallDecision#block(String)} — veto; the reason is fed back to the model as the
+ *       tool result (so the model can adjust), like Claude Code's PreToolUse exit-code-2.</li>
+ *   <li>{@link ToolCallDecision#modify(AgentToolCall)} — rewrite the call (name/arguments) then execute.</li>
+ *   <li>{@link ToolCallDecision#routeTo} — redirect execution to a sandbox (the beyond-pi capability;
+ *       see {@link ToolCallDecision#routeTo} for v1 status).</li>
+ * </ul>
+ *
+ * <p>This is the layer library users need to build policy/safety/prompt-shaping into their own
+ * agent systems. Register via {@code AgentBuilder.toolInterceptor(...)}.</p>
+ */
+public interface ToolInterceptor {
+
+    /**
+     * Called before {@code call} is executed. Return a decision; never return null (return
+     * {@link ToolCallDecision#allow()} instead). Throwing aborts the tool call with that error
+     * (same as an executor failure).
+     */
+    ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context);
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -21,6 +21,8 @@ import io.github.lnyocly.ai4j.agent.subagent.HandoffPolicyException;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCallSanitizer;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
 
@@ -388,8 +390,32 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
         if (executor == null) {
             throw new IllegalStateException("toolExecutor is required");
         }
+        AgentToolCall effectiveCall = call;
+        ToolInterceptor interceptor = context == null ? null : context.getToolInterceptor();
+        if (interceptor != null) {
+            ToolCallDecision decision = interceptor.beforeToolCall(call, context);
+            if (decision == null) {
+                decision = ToolCallDecision.allow();
+            }
+            switch (decision.getType()) {
+                case BLOCK:
+                    return buildBlockedOutput(call, decision.getReason());
+                case MODIFY:
+                    effectiveCall = decision.getModifiedCall();
+                    break;
+                case ROUTE_TO:
+                    // ponytail: sandbox routing needs a bound sandbox session on the runtime;
+                    // until that wiring lands, surface as a blocked result so the model learns the
+                    // command was not run locally. routeTo(...) carries the SandboxSpec for that follow-on.
+                    return buildBlockedOutput(call, "route-to-sandbox requested but no sandbox session is bound");
+                case ALLOW:
+                default:
+                    break;
+            }
+        }
+        final AgentToolCall callToRun = effectiveCall;
         try {
-            dispatchLifecycle(context, AgentLifecycleEventType.BEFORE_TOOL_CALL, step == null ? 0 : step, call == null ? null : call.getName(), call);
+            dispatchLifecycle(context, AgentLifecycleEventType.BEFORE_TOOL_CALL, step == null ? 0 : step, callToRun == null ? null : callToRun.getName(), callToRun);
             return AgentToolExecutionScope.runWithEmitter(new AgentToolExecutionScope.EventEmitter() {
                 @Override
                 public void emit(AgentEventType type, String message, Object payload) {
@@ -398,7 +424,7 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
             }, new AgentToolExecutionScope.ScopeCallable<String>() {
                 @Override
                 public String call() throws Exception {
-                    return executor.execute(call);
+                    return executor.execute(callToRun);
                 }
             });
         } catch (InterruptedException interruptedException) {
@@ -407,10 +433,23 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
         } catch (HandoffPolicyException handoffPolicyException) {
             throw handoffPolicyException;
         } catch (Exception ex) {
-            return buildToolErrorOutput(call, ex);
+            return buildToolErrorOutput(callToRun, ex);
         } finally {
-            dispatchLifecycle(context, AgentLifecycleEventType.AFTER_TOOL_CALL, step == null ? 0 : step, call == null ? null : call.getName(), call);
+            dispatchLifecycle(context, AgentLifecycleEventType.AFTER_TOOL_CALL, step == null ? 0 : step, callToRun == null ? null : callToRun.getName(), callToRun);
         }
+    }
+
+    protected String buildBlockedOutput(AgentToolCall call, String reason) {
+        JSONObject payload = new JSONObject();
+        payload.put("blocked", true);
+        payload.put("reason", reason == null ? "blocked by tool interceptor" : reason);
+        if (call != null) {
+            payload.put("tool", call.getName());
+            if (call.getCallId() != null) {
+                payload.put("callId", call.getCallId());
+            }
+        }
+        return "TOOL_BLOCKED: " + JSON.toJSONString(payload);
     }
 
     protected String buildToolErrorOutput(AgentToolCall call, Exception error) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
@@ -1,0 +1,160 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic agent-loop tests for the tool interceptor (no real LLM — interception is runtime
+ * logic). A scripted model client emits one tool call then a final answer; the interceptor decides
+ * block / modify / allow and we assert the runtime honors it.
+ */
+public class ToolInterceptorTest {
+
+    private static AgentToolCall call(String args) {
+        return AgentToolCall.builder().name("do_thing").callId("c1").arguments(args).build();
+    }
+
+    private static AgentToolRegistry registry() {
+        Tool.Function fn = new Tool.Function();
+        fn.setName("do_thing");
+        fn.setDescription("does a thing");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        param.setProperties(props);
+        param.setRequired(Collections.<String>emptyList());
+        fn.setParameters(param);
+        return new StaticToolRegistry(Collections.<Object>singletonList(new Tool("function", fn)));
+    }
+
+    /** model emits toolCall on first call, final text on the second. */
+    private static final class ScriptedModelClient implements AgentModelClient {
+        final List<AgentModelResult> scripted;
+        final List<AgentPrompt> prompts = new ArrayList<AgentPrompt>();
+        int idx = 0;
+        ScriptedModelClient(List<AgentModelResult> scripted) { this.scripted = scripted; }
+        public AgentModelResult create(AgentPrompt prompt) {
+            prompts.add(prompt);
+            return scripted.get(Math.min(idx++, scripted.size() - 1));
+        }
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener l) { return create(prompt); }
+    }
+
+    /** records every call it actually executed */
+    private static final class RecordingExecutor implements ToolExecutor {
+        final List<AgentToolCall> executed = new ArrayList<AgentToolCall>();
+        public String execute(AgentToolCall c) {
+            executed.add(c);
+            return "real-output";
+        }
+    }
+
+    @Test
+    public void blockVetoesTheCallAndFeedsReasonBackToModel() throws Exception {
+        AgentToolCall requested = call("{\"x\":1}");
+        ScriptedModelClient model = new ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("ok").build()));
+        RecordingExecutor exec = new RecordingExecutor();
+
+        Agent agent = Agents.react()
+                .modelClient(model)
+                .model("test-model")
+                .toolExecutor(exec)
+                .toolRegistry(registry())
+                .toolInterceptor((c, ctx) -> ToolCallDecision.block("forbidden by policy"))
+                .build();
+        AgentResult result = agent.newSession().run("do the thing");
+
+        assertEquals("blocked call must NOT reach the executor", 0, exec.executed.size());
+        assertTrue("model must be invoked again after the block", model.prompts.size() >= 2);
+        String fedBack = JSON.toJSONString(model.prompts.get(1));
+        assertTrue("block reason must be fed back to the model: " + fedBack,
+                fedBack.contains("TOOL_BLOCKED") && fedBack.contains("forbidden by policy"));
+        assertTrue(result.getOutputText().contains("ok"));
+    }
+
+    @Test
+    public void modifyRewritesTheCallBeforeExecution() throws Exception {
+        AgentToolCall requested = call("{\"x\":1}");
+        AgentToolCall rewritten = AgentToolCall.builder().name("do_thing").callId("c1").arguments("{\"x\":2}").build();
+        ScriptedModelClient model = new ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        RecordingExecutor exec = new RecordingExecutor();
+
+        Agent agent = Agents.react()
+                .modelClient(model)
+                .model("test-model")
+                .toolExecutor(exec)
+                .toolRegistry(registry())
+                .toolInterceptor((c, ctx) -> ToolCallDecision.modify(rewritten))
+                .build();
+        agent.newSession().run("do the thing");
+
+        assertEquals("modified call must execute exactly once", 1, exec.executed.size());
+        assertEquals("executor must receive the MODIFIED call, not the original",
+                "{\"x\":2}", exec.executed.get(0).getArguments());
+    }
+
+    @Test
+    public void allowRunsTheOriginalCall() throws Exception {
+        AgentToolCall requested = call("{\"x\":1}");
+        ScriptedModelClient model = new ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        RecordingExecutor exec = new RecordingExecutor();
+
+        Agent agent = Agents.react()
+                .modelClient(model)
+                .model("test-model")
+                .toolExecutor(exec)
+                .toolRegistry(registry())
+                .toolInterceptor((c, ctx) -> ToolCallDecision.allow())
+                .build();
+        agent.newSession().run("do the thing");
+
+        assertEquals(1, exec.executed.size());
+        assertEquals("{\"x\":1}", exec.executed.get(0).getArguments());
+    }
+
+    @Test
+    public void noInterceptorBehavesLikeAllow() throws Exception {
+        AgentToolCall requested = call("{\"x\":1}");
+        ScriptedModelClient model = new ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        RecordingExecutor exec = new RecordingExecutor();
+
+        Agent agent = Agents.react()
+                .modelClient(model)
+                .model("test-model")
+                .toolExecutor(exec)
+                .toolRegistry(registry())
+                .build();
+        agent.newSession().run("do the thing");
+
+        assertEquals("no interceptor => original call runs", 1, exec.executed.size());
+    }
+}


### PR DESCRIPTION
Task `2026-06-30-tool-interceptor-hooks-pi-aligned-observe-block-d042a8cd`. The keystone for aligning ai4j with pi / Claude Code: a control-flow hook layer (the SDK previously had observe-only lifecycle hooks).

## What

- **`ToolInterceptor.beforeToolCall(call, ctx) -> ToolCallDecision`** — the interception contract, alongside (not replacing) the observe-only `AgentLifecycleHook`.
- **`ToolCallDecision`**: `allow()` | `block(reason)` | `modify(newCall)` | `routeTo(sandboxSpec)`.
  - **block** — veto; reason fed back to the model as the tool result (Claude Code PreToolUse exit-2 semantics), so the model can adjust.
  - **modify** — rewrite the call (name/args), execute the rewritten one.
  - **routeTo** — redirect to a sandbox. This is the **beyond-pi** capability: pi and Claude Code lack a first-class sandbox SPI; ai4j has Daytona + E2B. v1 carries the `SandboxSpec`; wiring actual sandbox-session execution is a small follow-on (a ROUTE_TO with no bound sandbox currently surfaces as a blocked result).
- Wired into `BaseAgentRuntime.executeTool` — no interceptor registered means unchanged behavior.
- `AgentBuilder.toolInterceptor(...)` — also fixes the ergonomics gap (control-flow hooks no longer need the extension SPI).

## Why

Library users building their own agent systems need policy/safety/prompt-shaping hooks that can actually veto or rewrite — not just observe. This is the validated industry pattern (researched: pi ~18-25 hook points observe/block/modify/redirect; Claude Code 12 events with exit-2 block + JSON modify). It is NOT speculative — concrete goal, two major agents converge on it.

## Verification

4 deterministic agent-loop tests (scripted model emits a tool call; interceptor block/modify/allow; assert the runtime honors each — block feeds reason back, modify executes rewritten args, allow runs original, no-interceptor == allow). ai4j-agent full module **175 tests, 0 failures**. `git diff --check` clean. No real LLM needed — interception is deterministic runtime logic.

## Scope / next

This is library layer #1 (the keystone). Follow-ons (separate PRs): (2) wire `routeTo` to a bound sandbox session (true beyond-pi demo), (3) CLI shell-hook bridge so end users configure external hook commands Claude-Code-style, (4) a docs-site page.