### PR TITLE
feat(cli): external-command tool hooks (Claude-Code-style PreToolUse)

### DIFF
--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/config/CliWorkspaceConfig.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/config/CliWorkspaceConfig.java
@@ -1,5 +1,7 @@
 package io.github.lnyocly.ai4j.cli.config;
 
+import io.github.lnyocly.ai4j.cli.hook.CliHooksConfig;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,6 +14,7 @@ public class CliWorkspaceConfig {
     private List<String> enabledMcpServers;
     private List<String> skillDirectories;
     private List<String> agentDirectories;
+    private CliHooksConfig hooks;
 
     public CliWorkspaceConfig() {
     }
@@ -85,6 +88,14 @@ public class CliWorkspaceConfig {
 
     public void setEnabledMcpServers(List<String> enabledMcpServers) {
         this.enabledMcpServers = copy(enabledMcpServers);
+    }
+
+    public CliHooksConfig getHooks() {
+        return hooks;
+    }
+
+    public void setHooks(CliHooksConfig hooks) {
+        this.hooks = hooks;
     }
 
     public List<String> getSkillDirectories() {

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
@@ -4,6 +4,8 @@ import io.github.lnyocly.ai4j.cli.CliProtocol;
 import io.github.lnyocly.ai4j.cli.agent.CliCodingAgentRegistry;
 import io.github.lnyocly.ai4j.cli.command.CodeCommandOptions;
 import io.github.lnyocly.ai4j.cli.config.CliWorkspaceConfig;
+import io.github.lnyocly.ai4j.cli.hook.CliHookInterceptor;
+import io.github.lnyocly.ai4j.cli.hook.ProcessHookCommandRunner;
 import io.github.lnyocly.ai4j.cli.mcp.CliMcpRuntimeManager;
 import io.github.lnyocly.ai4j.cli.provider.CliProviderConfigManager;
 import io.github.lnyocly.ai4j.cli.render.CliAnsi;
@@ -201,6 +203,7 @@ public class DefaultCodingCliAgentFactory implements CodingCliAgentFactory {
             builder.sandbox(sandboxSession);
         }
         attachMcpRuntime(builder, mcpRuntimeManager);
+        attachToolHooks(builder, workspaceConfig);
         attachExperimentalAgents(builder, options, workspaceConfig, modelClient, workspaceContext, codingOptions, agentOptions);
         return builder.build();
     }
@@ -289,6 +292,21 @@ public class DefaultCodingCliAgentFactory implements CodingCliAgentFactory {
         }
         builder.toolRegistry(mcpRuntimeManager.getToolRegistry());
         builder.toolExecutor(mcpRuntimeManager.getToolExecutor());
+    }
+
+    /**
+     * If the user declared external tool hooks in the workspace config, attach the in-process
+     * {@link CliHookInterceptor} (which spawns the configured commands Claude-Code-style). No-op
+     * when no hooks are configured — existing behavior is unchanged.
+     */
+    private void attachToolHooks(io.github.lnyocly.ai4j.coding.CodingAgentBuilder builder,
+                                 CliWorkspaceConfig workspaceConfig) {
+        if (workspaceConfig == null
+                || workspaceConfig.getHooks() == null
+                || workspaceConfig.getHooks().isEmpty()) {
+            return;
+        }
+        builder.toolInterceptor(new CliHookInterceptor(workspaceConfig.getHooks(), new ProcessHookCommandRunner()));
     }
 
     private void attachExperimentalAgents(io.github.lnyocly.ai4j.coding.CodingAgentBuilder builder,

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookEntry.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookEntry.java
@@ -1,0 +1,32 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+/**
+ * One external hook command declared by the user. {@code command} is run as a shell command
+ * (Claude-Code-style); {@code match} is the tool name to match, or null/empty/"*" for all tools.
+ */
+public class CliHookEntry {
+
+    private String command;
+    private String match;
+
+    public CliHookEntry() {
+    }
+
+    public CliHookEntry(String command, String match) {
+        this.command = command;
+        this.match = match;
+    }
+
+    public String getCommand() { return command; }
+    public void setCommand(String command) { this.command = command; }
+    public String getMatch() { return match; }
+    public void setMatch(String match) { this.match = match; }
+
+    /** True if this entry applies to the given tool name (null/empty/"*" matches everything). */
+    public boolean matches(String toolName) {
+        if (match == null || match.trim().isEmpty() || "*".equals(match.trim())) {
+            return true;
+        }
+        return match.trim().equals(toolName);
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptor.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptor.java
@@ -1,0 +1,123 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+import java.util.List;
+
+/**
+ * Bridges the in-process {@link ToolInterceptor} to external shell commands — the Claude-Code-style
+ * end-user hook experience. On each tool call, for every matching {@code preToolUse} hook, it runs
+ * the user's command with the tool-call JSON on stdin and maps the outcome to a decision:
+ *
+ * <ul>
+ *   <li><b>exit 2</b> &rarr; {@link ToolCallDecision#block block} (reason = stderr/stdout). This is
+ *       Claude Code's PreToolUse exit-code-2 deny.</li>
+ *   <li><b>exit 0 + stdout JSON</b> {@code {"decision":"block","reason":"..."}} &rarr; block.</li>
+ *   <li><b>exit 0 + stdout JSON</b> {@code {"decision":"modify","name":"...","arguments":"..."}} &rarr; modify.</li>
+ *   <li><b>exit 0 / other</b> &rarr; continue to the next hook (allow so far).</li>
+ *   <li><b>hook crashes</b> &rarr; fail-closed: block-with-reason (a safety hook that errors must
+ *       not let the tool run).</li>
+ * </ul>
+ *
+ * <p>First block wins; else first modify wins; else allow. Process spawning is delegated to a
+ * {@link HookCommandRunner} so the decision logic is testable with a fake runner.</p>
+ */
+public class CliHookInterceptor implements ToolInterceptor {
+
+    private final CliHooksConfig config;
+    private final HookCommandRunner runner;
+
+    public CliHookInterceptor(CliHooksConfig config, HookCommandRunner runner) {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (runner == null) {
+            throw new IllegalArgumentException("runner must not be null");
+        }
+        this.config = config;
+        this.runner = runner;
+    }
+
+    @Override
+    public ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context) {
+        String toolName = call == null ? null : call.getName();
+        List<CliHookEntry> hooks = config.getPreToolUse();
+        for (CliHookEntry hook : hooks) {
+            if (hook == null || !hook.matches(toolName)) {
+                continue;
+            }
+            ToolCallDecision decision = runOne(hook, call);
+            if (decision != null) {
+                return decision;
+            }
+        }
+        return ToolCallDecision.allow();
+    }
+
+    /** Runs one hook; returns a non-null decision to short-circuit, or null to continue. */
+    private ToolCallDecision runOne(CliHookEntry hook, AgentToolCall call) {
+        String stdinJson = call == null ? "{}" : JSON.toJSONString(call);
+        HookCommandRunner.HookCommandResult result;
+        try {
+            result = runner.run(hook.getCommand(), stdinJson);
+        } catch (Exception e) {
+            // fail-closed: a hook that errors blocks the tool
+            return ToolCallDecision.block("hook '" + hook.getCommand() + "' failed: " + safeMessage(e));
+        }
+        if (result.exitCode == 2) {
+            return ToolCallDecision.block(reasonFrom(result));
+        }
+        if (result.exitCode != 0) {
+            // soft error (like Claude Code exit 1): continue, don't block
+            return null;
+        }
+        // exit 0: inspect stdout JSON for a structured decision
+        JSONObject json = parseJson(result.stdout);
+        if (json != null) {
+            String decision = json.getString("decision");
+            if ("block".equalsIgnoreCase(decision)) {
+                return ToolCallDecision.block(json.getString("reason"));
+            }
+            if ("modify".equalsIgnoreCase(decision)) {
+                String name = json.getString("name");
+                String args = json.getString("arguments");
+                if (name != null) {
+                    return ToolCallDecision.modify(AgentToolCall.builder()
+                            .name(name)
+                            .arguments(args)
+                            .callId(call == null ? null : call.getCallId())
+                            .build());
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String reasonFrom(HookCommandRunner.HookCommandResult result) {
+        String reason = result.stderr == null ? "" : result.stderr.trim();
+        if (reason.isEmpty()) {
+            reason = result.stdout == null ? "" : result.stdout.trim();
+        }
+        return reason.isEmpty() ? "blocked by hook" : reason;
+    }
+
+    private static JSONObject parseJson(String stdout) {
+        if (stdout == null || stdout.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON.parseObject(stdout);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String safeMessage(Throwable e) {
+        return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
@@ -1,0 +1,38 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * User-declared external hooks. Loaded from the workspace config (JSON), so end users configure
+ * hook commands without writing Java. v1 supports {@code preToolUse} (Claude Code's PreToolUse).
+ *
+ * <p>Example workspace config:</p>
+ * <pre>
+ * "hooks": {
+ *   "preToolUse": [
+ *     { "command": "python ~/.ai4j/hooks/guard.py", "match": "bash" }
+ *   ]
+ * }
+ * </pre>
+ */
+public class CliHooksConfig {
+
+    private List<CliHookEntry> preToolUse;
+
+    public CliHooksConfig() {
+    }
+
+    public List<CliHookEntry> getPreToolUse() {
+        return preToolUse == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(preToolUse);
+    }
+
+    public void setPreToolUse(List<CliHookEntry> preToolUse) {
+        this.preToolUse = preToolUse == null ? null : new ArrayList<CliHookEntry>(preToolUse);
+    }
+
+    public boolean isEmpty() {
+        return preToolUse == null || preToolUse.isEmpty();
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/HookCommandRunner.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/HookCommandRunner.java
@@ -1,0 +1,24 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+/**
+ * Runs one hook command, feeding {@code stdinJson} on stdin. Abstracted behind an interface so the
+ * {@link CliHookInterceptor} logic is testable without spawning real processes (a fake runner makes
+ * the bridge deterministic + cross-platform; {@link ProcessHookCommandRunner} is the real impl).
+ */
+public interface HookCommandRunner {
+
+    HookCommandResult run(String command, String stdinJson) throws Exception;
+
+    /** Result of one hook command: exit code + captured stdout/stderr. */
+    final class HookCommandResult {
+        public final int exitCode;
+        public final String stdout;
+        public final String stderr;
+
+        public HookCommandResult(int exitCode, String stdout, String stderr) {
+            this.exitCode = exitCode;
+            this.stdout = stdout == null ? "" : stdout;
+            this.stderr = stderr == null ? "" : stderr;
+        }
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/ProcessHookCommandRunner.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/ProcessHookCommandRunner.java
@@ -1,0 +1,57 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * {@link HookCommandRunner} that spawns the hook as a real shell command ({@code sh -c} on Unix,
+ * {@code cmd /c} on Windows), feeds the tool-call JSON on stdin, and captures exit code + stdout +
+ * stderr. Thin by design — the decision logic lives in {@link CliHookInterceptor}.
+ */
+public class ProcessHookCommandRunner implements HookCommandRunner {
+
+    @Override
+    public HookCommandResult run(String command, String stdinJson) throws Exception {
+        if (command == null || command.trim().isEmpty()) {
+            return new HookCommandResult(0, "", "");
+        }
+        boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        ProcessBuilder pb = new ProcessBuilder(windows ? "cmd" : "sh", windows ? "/c" : "-c", command);
+        Process process = pb.start();
+        if (stdinJson != null) {
+            try {
+                process.getOutputStream().write(stdinJson.getBytes(StandardCharsets.UTF_8));
+            } catch (IOException ignored) {
+                // some hooks read no stdin; ignore broken pipe on write
+            }
+        }
+        try {
+            process.getOutputStream().close();
+        } catch (IOException ignored) {
+            // best-effort
+        }
+        String stdout = readFully(process.getInputStream());
+        String stderr = readFully(process.getErrorStream());
+        int code = process.waitFor();
+        return new HookCommandResult(code, stdout, stderr);
+    }
+
+    private static String readFully(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[4096];
+        int read;
+        try {
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+        } finally {
+            input.close();
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+    }
+}

--- a/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptorTest.java
+++ b/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptorTest.java
@@ -1,0 +1,152 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic tests for {@link CliHookInterceptor} using a fake {@link HookCommandRunner} (no real
+ * process spawn — fast, cross-platform). Verifies the exit-code-2 block, JSON block/modify,
+ * allow-on-no-decision, fail-closed on hook error, and match filtering.
+ */
+public class CliHookInterceptorTest {
+
+    private static AgentToolCall bashCall() {
+        return AgentToolCall.builder().name("bash").callId("c1").arguments("{\"command\":\"rm -rf x\"}").build();
+    }
+
+    private static CliHooksConfig hooks(CliHookEntry... entries) {
+        CliHooksConfig c = new CliHooksConfig();
+        c.setPreToolUse(new ArrayList<CliHookEntry>(Arrays.asList(entries)));
+        return c;
+    }
+
+    /** Fake runner: returns a canned result per command, records stdin, optionally throws. */
+    static final class FakeRunner implements HookCommandRunner {
+        final Map<String, HookCommandResult> byCommand = new HashMap<String, HookCommandResult>();
+        final List<String> stdins = new ArrayList<String>();
+        Exception toThrow;
+        public HookCommandResult run(String command, String stdinJson) throws Exception {
+            stdins.add(stdinJson);
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            HookCommandResult r = byCommand.get(command);
+            return r == null ? new HookCommandResult(0, "", "") : r;
+        }
+    }
+
+    @Test
+    public void exitCode2BlocksAndStdinReceivesToolCallJson() {
+        FakeRunner runner = new FakeRunner();
+        runner.byCommand.put("guard.sh", new HookCommandRunner.HookCommandResult(2, "", "refusing destructive command"));
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("guard.sh", null)), runner);
+
+        ToolCallDecision d = interceptor.beforeToolCall(bashCall(), null);
+
+        assertEquals(ToolCallDecision.Type.BLOCK, d.getType());
+        assertTrue("block reason comes from stderr", d.getReason().contains("refusing destructive command"));
+        assertEquals("hook receives one stdin payload", 1, runner.stdins.size());
+        assertTrue("stdin carries the tool call json", runner.stdins.get(0).contains("rm -rf x"));
+    }
+
+    @Test
+    public void exitZeroWithBlockDecisionJsonBlocks() {
+        FakeRunner runner = new FakeRunner();
+        runner.byCommand.put("guard.sh", new HookCommandRunner.HookCommandResult(0,
+                "{\"decision\":\"block\",\"reason\":\"policy says no\"}", ""));
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("guard.sh", null)), runner);
+
+        ToolCallDecision d = interceptor.beforeToolCall(bashCall(), null);
+        assertEquals(ToolCallDecision.Type.BLOCK, d.getType());
+        assertEquals("policy says no", d.getReason());
+    }
+
+    @Test
+    public void exitZeroWithModifyDecisionRewritesTheCall() {
+        FakeRunner runner = new FakeRunner();
+        runner.byCommand.put("rewrite.sh", new HookCommandRunner.HookCommandResult(0,
+                "{\"decision\":\"modify\",\"name\":\"bash\",\"arguments\":\"{\\\"command\\\":\\\"echo safe\\\"}\"}", ""));
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("rewrite.sh", null)), runner);
+
+        ToolCallDecision d = interceptor.beforeToolCall(bashCall(), null);
+        assertEquals(ToolCallDecision.Type.MODIFY, d.getType());
+        assertEquals("bash", d.getModifiedCall().getName());
+        assertTrue(d.getModifiedCall().getArguments().contains("echo safe"));
+    }
+
+    @Test
+    public void exitZeroWithNoDecisionAllows() {
+        FakeRunner runner = new FakeRunner();
+        runner.byCommand.put("noop.sh", new HookCommandRunner.HookCommandResult(0, "ok", ""));
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("noop.sh", null)), runner);
+
+        assertEquals(ToolCallDecision.Type.ALLOW, interceptor.beforeToolCall(bashCall(), null).getType());
+    }
+
+    @Test
+    public void hookThatThrowsBlocksFailClosed() {
+        FakeRunner runner = new FakeRunner();
+        runner.toThrow = new RuntimeException("command not found");
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("broken.sh", null)), runner);
+
+        ToolCallDecision d = interceptor.beforeToolCall(bashCall(), null);
+        assertEquals("a crashed safety hook must fail closed", ToolCallDecision.Type.BLOCK, d.getType());
+        assertTrue(d.getReason().contains("command not found"));
+    }
+
+    @Test
+    public void matchFiltersHooksByToolName() {
+        FakeRunner runner = new FakeRunner();
+        runner.byCommand.put("guard-bash.sh", new HookCommandRunner.HookCommandResult(2, "", "blocked"));
+        CliHookInterceptor interceptor = new CliHookInterceptor(
+                hooks(new CliHookEntry("guard-bash.sh", "bash")), runner);
+
+        // matches bash -> block
+        assertEquals(ToolCallDecision.Type.BLOCK, interceptor.beforeToolCall(bashCall(), null).getType());
+        // does not match another tool -> allow, and the hook is not run
+        AgentToolCall readCall = AgentToolCall.builder().name("read_file").callId("c2").arguments("{}").build();
+        runner.stdins.clear();
+        ToolCallDecision d = interceptor.beforeToolCall(readCall, null);
+        assertEquals(ToolCallDecision.Type.ALLOW, d.getType());
+        assertEquals("non-matching hook must not run", 0, runner.stdins.size());
+    }
+
+    @Test
+    public void noHooksAllowsEverything() {
+        CliHooksConfig empty = new CliHooksConfig();
+        empty.setPreToolUse(Collections.<CliHookEntry>emptyList());
+        CliHookInterceptor interceptor = new CliHookInterceptor(empty, new FakeRunner());
+        assertEquals(ToolCallDecision.Type.ALLOW, interceptor.beforeToolCall(bashCall(), null).getType());
+    }
+
+    @Test
+    public void realProcessExit2BlocksAndExit0Allows() throws Exception {
+        // one smoke test for ProcessHookCommandRunner itself (cross-platform: sh -c / cmd /c)
+        ProcessHookCommandRunner runner = new ProcessHookCommandRunner();
+        // exit 2 -> block
+        CliHooksConfig blocking = hooks(new CliHookEntry(
+                System.getProperty("os.name", "").toLowerCase().contains("win") ? "exit 2" : "exit 2", null));
+        assertEquals(ToolCallDecision.Type.BLOCK,
+                new CliHookInterceptor(blocking, runner).beforeToolCall(bashCall(), null).getType());
+        // exit 0 -> allow
+        CliHooksConfig allowing = hooks(new CliHookEntry("exit 0", null));
+        assertEquals(ToolCallDecision.Type.ALLOW,
+                new CliHookInterceptor(allowing, runner).beforeToolCall(bashCall(), null).getType());
+    }
+}

--- a/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
+++ b/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
@@ -17,6 +17,7 @@ import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.coding.definition.BuiltInCodingAgentDefinitions;
 import io.github.lnyocly.ai4j.coding.definition.CodingAgentDefinitionRegistry;
 import io.github.lnyocly.ai4j.coding.delegate.CodingDelegateToolExecutor;
@@ -65,6 +66,7 @@ public class CodingAgentBuilder {
     private CodingAgentOptions codingOptions;
     private AgentToolRegistry toolRegistry;
     private ToolExecutor toolExecutor;
+    private ToolInterceptor toolInterceptor;
     private ExtensionRegistry extensionRegistry;
     private ExtensionAgentTools extensionTools;
     private CodingAgentDefinitionRegistry definitionRegistry;
@@ -121,6 +123,11 @@ public class CodingAgentBuilder {
 
     public CodingAgentBuilder toolExecutor(ToolExecutor toolExecutor) {
         this.toolExecutor = toolExecutor;
+        return this;
+    }
+
+    public CodingAgentBuilder toolInterceptor(ToolInterceptor toolInterceptor) {
+        this.toolInterceptor = toolInterceptor;
         return this;
     }
 
@@ -328,6 +335,7 @@ public class CodingAgentBuilder {
                 .options(resolvedAgentOptions)
                 .toolRegistry(resolvedToolRegistry)
                 .toolExecutor(resolvedToolExecutor)
+                .toolInterceptor(toolInterceptor)
                 .temperature(temperature)
                 .topP(topP)
                 .maxOutputTokens(maxOutputTokens)


### PR DESCRIPTION
Task `2026-06-30-cli-external-command-tool-hooks-claude-code-styl-d5fcaba8`. The final follow-on (#3) of the pi-alignment roadmap: end users can configure hook commands (any language, any tool) that run before a tool executes and decide allow/block/modify — the Claude-Code end-user hook experience, bridged to the in-process ToolInterceptor (#151).

## What

**ai4j-coding** — `CodingAgentBuilder.toolInterceptor(...)` (previously only toolExecutor) passes the interceptor through to the AgentBuilder.

**ai4j-cli** (new package `io.github.lnyocly.ai4j.cli.hook`):
- **`CliHookInterceptor`** — bridges `ToolInterceptor` to external shell commands. exit 2 → block (Claude Code PreToolUse deny semantics); exit-0 JSON `{decision:block|modify}` → block/modify; other exit → continue; hook crash → **fail-closed block** (a safety hook that errors must not let the tool run). First block/modify wins.
- **`HookCommandRunner`** (interface) + **`ProcessHookCommandRunner`** (real spawn: `sh -c`/`cmd /c`, feeds the tool-call JSON on stdin). The interface keeps the decision logic testable with a fake runner — deterministic + cross-platform.
- **`CliHookEntry` / `CliHooksConfig`** — user-declared hooks (`preToolUse` list + tool-name `match`).
- **`CliWorkspaceConfig`** — `hooks` field, auto-parsed from the workspace config JSON, so **end users configure via file, no Java**.
- **`DefaultCodingCliAgentFactory.attachToolHooks`** — wires the interceptor when hooks are configured; no-op otherwise (existing behavior unchanged).

## End-user result

A user drops this into their workspace config and any `bash` tool call runs their guard script first:
```json
"hooks": { "preToolUse": [{ "command": "python ~/.ai4j/hooks/guard.py", "match": "bash" }] }
```
The script reads the tool-call JSON on stdin, exits 2 (or emits `{decision:block,reason:...}`) to veto, or `{decision:modify,...}` to rewrite. Identical mental model to Claude Code hooks, any language.

## Verification

8 tests: exit-2 block, JSON block, JSON modify, allow-on-no-decision, fail-closed on hook crash, match filtering, no-hooks, + a **real-process smoke test** for `ProcessHookCommandRunner` (cross-platform `exit 2`/`exit 0`). ai4j-coding + ai4j-cli regression **310 tests, 0 failures**. `git diff --check` clean.

## Status

This completes the pi-alignment roadmap: observe (lifecycle hooks) + block/modify/routeTo (#151/#152) at the library layer, documented (#153), and now the Claude-Code-style external-command hooks at the CLI layer (#3).