### PR TITLE
feat(agent): wire tool interceptor routeTo to sandbox execution

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -31,6 +31,7 @@ import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
@@ -65,6 +66,7 @@ public class AgentBuilder {
     private final List<SubAgentDefinition> subAgentDefinitions = new ArrayList<>();
     private ToolExecutor toolExecutor;
     private ToolInterceptor toolInterceptor;
+    private SandboxProvider sandboxProvider;
     private CodeExecutor codeExecutor;
     private Supplier<AgentMemory> memorySupplier;
     private AgentOptions options;
@@ -253,6 +255,11 @@ public class AgentBuilder {
         return this;
     }
 
+    public AgentBuilder sandboxProvider(SandboxProvider sandboxProvider) {
+        this.sandboxProvider = sandboxProvider;
+        return this;
+    }
+
     public AgentBuilder codeExecutor(CodeExecutor codeExecutor) {
         this.codeExecutor = codeExecutor;
         return this;
@@ -425,6 +432,7 @@ public class AgentBuilder {
                 .toolRegistry(resolvedToolRegistry)
                 .toolExecutor(resolvedToolExecutor)
                 .toolInterceptor(toolInterceptor)
+                .sandboxProvider(sandboxProvider)
                 .codeExecutor(resolvedCodeExecutor)
                 .memory(memory)
                 .options(resolvedOptions)

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -13,6 +13,7 @@ import io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicy;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import lombok.Builder;
 import lombok.Data;
 
@@ -29,6 +30,8 @@ public class AgentContext {
     private ToolExecutor toolExecutor;
 
     private ToolInterceptor toolInterceptor;
+
+    private SandboxProvider sandboxProvider;
 
     private CodeExecutor codeExecutor;
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolCallDecision.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolCallDecision.java
@@ -1,5 +1,6 @@
 package io.github.lnyocly.ai4j.agent.interceptor;
 
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 
@@ -15,17 +16,20 @@ public final class ToolCallDecision {
     private final String reason;
     private final AgentToolCall modifiedCall;
     private final SandboxSpec sandboxSpec;
+    private final SandboxCommand sandboxCommand;
 
-    private ToolCallDecision(Type type, String reason, AgentToolCall modifiedCall, SandboxSpec sandboxSpec) {
+    private ToolCallDecision(Type type, String reason, AgentToolCall modifiedCall,
+                             SandboxSpec sandboxSpec, SandboxCommand sandboxCommand) {
         this.type = type;
         this.reason = reason;
         this.modifiedCall = modifiedCall;
         this.sandboxSpec = sandboxSpec;
+        this.sandboxCommand = sandboxCommand;
     }
 
     /** Proceed with the original call. */
     public static ToolCallDecision allow() {
-        return new ToolCallDecision(Type.ALLOW, null, null, null);
+        return new ToolCallDecision(Type.ALLOW, null, null, null, null);
     }
 
     /**
@@ -33,7 +37,7 @@ public final class ToolCallDecision {
      * like Claude Code's PreToolUse exit-code-2 deny.
      */
     public static ToolCallDecision block(String reason) {
-        return new ToolCallDecision(Type.BLOCK, reason, null, null);
+        return new ToolCallDecision(Type.BLOCK, reason, null, null, null);
     }
 
     /** Replace the call with {@code modifiedCall} (rewritten name/arguments) and execute that. */
@@ -41,24 +45,29 @@ public final class ToolCallDecision {
         if (modifiedCall == null) {
             throw new IllegalArgumentException("modifiedCall must not be null");
         }
-        return new ToolCallDecision(Type.MODIFY, null, modifiedCall, null);
+        return new ToolCallDecision(Type.MODIFY, null, modifiedCall, null, null);
     }
 
     /**
-     * Redirect execution to a sandbox described by {@code spec}. This is the beyond-pi capability
-     * (pi/Claude Code lack a first-class sandbox SPI). v1: the decision is honored as a signal;
-     * actual sandbox execution requires a bound sandbox session on the runtime and is wired in a
-     * follow-on — until then a ROUTE_TO with no bound sandbox surfaces as a blocked result.
+     * Redirect execution to a sandbox: the runtime creates a session from {@code spec} (via the
+     * configured {@code SandboxProvider}) and runs {@code command} there, feeding the output back
+     * as the tool result. This is the beyond-pi capability — pi and Claude Code lack a first-class
+     * sandbox SPI; ai4j has Daytona/E2B. The interceptor owns the tool&rarr;command mapping (it knows
+     * its tools); the runtime owns session creation/execution.
      */
-    public static ToolCallDecision routeTo(SandboxSpec spec) {
+    public static ToolCallDecision routeTo(SandboxSpec spec, SandboxCommand command) {
         if (spec == null) {
             throw new IllegalArgumentException("sandboxSpec must not be null");
         }
-        return new ToolCallDecision(Type.ROUTE_TO, null, null, spec);
+        if (command == null) {
+            throw new IllegalArgumentException("sandboxCommand must not be null");
+        }
+        return new ToolCallDecision(Type.ROUTE_TO, null, null, spec, command);
     }
 
     public Type getType() { return type; }
     public String getReason() { return reason; }
     public AgentToolCall getModifiedCall() { return modifiedCall; }
     public SandboxSpec getSandboxSpec() { return sandboxSpec; }
+    public SandboxCommand getSandboxCommand() { return sandboxCommand; }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -23,6 +23,9 @@ import io.github.lnyocly.ai4j.agent.tool.AgentToolCallSanitizer;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
 
@@ -404,10 +407,7 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
                     effectiveCall = decision.getModifiedCall();
                     break;
                 case ROUTE_TO:
-                    // ponytail: sandbox routing needs a bound sandbox session on the runtime;
-                    // until that wiring lands, surface as a blocked result so the model learns the
-                    // command was not run locally. routeTo(...) carries the SandboxSpec for that follow-on.
-                    return buildBlockedOutput(call, "route-to-sandbox requested but no sandbox session is bound");
+                    return routeToSandbox(context, call, decision);
                 case ALLOW:
                 default:
                     break;
@@ -450,6 +450,53 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
             }
         }
         return "TOOL_BLOCKED: " + JSON.toJSONString(payload);
+    }
+
+    /**
+     * Honors a {@link ToolCallDecision.Type#ROUTE_TO}: create a sandbox session from the decision's
+     * spec (via the configured {@link SandboxProvider}), run the decision's command there, and feed
+     * the output back as the tool result. The beyond-pi capability — pi/Claude Code lack a sandbox
+     * SPI; ai4j routes to Daytona/E2B.
+     */
+    protected String routeToSandbox(AgentContext context, AgentToolCall call, ToolCallDecision decision) {
+        SandboxProvider provider = context == null ? null : context.getSandboxProvider();
+        if (provider == null) {
+            return buildBlockedOutput(call, "route-to-sandbox requested but no sandbox provider is configured");
+        }
+        SandboxSession session = null;
+        try {
+            session = provider.createSession(decision.getSandboxSpec());
+            SandboxResult result = session.execute(decision.getSandboxCommand());
+            return buildSandboxOutput(call, result);
+        } catch (Exception e) {
+            return buildToolErrorOutput(call, e);
+        } finally {
+            if (session != null) {
+                try {
+                    session.close();
+                } catch (Exception ignored) {
+                    // best-effort close
+                }
+            }
+        }
+    }
+
+    protected String buildSandboxOutput(AgentToolCall call, SandboxResult result) {
+        JSONObject payload = new JSONObject();
+        payload.put("routed", true);
+        if (result != null) {
+            payload.put("exitCode", result.getExitCode());
+            if (result.getStdout() != null) {
+                payload.put("stdout", result.getStdout());
+            }
+            if (result.getStderr() != null) {
+                payload.put("stderr", result.getStderr());
+            }
+        }
+        if (call != null) {
+            payload.put("tool", call.getName());
+        }
+        return "SANDBOX_RESULT: " + JSON.toJSONString(payload);
     }
 
     protected String buildToolErrorOutput(AgentToolCall call, Exception error) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorRouteToTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorRouteToTest.java
@@ -1,0 +1,132 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxArtifact;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic routeTo tests: a tool call is redirected to a fake sandbox (no real E2B/Daytona —
+ * the routing logic is what's under test). Verifies the command runs in the sandbox, the local
+ * executor is bypassed, and the sandbox output is fed back to the model. Also: routeTo with no
+ * provider configured surfaces as a blocked result.
+ */
+public class ToolInterceptorRouteToTest {
+
+    private static AgentToolRegistry bashRegistry() {
+        Tool.Function fn = new Tool.Function();
+        fn.setName("bash");
+        fn.setDescription("run a shell command");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        Tool.Function.Property cmdProp = new Tool.Function.Property();
+        cmdProp.setType("string");
+        props.put("command", cmdProp);
+        param.setProperties(props);
+        param.setRequired(Collections.singletonList("command"));
+        fn.setParameters(param);
+        return new StaticToolRegistry(Collections.<Object>singletonList(new Tool("function", fn)));
+    }
+
+    static final class FakeSandboxSession implements SandboxSession {
+        final List<SandboxCommand> executed = new ArrayList<SandboxCommand>();
+        final SandboxResult result;
+        boolean closed = false;
+        FakeSandboxSession(SandboxResult result) { this.result = result; }
+        public String getSessionId() { return "fake-sid"; }
+        public String getProviderId() { return "fake"; }
+        public SandboxSpec getSpec() { return null; }
+        public SandboxStatus getStatus() { return SandboxStatus.RUNNING; }
+        public SandboxResult execute(SandboxCommand command) { executed.add(command); return result; }
+        public boolean cancel(String commandId) { return false; }
+        public List<SandboxArtifact> listArtifacts() { return Collections.<SandboxArtifact>emptyList(); }
+        public void close() { closed = true; }
+    }
+
+    static final class FakeSandboxProvider implements SandboxProvider {
+        final List<SandboxSpec> created = new ArrayList<SandboxSpec>();
+        final SandboxResult result;
+        FakeSandboxProvider(SandboxResult result) { this.result = result; }
+        public String getProviderId() { return "fake"; }
+        public boolean supports(SandboxSpec spec) { return true; }
+        public SandboxSession createSession(SandboxSpec spec) { created.add(spec); return new FakeSandboxSession(result); }
+    }
+
+    @Test
+    public void routeToRunsCommandInSandboxBypassingLocalExecutor() throws Exception {
+        AgentToolCall requested = AgentToolCall.builder().name("bash").callId("c1").arguments("{\"command\":\"rm -rf x\"}").build();
+        ToolInterceptorTest.ScriptedModelClient model = new ToolInterceptorTest.ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        ToolInterceptorTest.RecordingExecutor localExec = new ToolInterceptorTest.RecordingExecutor();
+
+        SandboxResult sandboxResult = SandboxResult.builder().exitCode(Integer.valueOf(0)).stdout("sandboxed-output").build();
+        FakeSandboxProvider provider = new FakeSandboxProvider(sandboxResult);
+        SandboxSpec spec = SandboxSpec.builder().providerId("fake").build();
+        SandboxCommand cmd = SandboxCommand.builder().command("rm -rf x").build();
+
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .toolExecutor(localExec)
+                .toolRegistry(bashRegistry())
+                .sandboxProvider(provider)
+                .toolInterceptor((c, ctx) -> ToolCallDecision.routeTo(spec, cmd))
+                .build();
+        agent.newSession().run("delete something");
+
+        assertEquals("local executor must be bypassed when routed to sandbox", 0, localExec.executed.size());
+        assertEquals("a sandbox session must be created", 1, provider.created.size());
+        assertTrue("model must be invoked again after the sandbox result", model.prompts.size() >= 2);
+        String fedBack = JSON.toJSONString(model.prompts.get(1));
+        assertTrue("sandbox output must be fed back to the model: " + fedBack,
+                fedBack.contains("SANDBOX_RESULT") && fedBack.contains("sandboxed-output"));
+    }
+
+    @Test
+    public void routeToWithoutProviderSurfacesAsBlocked() throws Exception {
+        AgentToolCall requested = AgentToolCall.builder().name("bash").callId("c1").arguments("{\"command\":\"rm -rf x\"}").build();
+        ToolInterceptorTest.ScriptedModelClient model = new ToolInterceptorTest.ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        ToolInterceptorTest.RecordingExecutor localExec = new ToolInterceptorTest.RecordingExecutor();
+
+        // no sandboxProvider configured
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .toolExecutor(localExec)
+                .toolRegistry(bashRegistry())
+                .toolInterceptor((c, ctx) -> ToolCallDecision.routeTo(
+                        SandboxSpec.builder().providerId("fake").build(),
+                        SandboxCommand.builder().command("rm -rf x").build()))
+                .build();
+        agent.newSession().run("delete something");
+
+        assertEquals(0, localExec.executed.size());
+        String fedBack = JSON.toJSONString(model.prompts.get(1));
+        assertTrue("routeTo without provider must feed back a blocked reason: " + fedBack,
+                fedBack.contains("TOOL_BLOCKED") && fedBack.contains("no sandbox provider"));
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
@@ -49,7 +49,7 @@ public class ToolInterceptorTest {
     }
 
     /** model emits toolCall on first call, final text on the second. */
-    private static final class ScriptedModelClient implements AgentModelClient {
+    static final class ScriptedModelClient implements AgentModelClient {
         final List<AgentModelResult> scripted;
         final List<AgentPrompt> prompts = new ArrayList<AgentPrompt>();
         int idx = 0;
@@ -62,7 +62,7 @@ public class ToolInterceptorTest {
     }
 
     /** records every call it actually executed */
-    private static final class RecordingExecutor implements ToolExecutor {
+    static final class RecordingExecutor implements ToolExecutor {
         final List<AgentToolCall> executed = new ArrayList<AgentToolCall>();
         public String execute(AgentToolCall c) {
             executed.add(c);


### PR DESCRIPTION
Task `2026-06-30-wire-tool-interceptor-routeto-to-sandbox-executi-06aa4626`. Follow-on #2 to the interceptor keystone (#151): make `routeTo` actually execute in a sandbox — the beyond-pi capability, for real.

## What

- **`ToolCallDecision.routeTo(SandboxSpec spec, SandboxCommand command)`** — the interceptor owns the tool&rarr;command mapping (it knows how its tools become shell commands); the runtime owns session creation + execution.
- **`AgentContext`/`AgentBuilder`**: add a configured `SandboxProvider` (the sandbox factory).
- **`BaseAgentRuntime.executeTool` ROUTE_TO**: `provider.createSession(spec)` &rarr; `session.execute(command)` &rarr; feed `SANDBOX_RESULT` (exitCode/stdout/stderr) back to the model; close the session. No provider configured &rarr; blocked-with-reason (graceful, not a crash).

## Why

This is the move that surpasses pi: pi can "redirect dangerous commands to a sandbox" but has no first-class sandbox SPI — ai4j routes to Daytona/E2B via the existing Sandbox SPI. An interceptor that blocks `rm -rf` and re-runs it in E2B is now a one-liner.

## Verification

2 deterministic tests (routeTo runs in a fake sandbox, bypasses the local executor, output fed back to model; routeTo with no provider &rarr; blocked-with-reason). Interceptor suite still green. ai4j-agent full module **177 tests, 0 failures**. `git diff --check` clean. No real sandbox needed — the routing logic is deterministic; real E2B is covered by the provider's own live test.

## Note

A session is created per ROUTE_TO (acceptable for v2; a bound/reused session is a future optimization). Library layer #2 done; remaining follow-ons: #3 CLI external-command bridge (end-user Claude-Code-style hooks), #4 docs page.