### PR TITLE
feat(agent+cli): UserPromptSubmit interception hook (block/modify prompt)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -31,6 +31,7 @@ import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
@@ -66,6 +67,7 @@ public class AgentBuilder {
     private final List<SubAgentDefinition> subAgentDefinitions = new ArrayList<>();
     private ToolExecutor toolExecutor;
     private ToolInterceptor toolInterceptor;
+    private PromptInterceptor promptInterceptor;
     private SandboxProvider sandboxProvider;
     private CodeExecutor codeExecutor;
     private Supplier<AgentMemory> memorySupplier;
@@ -255,6 +257,11 @@ public class AgentBuilder {
         return this;
     }
 
+    public AgentBuilder promptInterceptor(PromptInterceptor promptInterceptor) {
+        this.promptInterceptor = promptInterceptor;
+        return this;
+    }
+
     public AgentBuilder sandboxProvider(SandboxProvider sandboxProvider) {
         this.sandboxProvider = sandboxProvider;
         return this;
@@ -432,6 +439,7 @@ public class AgentBuilder {
                 .toolRegistry(resolvedToolRegistry)
                 .toolExecutor(resolvedToolExecutor)
                 .toolInterceptor(toolInterceptor)
+                .promptInterceptor(promptInterceptor)
                 .sandboxProvider(sandboxProvider)
                 .codeExecutor(resolvedCodeExecutor)
                 .memory(memory)

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -13,6 +13,7 @@ import io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicy;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,8 @@ public class AgentContext {
     private ToolExecutor toolExecutor;
 
     private ToolInterceptor toolInterceptor;
+
+    private PromptInterceptor promptInterceptor;
 
     private SandboxProvider sandboxProvider;
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PromptDecision.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PromptDecision.java
@@ -1,0 +1,45 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+/**
+ * The verdict a {@link PromptInterceptor} returns for one user input. Immutable; construct via the
+ * static factories. Mirrors {@link ToolCallDecision}'s shape for prompts.
+ */
+public final class PromptDecision {
+
+    public enum Type { ALLOW, BLOCK, MODIFY }
+
+    private final Type type;
+    private final String reason;
+    private final String modifiedInput;
+
+    private PromptDecision(Type type, String reason, String modifiedInput) {
+        this.type = type;
+        this.reason = reason;
+        this.modifiedInput = modifiedInput;
+    }
+
+    /** Use the input as-is. */
+    public static PromptDecision allow() {
+        return new PromptDecision(Type.ALLOW, null, null);
+    }
+
+    /**
+     * Reject the input outright; the agent does not run for this turn and {@code reason} is the
+     * returned output (so the caller/user sees why).
+     */
+    public static PromptDecision block(String reason) {
+        return new PromptDecision(Type.BLOCK, reason, null);
+    }
+
+    /** Replace the input with {@code modifiedInput} (rewritten/normalized/redacted) and proceed. */
+    public static PromptDecision modify(String modifiedInput) {
+        if (modifiedInput == null) {
+            throw new IllegalArgumentException("modifiedInput must not be null");
+        }
+        return new PromptDecision(Type.MODIFY, null, modifiedInput);
+    }
+
+    public Type getType() { return type; }
+    public String getReason() { return reason; }
+    public String getModifiedInput() { return modifiedInput; }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PromptInterceptor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PromptInterceptor.java
@@ -1,0 +1,21 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+
+/**
+ * Control-flow hook that runs before the user's input is committed to the conversation — the
+ * Claude-Code "UserPromptSubmit" interception capability. Lets the host block a harmful prompt or
+ * rewrite/normalize it before the model ever sees it (prompt guardrails, injection defense, PII
+ * redaction, prefix injection).
+ *
+ * <p>Register via {@code AgentBuilder.promptInterceptor(...)}. Sibling to {@link ToolInterceptor}
+ * (which covers tool calls).</p>
+ */
+public interface PromptInterceptor {
+
+    /**
+     * Called with the raw user input before it enters memory / the model. Return a decision;
+     * never return null (return {@link PromptDecision#allow()} instead).
+     */
+    PromptDecision beforePrompt(String input, AgentContext context);
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -23,6 +23,8 @@ import io.github.lnyocly.ai4j.agent.tool.AgentToolCallSanitizer;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptDecision;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
@@ -87,7 +89,34 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
         }
 
         if (request != null && request.getInput() != null) {
-            memory.addUserInput(request.getInput());
+            Object rawInput = request.getInput();
+            Object effectiveInput = rawInput;
+            PromptInterceptor promptInterceptor = context == null ? null : context.getPromptInterceptor();
+            if (promptInterceptor != null && rawInput instanceof String) {
+                PromptDecision decision = promptInterceptor.beforePrompt((String) rawInput, context);
+                if (decision == null) {
+                    decision = PromptDecision.allow();
+                }
+                switch (decision.getType()) {
+                    case BLOCK:
+                        String reason = decision.getReason() == null ? "blocked by prompt interceptor" : decision.getReason();
+                        publish(context, listener, AgentEventType.FINAL_OUTPUT, 0, "PROMPT_BLOCKED: " + reason, null, runId, sessionId, turnId);
+                        return AgentResult.builder()
+                                .runId(runId)
+                                .sessionId(sessionId)
+                                .turnId(turnId)
+                                .outputText("PROMPT_BLOCKED: " + reason)
+                                .steps(0)
+                                .build();
+                    case MODIFY:
+                        effectiveInput = decision.getModifiedInput();
+                        break;
+                    case ALLOW:
+                    default:
+                        break;
+                }
+            }
+            memory.addUserInput(effectiveInput);
         }
 
         List<AgentToolCall> toolCalls = new ArrayList<>();

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/PromptInterceptorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/PromptInterceptorTest.java
@@ -1,0 +1,79 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic agent-loop tests for the {@link PromptInterceptor} (no real LLM). Verifies block
+ * (agent returns without calling the model), modify (rewritten input reaches the model), and allow.
+ */
+public class PromptInterceptorTest {
+
+    private static ToolInterceptorTest.ScriptedModelClient finalAnswerModel() {
+        // emits a final answer on the first call (no tool calls)
+        return new ToolInterceptorTest.ScriptedModelClient(Collections.singletonList(
+                AgentModelResult.builder().outputText("done").build()));
+    }
+
+    @Test
+    public void blockStopsBeforeTheModelRuns() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = finalAnswerModel();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .promptInterceptor((input, ctx) -> PromptDecision.block("forbidden topic"))
+                .build();
+        AgentResult result = agent.newSession().run("tell me a forbidden thing");
+
+        assertEquals("blocked prompt must NOT reach the model", 0, model.prompts.size());
+        assertTrue("result must carry the block reason", result.getOutputText().contains("PROMPT_BLOCKED"));
+        assertTrue(result.getOutputText().contains("forbidden topic"));
+    }
+
+    @Test
+    public void modifyRewritesTheInputBeforeTheModelSeesIt() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = finalAnswerModel();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .promptInterceptor((input, ctx) -> PromptDecision.modify(input.toUpperCase()))
+                .build();
+        agent.newSession().run("hello world");
+
+        assertEquals("model must be called once", 1, model.prompts.size());
+        String seenByModel = JSON.toJSONString(model.prompts.get(0));
+        assertTrue("model must see the MODIFIED (uppercased) input: " + seenByModel,
+                seenByModel.contains("HELLO WORLD"));
+    }
+
+    @Test
+    public void allowPassesTheInputThrough() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = finalAnswerModel();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .promptInterceptor((input, ctx) -> PromptDecision.allow())
+                .build();
+        agent.newSession().run("hello world");
+
+        assertEquals(1, model.prompts.size());
+        assertTrue(JSON.toJSONString(model.prompts.get(0)).contains("hello world"));
+    }
+
+    @Test
+    public void noInterceptorBehavesLikeAllow() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = finalAnswerModel();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .build();
+        AgentResult result = agent.newSession().run("hello world");
+        assertEquals(1, model.prompts.size());
+        assertTrue(result.getOutputText().contains("done"));
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
@@ -5,6 +5,8 @@ import io.github.lnyocly.ai4j.cli.agent.CliCodingAgentRegistry;
 import io.github.lnyocly.ai4j.cli.command.CodeCommandOptions;
 import io.github.lnyocly.ai4j.cli.config.CliWorkspaceConfig;
 import io.github.lnyocly.ai4j.cli.hook.CliHookInterceptor;
+import io.github.lnyocly.ai4j.cli.hook.CliPromptInterceptor;
+import io.github.lnyocly.ai4j.cli.hook.CliHooksConfig;
 import io.github.lnyocly.ai4j.cli.hook.ProcessHookCommandRunner;
 import io.github.lnyocly.ai4j.cli.mcp.CliMcpRuntimeManager;
 import io.github.lnyocly.ai4j.cli.provider.CliProviderConfigManager;
@@ -295,9 +297,10 @@ public class DefaultCodingCliAgentFactory implements CodingCliAgentFactory {
     }
 
     /**
-     * If the user declared external tool hooks in the workspace config, attach the in-process
-     * {@link CliHookInterceptor} (which spawns the configured commands Claude-Code-style). No-op
-     * when no hooks are configured — existing behavior is unchanged.
+     * If the user declared external hooks in the workspace config, attach the in-process
+     * interceptors ({@link CliHookInterceptor} for preToolUse, {@link CliPromptInterceptor} for
+     * userPromptSubmit) — Claude-Code-style external command hooks. No-op when no hooks are
+     * configured — existing behavior is unchanged.
      */
     private void attachToolHooks(io.github.lnyocly.ai4j.coding.CodingAgentBuilder builder,
                                  CliWorkspaceConfig workspaceConfig) {
@@ -306,7 +309,13 @@ public class DefaultCodingCliAgentFactory implements CodingCliAgentFactory {
                 || workspaceConfig.getHooks().isEmpty()) {
             return;
         }
-        builder.toolInterceptor(new CliHookInterceptor(workspaceConfig.getHooks(), new ProcessHookCommandRunner()));
+        CliHooksConfig hooks = workspaceConfig.getHooks();
+        if (!hooks.getPreToolUse().isEmpty()) {
+            builder.toolInterceptor(new CliHookInterceptor(hooks, new ProcessHookCommandRunner()));
+        }
+        if (hooks.hasPromptHooks()) {
+            builder.promptInterceptor(new CliPromptInterceptor(hooks, new ProcessHookCommandRunner()));
+        }
     }
 
     private void attachExperimentalAgents(io.github.lnyocly.ai4j.coding.CodingAgentBuilder builder,

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
@@ -6,13 +6,17 @@ import java.util.List;
 
 /**
  * User-declared external hooks. Loaded from the workspace config (JSON), so end users configure
- * hook commands without writing Java. v1 supports {@code preToolUse} (Claude Code's PreToolUse).
+ * hook commands without writing Java. Supports {@code preToolUse} (Claude Code's PreToolUse) and
+ * {@code userPromptSubmit} (Claude Code's UserPromptSubmit).
  *
  * <p>Example workspace config:</p>
  * <pre>
  * "hooks": {
  *   "preToolUse": [
  *     { "command": "python ~/.ai4j/hooks/guard.py", "match": "bash" }
+ *   ],
+ *   "userPromptSubmit": [
+ *     { "command": "python ~/.ai4j/hooks/prompt_guard.py" }
  *   ]
  * }
  * </pre>
@@ -20,6 +24,7 @@ import java.util.List;
 public class CliHooksConfig {
 
     private List<CliHookEntry> preToolUse;
+    private List<CliHookEntry> userPromptSubmit;
 
     public CliHooksConfig() {
     }
@@ -32,7 +37,20 @@ public class CliHooksConfig {
         this.preToolUse = preToolUse == null ? null : new ArrayList<CliHookEntry>(preToolUse);
     }
 
+    public List<CliHookEntry> getUserPromptSubmit() {
+        return userPromptSubmit == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(userPromptSubmit);
+    }
+
+    public void setUserPromptSubmit(List<CliHookEntry> userPromptSubmit) {
+        this.userPromptSubmit = userPromptSubmit == null ? null : new ArrayList<CliHookEntry>(userPromptSubmit);
+    }
+
     public boolean isEmpty() {
-        return preToolUse == null || preToolUse.isEmpty();
+        return (preToolUse == null || preToolUse.isEmpty())
+                && (userPromptSubmit == null || userPromptSubmit.isEmpty());
+    }
+
+    public boolean hasPromptHooks() {
+        return userPromptSubmit != null && !userPromptSubmit.isEmpty();
     }
 }

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliPromptInterceptor.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliPromptInterceptor.java
@@ -1,0 +1,115 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptDecision;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bridges the in-process {@link PromptInterceptor} to external shell commands — the Claude-Code
+ * "UserPromptSubmit" end-user hook. Mirrors {@link CliHookInterceptor}: for each configured
+ * {@code userPromptSubmit} command, runs it with the prompt JSON on stdin and maps the outcome to a
+ * {@link PromptDecision}:
+ *
+ * <ul>
+ *   <li><b>exit 2</b> &rarr; {@link PromptDecision#block block} (reason = stderr/stdout).</li>
+ *   <li><b>exit 0 + stdout JSON</b> {@code {"decision":"block","reason":"..."}} &rarr; block.</li>
+ *   <li><b>exit 0 + stdout JSON</b> {@code {"decision":"modify","input":"..."}} &rarr; modify.</li>
+ *   <li><b>exit 0 / other</b> &rarr; continue to the next hook (allow so far).</li>
+ *   <li><b>hook crashes</b> &rarr; fail-closed block.</li>
+ * </ul>
+ *
+ * <p>First block wins; else first modify wins; else allow. The {@code match} field on
+ * {@link CliHookEntry} is ignored for prompt hooks (all prompts match).</p>
+ */
+public class CliPromptInterceptor implements PromptInterceptor {
+
+    private final CliHooksConfig config;
+    private final HookCommandRunner runner;
+
+    public CliPromptInterceptor(CliHooksConfig config, HookCommandRunner runner) {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (runner == null) {
+            throw new IllegalArgumentException("runner must not be null");
+        }
+        this.config = config;
+        this.runner = runner;
+    }
+
+    @Override
+    public PromptDecision beforePrompt(String input, AgentContext context) {
+        List<CliHookEntry> hooks = config.getUserPromptSubmit();
+        for (CliHookEntry hook : hooks) {
+            if (hook == null) {
+                continue;
+            }
+            PromptDecision decision = runOne(hook, input);
+            if (decision != null) {
+                return decision;
+            }
+        }
+        return PromptDecision.allow();
+    }
+
+    private PromptDecision runOne(CliHookEntry hook, String input) {
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("input", input == null ? "" : input);
+        String stdinJson = JSON.toJSONString(payload);
+        HookCommandRunner.HookCommandResult result;
+        try {
+            result = runner.run(hook.getCommand(), stdinJson);
+        } catch (Exception e) {
+            return PromptDecision.block("hook '" + hook.getCommand() + "' failed: " + safeMessage(e));
+        }
+        if (result.exitCode == 2) {
+            return PromptDecision.block(reasonFrom(result));
+        }
+        if (result.exitCode != 0) {
+            return null; // soft error: continue
+        }
+        JSONObject json = parseJson(result.stdout);
+        if (json != null) {
+            String decision = json.getString("decision");
+            if ("block".equalsIgnoreCase(decision)) {
+                return PromptDecision.block(json.getString("reason"));
+            }
+            if ("modify".equalsIgnoreCase(decision)) {
+                String modified = json.getString("input");
+                if (modified != null) {
+                    return PromptDecision.modify(modified);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String reasonFrom(HookCommandRunner.HookCommandResult result) {
+        String reason = result.stderr == null ? "" : result.stderr.trim();
+        if (reason.isEmpty()) {
+            reason = result.stdout == null ? "" : result.stdout.trim();
+        }
+        return reason.isEmpty() ? "blocked by prompt hook" : reason;
+    }
+
+    private static JSONObject parseJson(String stdout) {
+        if (stdout == null || stdout.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON.parseObject(stdout);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String safeMessage(Throwable e) {
+        return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+    }
+}

--- a/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliPromptInterceptorTest.java
+++ b/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliPromptInterceptorTest.java
@@ -1,0 +1,71 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import io.github.lnyocly.ai4j.agent.interceptor.PromptDecision;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic tests for {@link CliPromptInterceptor} (UserPromptSubmit external-command bridge)
+ * using the fake runner from {@link CliHookInterceptorTest}. Mirrors the tool-hook bridge tests.
+ */
+public class CliPromptInterceptorTest {
+
+    private static CliHooksConfig promptHooks(String command) {
+        CliHooksConfig c = new CliHooksConfig();
+        c.setUserPromptSubmit(java.util.Collections.singletonList(new CliHookEntry(command, null)));
+        return c;
+    }
+
+    @Test
+    public void exitCode2BlocksAndStdinReceivesPromptJson() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("guard.sh", new HookCommandRunner.HookCommandResult(2, "", "prompt not allowed"));
+        CliPromptInterceptor interceptor = new CliPromptInterceptor(promptHooks("guard.sh"), runner);
+
+        PromptDecision d = interceptor.beforePrompt("drop table users", null);
+
+        assertEquals(PromptDecision.Type.BLOCK, d.getType());
+        assertTrue(d.getReason().contains("prompt not allowed"));
+        assertEquals(1, runner.stdins.size());
+        assertTrue("stdin carries the prompt json", runner.stdins.get(0).contains("drop table users"));
+    }
+
+    @Test
+    public void exitZeroWithBlockDecisionJsonBlocks() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("guard.sh", new HookCommandRunner.HookCommandResult(0,
+                "{\"decision\":\"block\",\"reason\":\"sql injection\"}", ""));
+        PromptDecision d = new CliPromptInterceptor(promptHooks("guard.sh"), runner).beforePrompt("x", null);
+        assertEquals(PromptDecision.Type.BLOCK, d.getType());
+        assertEquals("sql injection", d.getReason());
+    }
+
+    @Test
+    public void exitZeroWithModifyDecisionRewritesPrompt() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("norm.sh", new HookCommandRunner.HookCommandResult(0,
+                "{\"decision\":\"modify\",\"input\":\"sanitized prompt\"}", ""));
+        PromptDecision d = new CliPromptInterceptor(promptHooks("norm.sh"), runner).beforePrompt("x", null);
+        assertEquals(PromptDecision.Type.MODIFY, d.getType());
+        assertEquals("sanitized prompt", d.getModifiedInput());
+    }
+
+    @Test
+    public void exitZeroWithNoDecisionAllows() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("noop.sh", new HookCommandRunner.HookCommandResult(0, "ok", ""));
+        PromptDecision d = new CliPromptInterceptor(promptHooks("noop.sh"), runner).beforePrompt("hello", null);
+        assertEquals(PromptDecision.Type.ALLOW, d.getType());
+    }
+
+    @Test
+    public void hookThatThrowsBlocksFailClosed() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.toThrow = new RuntimeException("command not found");
+        PromptDecision d = new CliPromptInterceptor(promptHooks("broken.sh"), runner).beforePrompt("hello", null);
+        assertEquals(PromptDecision.Type.BLOCK, d.getType());
+        assertTrue(d.getReason().contains("command not found"));
+    }
+}

--- a/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
+++ b/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
@@ -18,6 +18,7 @@ import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.coding.definition.BuiltInCodingAgentDefinitions;
 import io.github.lnyocly.ai4j.coding.definition.CodingAgentDefinitionRegistry;
 import io.github.lnyocly.ai4j.coding.delegate.CodingDelegateToolExecutor;
@@ -67,6 +68,7 @@ public class CodingAgentBuilder {
     private AgentToolRegistry toolRegistry;
     private ToolExecutor toolExecutor;
     private ToolInterceptor toolInterceptor;
+    private PromptInterceptor promptInterceptor;
     private ExtensionRegistry extensionRegistry;
     private ExtensionAgentTools extensionTools;
     private CodingAgentDefinitionRegistry definitionRegistry;
@@ -128,6 +130,11 @@ public class CodingAgentBuilder {
 
     public CodingAgentBuilder toolInterceptor(ToolInterceptor toolInterceptor) {
         this.toolInterceptor = toolInterceptor;
+        return this;
+    }
+
+    public CodingAgentBuilder promptInterceptor(PromptInterceptor promptInterceptor) {
+        this.promptInterceptor = promptInterceptor;
         return this;
     }
 
@@ -336,6 +343,7 @@ public class CodingAgentBuilder {
                 .toolRegistry(resolvedToolRegistry)
                 .toolExecutor(resolvedToolExecutor)
                 .toolInterceptor(toolInterceptor)
+                .promptInterceptor(promptInterceptor)
                 .temperature(temperature)
                 .topP(topP)
                 .maxOutputTokens(maxOutputTokens)

--- a/docs-site/docs/agent/tool-interceptor.md
+++ b/docs-site/docs/agent/tool-interceptor.md
@@ -2,12 +2,15 @@
 sidebar_position: 11
 ---
 
-# Tool Interceptor (block / modify / route-to-sandbox)
+# Interception Hooks (tool + prompt: block / modify / route-to-sandbox)
 
-`ToolInterceptor` is the **control-flow** hook — the Claude-Code / pi "PreToolUse" interception
-capability, in-process. It runs before a tool executes and the runtime honors its decision. This is
-distinct from the observe-only [lifecycle hooks](/docs/agent/plugin-lifecycle-hooks) (which only
-notify); an interceptor can veto, rewrite, or redirect a tool call.
+ai4j has two control-flow hook interfaces — the Claude-Code / pi interception capability, in-process.
+They run before the relevant action and the runtime honors the decision. This is distinct from the
+observe-only [lifecycle hooks](/docs/agent/plugin-lifecycle-hooks) (which only notify); an interceptor
+can veto, rewrite, or redirect.
+
+- **`ToolInterceptor`** — before a tool executes (Claude Code "PreToolUse"). Can block / modify / route to sandbox.
+- **`PromptInterceptor`** — before the user's input reaches the model (Claude Code "UserPromptSubmit"). Can block / modify the prompt (guardrails, injection defense, PII redaction, prefix injection).
 
 This is the layer library users need to build policy, safety, or prompt-shaping into their own agent
 systems. It aligns ai4j with pi and Claude Code, and one decision — `routeTo` — surpasses them.
@@ -83,6 +86,26 @@ Agent agent = Agents.react()
 The runtime creates a sandbox session from the spec, runs the command, and feeds
 `SANDBOX_RESULT: {"exitCode":0,"stdout":"..."}` back to the model. The interceptor owns the
 tool→command mapping (it knows its tools); the runtime owns session creation/execution.
+
+## Prompt interception (UserPromptSubmit)
+
+`PromptInterceptor` runs before the user's input is committed to the conversation — block a harmful
+prompt or rewrite it before the model sees it.
+
+```java
+Agent agent = Agents.react()
+        .anthropicMessages(key, baseUrl).model("glm-5.1")
+        .promptInterceptor((input, ctx) -> {
+            if (looksLikeInjection(input)) {
+                return PromptDecision.block("possible prompt injection");
+            }
+            return PromptDecision.allow();
+        })
+        .build();
+```
+
+`PromptDecision` mirrors `ToolCallDecision`: `allow()` / `block(reason)` / `modify(newInput)`. On
+`block`, the agent returns immediately with `PROMPT_BLOCKED: <reason>` and the model is never called.
 
 ## Interceptor vs observe-only lifecycle hooks
 


### PR DESCRIPTION
The second control-flow interception event, parallel to the tool interceptor. Before the user's input reaches the model, a `PromptInterceptor` can block it or rewrite it — prompt guardrails, injection defense, PII redaction, prefix injection.

## What

**Library** (`ai4j-agent`, `io.github.lnyocly.ai4j.agent.interceptor`):
- `PromptInterceptor.beforePrompt(input, ctx) -> PromptDecision`
- `PromptDecision`: `allow` / `block(reason)` / `modify(newInput)`
- Wired into `BaseAgentRuntime.runInternal` before the input enters memory: `block` returns `PROMPT_BLOCKED` without calling the model; `modify` replaces the input; `allow` proceeds. Non-String (multimodal) inputs skip the interceptor.

**CLI** (`ai4j-cli`, `io.github.lnyocly.ai4j.cli.hook`):
- `CliPromptInterceptor`: bridges `PromptInterceptor` to external commands (`userPromptSubmit` config), mirroring `CliHookInterceptor` — exit 2 / JSON decision / fail-closed, same semantics.
- `CliHooksConfig.userPromptSubmit` field (auto-parsed from workspace JSON).
- `CodingAgentBuilder.promptInterceptor` (ai4j-coding enabler) + factory wires both tool + prompt hooks.

**Docs**: `tool-interceptor.md` retitled to 'Interception Hooks (tool + prompt)' + a UserPromptSubmit section.

## Why

PreToolUse (#151) covered tool calls; UserPromptSubmit covers the other high-value interception point (the prompt itself). PostToolUse/Stop are mostly observe (already covered by lifecycle hooks). Library users + CLI end users (file-configured) both get it.

## Verification

4 library tests (block stops before model, modify rewrites the input the model sees, allow, none==allow) + 5 CLI bridge tests (exit-2 block, JSON block/modify, allow, fail-closed). agent+coding+cli regression **315 tests, 0 failures**. `npm --prefix docs-site run build` exit 0. `git diff --check` clean.