### PR TITLE
feat(agent+cli): complete hook event coverage (PostToolUse + observe bridge)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -12,6 +12,7 @@ import io.github.lnyocly.ai4j.agent.event.AgentEventPublisher;
 import io.github.lnyocly.ai4j.agent.extension.ExtensionAgentTools;
 import io.github.lnyocly.ai4j.agent.extension.ExtensionGuardrailToolExecutor;
 import io.github.lnyocly.ai4j.agent.lifecycle.AgentLifecycleHookDispatcher;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleHook;
 import io.github.lnyocly.ai4j.agent.memory.AgentMemory;
 import io.github.lnyocly.ai4j.agent.memory.InMemoryAgentMemory;
 import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
@@ -69,6 +70,7 @@ public class AgentBuilder {
     private ToolInterceptor toolInterceptor;
     private PromptInterceptor promptInterceptor;
     private SandboxProvider sandboxProvider;
+    private final List<AgentLifecycleHook> additionalLifecycleHooks = new ArrayList<AgentLifecycleHook>();
     private CodeExecutor codeExecutor;
     private Supplier<AgentMemory> memorySupplier;
     private AgentOptions options;
@@ -262,6 +264,17 @@ public class AgentBuilder {
         return this;
     }
 
+    /**
+     * Registers an additional observe-only lifecycle hook without going through the extension SPI.
+     * Fixes the long-standing "hooks need an extension package" ergonomics gap for simple cases.
+     */
+    public AgentBuilder lifecycleHook(AgentLifecycleHook hook) {
+        if (hook != null) {
+            additionalLifecycleHooks.add(hook);
+        }
+        return this;
+    }
+
     public AgentBuilder sandboxProvider(SandboxProvider sandboxProvider) {
         this.sandboxProvider = sandboxProvider;
         return this;
@@ -430,9 +443,14 @@ public class AgentBuilder {
         if (modelClient == null) {
             throw new IllegalStateException("modelClient is required");
         }
-        AgentLifecycleHookDispatcher lifecycleHooks = extensionTools == null
+        List<AgentLifecycleHook> mergedHooks = new ArrayList<AgentLifecycleHook>();
+        if (extensionTools != null && extensionTools.getLifecycleHooks() != null) {
+            mergedHooks.addAll(extensionTools.getLifecycleHooks());
+        }
+        mergedHooks.addAll(additionalLifecycleHooks);
+        AgentLifecycleHookDispatcher lifecycleHooks = mergedHooks.isEmpty()
                 ? AgentLifecycleHookDispatcher.empty()
-                : new AgentLifecycleHookDispatcher(extensionTools.getLifecycleHooks());
+                : new AgentLifecycleHookDispatcher(mergedHooks);
 
         AgentContext context = AgentContext.builder()
                 .modelClient(modelClient)

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptor.java
@@ -29,4 +29,15 @@ public interface ToolInterceptor {
      * (same as an executor failure).
      */
     ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context);
+
+    /**
+     * Called after the tool ran, with its output. PostToolUse interception (Claude Code
+     * "PostToolUse"): return {@link ToolCallDecision#block(String)} to replace the result with a
+     * blocked message fed back to the model (e.g. output leaked a secret), or
+     * {@link ToolCallDecision#allow()} to use the result as-is. Default is allow (no-op), so this
+     * stays a functional interface for {@code beforeToolCall} lambdas.
+     */
+    default ToolCallDecision afterToolCall(AgentToolCall call, String output, AgentContext context) {
+        return ToolCallDecision.allow();
+    }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -445,7 +445,7 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
         final AgentToolCall callToRun = effectiveCall;
         try {
             dispatchLifecycle(context, AgentLifecycleEventType.BEFORE_TOOL_CALL, step == null ? 0 : step, callToRun == null ? null : callToRun.getName(), callToRun);
-            return AgentToolExecutionScope.runWithEmitter(new AgentToolExecutionScope.EventEmitter() {
+            String output = AgentToolExecutionScope.runWithEmitter(new AgentToolExecutionScope.EventEmitter() {
                 @Override
                 public void emit(AgentEventType type, String message, Object payload) {
                     publish(context, listener, type, step == null ? 0 : step, message, payload, runId, sessionId, turnId);
@@ -456,6 +456,14 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
                     return executor.execute(callToRun);
                 }
             });
+            // PostToolUse interception: a hook may veto the result (e.g. output leaked a secret).
+            if (interceptor != null) {
+                ToolCallDecision after = interceptor.afterToolCall(callToRun, output, context);
+                if (after != null && after.getType() == ToolCallDecision.Type.BLOCK) {
+                    return buildBlockedOutput(callToRun, after.getReason());
+                }
+            }
+            return output;
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
             throw interruptedException;

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
@@ -2,6 +2,7 @@ package io.github.lnyocly.ai4j.agent.interceptor;
 
 import com.alibaba.fastjson2.JSON;
 import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentContext;
 import io.github.lnyocly.ai4j.agent.AgentResult;
 import io.github.lnyocly.ai4j.agent.Agents;
 import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
@@ -156,5 +157,40 @@ public class ToolInterceptorTest {
         agent.newSession().run("do the thing");
 
         assertEquals("no interceptor => original call runs", 1, exec.executed.size());
+    }
+
+    @Test
+    public void afterToolCallBlockReplacesTheResultFedBackToModel() throws Exception {
+        AgentToolCall requested = call("{\"x\":1}");
+        ScriptedModelClient model = new ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(requested)).build(),
+                AgentModelResult.builder().outputText("done").build()));
+        RecordingExecutor exec = new RecordingExecutor();
+
+        // allow before, block after (e.g. output leaked a secret). Anonymous class overrides the
+        // default afterToolCall in addition to the abstract beforeToolCall.
+        Agent agent = Agents.react()
+                .modelClient(model)
+                .model("test-model")
+                .toolExecutor(exec)
+                .toolRegistry(registry())
+                .toolInterceptor(new ToolInterceptor() {
+                    @Override
+                    public ToolCallDecision beforeToolCall(AgentToolCall c, AgentContext ctx) {
+                        return ToolCallDecision.allow();
+                    }
+                    @Override
+                    public ToolCallDecision afterToolCall(AgentToolCall c, String output, AgentContext ctx) {
+                        return ToolCallDecision.block("output leaked a secret");
+                    }
+                })
+                .build();
+        agent.newSession().run("do the thing");
+
+        assertEquals("tool must still run (block is post-execution)", 1, exec.executed.size());
+        assertTrue("model must be invoked again after the post-block", model.prompts.size() >= 2);
+        String fedBack = JSON.toJSONString(model.prompts.get(1));
+        assertTrue("blocked result must be fed back: " + fedBack,
+                fedBack.contains("TOOL_BLOCKED") && fedBack.contains("leaked a secret"));
     }
 }

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/factory/DefaultCodingCliAgentFactory.java
@@ -6,6 +6,7 @@ import io.github.lnyocly.ai4j.cli.command.CodeCommandOptions;
 import io.github.lnyocly.ai4j.cli.config.CliWorkspaceConfig;
 import io.github.lnyocly.ai4j.cli.hook.CliHookInterceptor;
 import io.github.lnyocly.ai4j.cli.hook.CliPromptInterceptor;
+import io.github.lnyocly.ai4j.cli.hook.CliLifecycleHookBridge;
 import io.github.lnyocly.ai4j.cli.hook.CliHooksConfig;
 import io.github.lnyocly.ai4j.cli.hook.ProcessHookCommandRunner;
 import io.github.lnyocly.ai4j.cli.mcp.CliMcpRuntimeManager;
@@ -310,11 +311,14 @@ public class DefaultCodingCliAgentFactory implements CodingCliAgentFactory {
             return;
         }
         CliHooksConfig hooks = workspaceConfig.getHooks();
-        if (!hooks.getPreToolUse().isEmpty()) {
+        if (!hooks.getPreToolUse().isEmpty() || !hooks.getPostToolUse().isEmpty()) {
             builder.toolInterceptor(new CliHookInterceptor(hooks, new ProcessHookCommandRunner()));
         }
         if (hooks.hasPromptHooks()) {
             builder.promptInterceptor(new CliPromptInterceptor(hooks, new ProcessHookCommandRunner()));
+        }
+        if (hooks.hasObserveHooks()) {
+            builder.lifecycleHook(new CliLifecycleHookBridge(hooks, new ProcessHookCommandRunner()));
         }
     }
 

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptor.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHookInterceptor.java
@@ -46,12 +46,33 @@ public class CliHookInterceptor implements ToolInterceptor {
     @Override
     public ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context) {
         String toolName = call == null ? null : call.getName();
+        String stdinJson = call == null ? "{}" : JSON.toJSONString(call);
         List<CliHookEntry> hooks = config.getPreToolUse();
         for (CliHookEntry hook : hooks) {
             if (hook == null || !hook.matches(toolName)) {
                 continue;
             }
-            ToolCallDecision decision = runOne(hook, call);
+            ToolCallDecision decision = runOne(hook, stdinJson, call);
+            if (decision != null) {
+                return decision;
+            }
+        }
+        return ToolCallDecision.allow();
+    }
+
+    @Override
+    public ToolCallDecision afterToolCall(AgentToolCall call, String output, AgentContext context) {
+        String toolName = call == null ? null : call.getName();
+        java.util.Map<String, Object> payload = new java.util.LinkedHashMap<String, Object>();
+        payload.put("call", call);
+        payload.put("output", output == null ? "" : output);
+        String stdinJson = JSON.toJSONString(payload);
+        List<CliHookEntry> hooks = config.getPostToolUse();
+        for (CliHookEntry hook : hooks) {
+            if (hook == null || !hook.matches(toolName)) {
+                continue;
+            }
+            ToolCallDecision decision = runOne(hook, stdinJson, call);
             if (decision != null) {
                 return decision;
             }
@@ -60,8 +81,7 @@ public class CliHookInterceptor implements ToolInterceptor {
     }
 
     /** Runs one hook; returns a non-null decision to short-circuit, or null to continue. */
-    private ToolCallDecision runOne(CliHookEntry hook, AgentToolCall call) {
-        String stdinJson = call == null ? "{}" : JSON.toJSONString(call);
+    private ToolCallDecision runOne(CliHookEntry hook, String stdinJson, AgentToolCall call) {
         HookCommandRunner.HookCommandResult result;
         try {
             result = runner.run(hook.getCommand(), stdinJson);

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliHooksConfig.java
@@ -24,7 +24,12 @@ import java.util.List;
 public class CliHooksConfig {
 
     private List<CliHookEntry> preToolUse;
+    private List<CliHookEntry> postToolUse;
     private List<CliHookEntry> userPromptSubmit;
+    private List<CliHookEntry> stop;
+    private List<CliHookEntry> preCompact;
+    private List<CliHookEntry> sessionStart;
+    private List<CliHookEntry> sessionEnd;
 
     public CliHooksConfig() {
     }
@@ -45,12 +50,65 @@ public class CliHooksConfig {
         this.userPromptSubmit = userPromptSubmit == null ? null : new ArrayList<CliHookEntry>(userPromptSubmit);
     }
 
+    public List<CliHookEntry> getPostToolUse() {
+        return postToolUse == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(postToolUse);
+    }
+
+    public void setPostToolUse(List<CliHookEntry> postToolUse) {
+        this.postToolUse = postToolUse == null ? null : new ArrayList<CliHookEntry>(postToolUse);
+    }
+
+    public List<CliHookEntry> getStop() {
+        return stop == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(stop);
+    }
+
+    public void setStop(List<CliHookEntry> stop) {
+        this.stop = stop == null ? null : new ArrayList<CliHookEntry>(stop);
+    }
+
+    public List<CliHookEntry> getPreCompact() {
+        return preCompact == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(preCompact);
+    }
+
+    public void setPreCompact(List<CliHookEntry> preCompact) {
+        this.preCompact = preCompact == null ? null : new ArrayList<CliHookEntry>(preCompact);
+    }
+
+    public List<CliHookEntry> getSessionStart() {
+        return sessionStart == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(sessionStart);
+    }
+
+    public void setSessionStart(List<CliHookEntry> sessionStart) {
+        this.sessionStart = sessionStart == null ? null : new ArrayList<CliHookEntry>(sessionStart);
+    }
+
+    public List<CliHookEntry> getSessionEnd() {
+        return sessionEnd == null ? Collections.<CliHookEntry>emptyList() : new ArrayList<CliHookEntry>(sessionEnd);
+    }
+
+    public void setSessionEnd(List<CliHookEntry> sessionEnd) {
+        this.sessionEnd = sessionEnd == null ? null : new ArrayList<CliHookEntry>(sessionEnd);
+    }
+
     public boolean isEmpty() {
         return (preToolUse == null || preToolUse.isEmpty())
-                && (userPromptSubmit == null || userPromptSubmit.isEmpty());
+                && (postToolUse == null || postToolUse.isEmpty())
+                && (userPromptSubmit == null || userPromptSubmit.isEmpty())
+                && (stop == null || stop.isEmpty())
+                && (preCompact == null || preCompact.isEmpty())
+                && (sessionStart == null || sessionStart.isEmpty())
+                && (sessionEnd == null || sessionEnd.isEmpty());
     }
 
     public boolean hasPromptHooks() {
         return userPromptSubmit != null && !userPromptSubmit.isEmpty();
+    }
+
+    /** Observe/side-effect events routed through the lifecycle hook bridge. */
+    public boolean hasObserveHooks() {
+        return (stop != null && !stop.isEmpty())
+                || (preCompact != null && !preCompact.isEmpty())
+                || (sessionStart != null && !sessionStart.isEmpty())
+                || (sessionEnd != null && !sessionEnd.isEmpty());
     }
 }

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliLifecycleHookBridge.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/hook/CliLifecycleHookBridge.java
@@ -1,0 +1,80 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleHook;
+
+import java.util.List;
+
+/**
+ * Bridges observe-only lifecycle events to external shell commands — covers the Claude-Code events
+ * that are side-effects, not decisions: {@code stop} (AFTER_TURN), {@code preCompact} (ON_COMPACT),
+ * {@code sessionStart}/{@code sessionEnd}. One component, config-driven, so adding observe events
+ * is a config-line, not new code.
+ *
+ * <p>Registered as an {@link AgentLifecycleHook} (now possible directly via
+ * {@code AgentBuilder.lifecycleHook(...)}). Side-effect only: commands run with the event JSON on
+ * stdin, output is ignored, and errors are swallowed — an observe hook must never break the run.</p>
+ *
+ * <p>PostToolUse is NOT here: it's an interception event (can block feedback) and lives on
+ * {@link CliHookInterceptor#afterToolCall}.</p>
+ */
+public class CliLifecycleHookBridge implements AgentLifecycleHook {
+
+    private final CliHooksConfig config;
+    private final HookCommandRunner runner;
+
+    public CliLifecycleHookBridge(CliHooksConfig config, HookCommandRunner runner) {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (runner == null) {
+            throw new IllegalArgumentException("runner must not be null");
+        }
+        this.config = config;
+        this.runner = runner;
+    }
+
+    @Override
+    public String name() {
+        return "cli-lifecycle-hook-bridge";
+    }
+
+    @Override
+    public void onEvent(AgentLifecycleEvent event) {
+        if (event == null || event.getType() == null) {
+            return;
+        }
+        List<CliHookEntry> hooks = hooksFor(event.getType());
+        if (hooks == null || hooks.isEmpty()) {
+            return;
+        }
+        String stdinJson = JSON.toJSONString(event);
+        for (CliHookEntry hook : hooks) {
+            if (hook == null || hook.getCommand() == null || hook.getCommand().trim().isEmpty()) {
+                continue;
+            }
+            try {
+                runner.run(hook.getCommand(), stdinJson);
+            } catch (Exception ignored) {
+                // observe hooks must not break the run; swallow
+            }
+        }
+    }
+
+    private List<CliHookEntry> hooksFor(AgentLifecycleEventType type) {
+        switch (type) {
+            case AFTER_TURN:
+                return config.getStop();
+            case ON_COMPACT:
+                return config.getPreCompact();
+            case SESSION_START:
+                return config.getSessionStart();
+            case SESSION_END:
+                return config.getSessionEnd();
+            default:
+                return null;
+        }
+    }
+}

--- a/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliLifecycleHookBridgeTest.java
+++ b/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/hook/CliLifecycleHookBridgeTest.java
@@ -1,0 +1,81 @@
+package io.github.lnyocly.ai4j.cli.hook;
+
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic tests for {@link CliLifecycleHookBridge} — the generic observe bridge that covers
+ * stop / preCompact / sessionStart / sessionEnd via the lifecycle hook. Verifies each event maps to
+ * the right configured command, unrelated events are skipped, and a crashing command is swallowed.
+ */
+public class CliLifecycleHookBridgeTest {
+
+    private static CliHooksConfig config(String key, String command) {
+        CliHooksConfig c = new CliHooksConfig();
+        CliHookEntry entry = new CliHookEntry(command, null);
+        switch (key) {
+            case "stop": c.setStop(Collections.singletonList(entry)); break;
+            case "preCompact": c.setPreCompact(Collections.singletonList(entry)); break;
+            case "sessionStart": c.setSessionStart(Collections.singletonList(entry)); break;
+            case "sessionEnd": c.setSessionEnd(Collections.singletonList(entry)); break;
+            default: throw new IllegalArgumentException(key);
+        }
+        return c;
+    }
+
+    private static AgentLifecycleEvent event(AgentLifecycleEventType type) {
+        return AgentLifecycleEvent.builder(type).runtime("test").step(0).build();
+    }
+
+    @Test
+    public void afterTurnMapsToStopCommand() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("on-stop.sh", new HookCommandRunner.HookCommandResult(0, "ok", ""));
+        new CliLifecycleHookBridge(config("stop", "on-stop.sh"), runner).onEvent(event(AgentLifecycleEventType.AFTER_TURN));
+
+        assertEquals(1, runner.stdins.size());
+        assertTrue(runner.stdins.get(0).contains("AFTER_TURN"));
+    }
+
+    @Test
+    public void eachEventMapsToItsOwnCommand() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("compact.sh", new HookCommandRunner.HookCommandResult(0, "", ""));
+        runner.byCommand.put("start.sh", new HookCommandRunner.HookCommandResult(0, "", ""));
+        CliHooksConfig c = new CliHooksConfig();
+        c.setPreCompact(Collections.singletonList(new CliHookEntry("compact.sh", null)));
+        c.setSessionStart(Collections.singletonList(new CliHookEntry("start.sh", null)));
+        CliLifecycleHookBridge bridge = new CliLifecycleHookBridge(c, runner);
+
+        bridge.onEvent(event(AgentLifecycleEventType.ON_COMPACT));
+        bridge.onEvent(event(AgentLifecycleEventType.SESSION_START));
+        // SESSION_END has no config -> no command
+        bridge.onEvent(event(AgentLifecycleEventType.SESSION_END));
+
+        assertEquals(2, runner.stdins.size());
+    }
+
+    @Test
+    public void unrelatedEventsAreSkipped() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.byCommand.put("on-stop.sh", new HookCommandRunner.HookCommandResult(0, "", ""));
+        new CliLifecycleHookBridge(config("stop", "on-stop.sh"), runner)
+                .onEvent(event(AgentLifecycleEventType.BEFORE_MODEL_REQUEST));
+        assertEquals("events without configured hooks must not run a command", 0, runner.stdins.size());
+    }
+
+    @Test
+    public void crashingCommandIsSwallowed() {
+        CliHookInterceptorTest.FakeRunner runner = new CliHookInterceptorTest.FakeRunner();
+        runner.toThrow = new RuntimeException("boom");
+        // must not throw — an observe hook must not break the run
+        new CliLifecycleHookBridge(config("stop", "broken.sh"), runner).onEvent(event(AgentLifecycleEventType.AFTER_TURN));
+        assertEquals(1, runner.stdins.size());
+    }
+}

--- a/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
+++ b/ai4j-coding/src/main/java/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.java
@@ -19,6 +19,7 @@ import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleHook;
 import io.github.lnyocly.ai4j.coding.definition.BuiltInCodingAgentDefinitions;
 import io.github.lnyocly.ai4j.coding.definition.CodingAgentDefinitionRegistry;
 import io.github.lnyocly.ai4j.coding.delegate.CodingDelegateToolExecutor;
@@ -69,6 +70,7 @@ public class CodingAgentBuilder {
     private ToolExecutor toolExecutor;
     private ToolInterceptor toolInterceptor;
     private PromptInterceptor promptInterceptor;
+    private final List<AgentLifecycleHook> additionalLifecycleHooks = new ArrayList<AgentLifecycleHook>();
     private ExtensionRegistry extensionRegistry;
     private ExtensionAgentTools extensionTools;
     private CodingAgentDefinitionRegistry definitionRegistry;
@@ -135,6 +137,13 @@ public class CodingAgentBuilder {
 
     public CodingAgentBuilder promptInterceptor(PromptInterceptor promptInterceptor) {
         this.promptInterceptor = promptInterceptor;
+        return this;
+    }
+
+    public CodingAgentBuilder lifecycleHook(AgentLifecycleHook hook) {
+        if (hook != null) {
+            additionalLifecycleHooks.add(hook);
+        }
         return this;
     }
 
@@ -333,6 +342,9 @@ public class CodingAgentBuilder {
         AgentBuilder delegate = new AgentBuilder();
         if (runtime != null) {
             delegate.runtime(runtime);
+        }
+        for (AgentLifecycleHook hook : additionalLifecycleHooks) {
+            delegate.lifecycleHook(hook);
         }
         Agent agent = delegate
                 .modelClient(modelClient)


### PR DESCRIPTION
Completes the Claude-Code-equivalent hook event coverage. One interception event (PostToolUse) + one generic observe bridge (stop/preCompact/sessionStart/sessionEnd) — the bridge also fixes the long-standing lifecycle-hook registration ergonomics gap.

## What

**Library** (`ai4j-agent`):
- `ToolInterceptor.afterToolCall` (default method) → PostToolUse interception. Runtime calls it after the tool runs; if it returns `block`, the result is replaced with `TOOL_BLOCKED` fed back to the model (e.g. output leaked a secret). Functional interface preserved (still 1 abstract method).
- `AgentBuilder.lifecycleHook(AgentLifecycleHook)` → register observe hooks directly, no extension SPI. Closes the ergonomics gap I flagged earlier.

**CLI** (`ai4j-cli`, `io.github.lnyocly.ai4j.cli.hook`):
- `CliHookInterceptor.afterToolCall` → `postToolUse` config → external command (exit 2 blocks the result).
- `CliLifecycleHookBridge` → ONE generic `AgentLifecycleHook` that routes AFTER_TURN/ON_COMPACT/SESSION_START/SESSION_END to `stop`/`preCompact`/`sessionStart`/`sessionEnd` commands. Side-effect only; errors swallowed (observe hooks must not break the run).
- `CliHooksConfig`: postToolUse, stop, preCompact, sessionStart, sessionEnd.
- `CodingAgentBuilder.lifecycleHook`; factory wires tool + prompt + observe bridges.

## Events now covered (all file-configurable end-user)

| Event | Type | Mechanism |
|---|---|---|
| PreToolUse | interception (block/modify/routeTo) | ToolInterceptor (#151) |
| PostToolUse | interception (block result) | ToolInterceptor.afterToolCall (this PR) |
| UserPromptSubmit | interception (block/modify prompt) | PromptInterceptor (#155) |
| Stop | observe | bridge → AFTER_TURN |
| PreCompact | observe | bridge → ON_COMPACT |
| SessionStart / SessionEnd | observe | bridge → SESSION_START/END |

## Verification

+1 library test (afterToolCall block replaces result fed to model) + 4 observe-bridge tests (event→command mapping, unrelated skipped, crash swallowed). agent+coding+cli regression **319 tests, 0 failures**. `git diff --check` clean.