### PR TITLE
feat(agent): AgentHooks facade — named per-event sugar over interceptors

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -33,6 +33,7 @@ import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
+import io.github.lnyocly.ai4j.agent.interceptor.AgentHooks;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
@@ -261,6 +262,21 @@ public class AgentBuilder {
 
     public AgentBuilder promptInterceptor(PromptInterceptor promptInterceptor) {
         this.promptInterceptor = promptInterceptor;
+        return this;
+    }
+
+    /**
+     * Convenience facade over the typed interceptors — pi-like "one place, all events". Configure
+     * preToolUse / postToolUse / userPromptSubmit / stop / preCompact / sessionStart / sessionEnd
+     * with typed lambdas; they compose into the runtime's interceptor slots. Pure sugar over
+     * {@link #toolInterceptor}/{@link #promptInterceptor}/{@link #lifecycleHook}.
+     */
+    public AgentBuilder hooks(java.util.function.Consumer<AgentHooks> config) {
+        if (config != null) {
+            AgentHooks hooks = new AgentHooks();
+            config.accept(hooks);
+            hooks.applyTo(this);
+        }
         return this;
     }
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooks.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooks.java
@@ -1,0 +1,187 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.AgentBuilder;
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleHook;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Named per-event facade over the typed interceptors — the pi-like "one place, all events,
+ * discoverable" sugar. Each method accepts the right typed functional interface (compile-time
+ * safe), and {@link #applyTo} composes them into the single interceptor slots the runtime exposes.
+ *
+ * <p>This is pure sugar: the underlying {@link ToolInterceptor} / {@link PromptInterceptor} /
+ * {@code AgentLifecycleHook} stay the source of truth. Use via {@code AgentBuilder.hooks(...)}:</p>
+ * <pre>
+ * Agents.react()
+ *     .hooks(h -&gt; h
+ *         .preToolUse((call, ctx) -&gt; isDangerous(call) ? ToolCallDecision.block("no") : ToolCallDecision.allow())
+ *         .postToolUse((call, out, ctx) -&gt; leaks(out) ? ToolCallDecision.block("secret") : ToolCallDecision.allow())
+ *         .userPromptSubmit((input, ctx) -&gt; PromptDecision.allow())
+ *         .stop(ev -&gt; metrics.turnEnd())
+ *         .sessionStart(ev -&gt; log.info("session start")))
+ *     ...
+ * </pre>
+ *
+ * <p>Semantics: for interception events the first non-allow decision wins (pre/post/prompt); observe
+ * handlers all run (side-effects). Pre and Post compose into one {@link ToolInterceptor} (the runtime
+ * takes one), so you can register both without conflict.</p>
+ */
+public final class AgentHooks {
+
+    private final List<ToolInterceptor> preToolUse = new ArrayList<ToolInterceptor>();
+    private final List<PostToolUseHook> postToolUse = new ArrayList<PostToolUseHook>();
+    private final List<PromptInterceptor> userPromptSubmit = new ArrayList<PromptInterceptor>();
+    private final Map<AgentLifecycleEventType, List<ObserveHook>> observe = new LinkedHashMap<AgentLifecycleEventType, List<ObserveHook>>();
+
+    public AgentHooks preToolUse(ToolInterceptor hook) {
+        if (hook != null) {
+            preToolUse.add(hook);
+        }
+        return this;
+    }
+
+    public AgentHooks postToolUse(PostToolUseHook hook) {
+        if (hook != null) {
+            postToolUse.add(hook);
+        }
+        return this;
+    }
+
+    public AgentHooks userPromptSubmit(PromptInterceptor hook) {
+        if (hook != null) {
+            userPromptSubmit.add(hook);
+        }
+        return this;
+    }
+
+    public AgentHooks stop(ObserveHook hook) {
+        return observe(AgentLifecycleEventType.AFTER_TURN, hook);
+    }
+
+    public AgentHooks preCompact(ObserveHook hook) {
+        return observe(AgentLifecycleEventType.ON_COMPACT, hook);
+    }
+
+    public AgentHooks sessionStart(ObserveHook hook) {
+        return observe(AgentLifecycleEventType.SESSION_START, hook);
+    }
+
+    public AgentHooks sessionEnd(ObserveHook hook) {
+        return observe(AgentLifecycleEventType.SESSION_END, hook);
+    }
+
+    private AgentHooks observe(AgentLifecycleEventType type, ObserveHook hook) {
+        if (hook != null) {
+            List<ObserveHook> list = observe.get(type);
+            if (list == null) {
+                list = new ArrayList<ObserveHook>();
+                observe.put(type, list);
+            }
+            list.add(hook);
+        }
+        return this;
+    }
+
+    /** Apply the collected hooks to the builder (composing into the runtime's interceptor slots). */
+    public void applyTo(AgentBuilder builder) {
+        if (builder == null) {
+            return;
+        }
+        if (!preToolUse.isEmpty() || !postToolUse.isEmpty()) {
+            builder.toolInterceptor(composeToolInterceptor());
+        }
+        if (!userPromptSubmit.isEmpty()) {
+            builder.promptInterceptor(composePromptInterceptor());
+        }
+        if (!observe.isEmpty()) {
+            builder.lifecycleHook(composeLifecycleHook());
+        }
+    }
+
+    boolean isEmpty() {
+        return preToolUse.isEmpty() && postToolUse.isEmpty() && userPromptSubmit.isEmpty() && observe.isEmpty();
+    }
+
+    private ToolInterceptor composeToolInterceptor() {
+        final List<ToolInterceptor> pre = new ArrayList<ToolInterceptor>(preToolUse);
+        final List<PostToolUseHook> post = new ArrayList<PostToolUseHook>(postToolUse);
+        return new ToolInterceptor() {
+            @Override
+            public ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context) {
+                for (ToolInterceptor h : pre) {
+                    ToolCallDecision d = h.beforeToolCall(call, context);
+                    if (d != null && d.getType() != ToolCallDecision.Type.ALLOW) {
+                        return d; // first block/modify/routeTo wins
+                    }
+                }
+                return ToolCallDecision.allow();
+            }
+
+            @Override
+            public ToolCallDecision afterToolCall(AgentToolCall call, String output, AgentContext context) {
+                for (PostToolUseHook h : post) {
+                    ToolCallDecision d = h.afterToolCall(call, output, context);
+                    if (d != null && d.getType() == ToolCallDecision.Type.BLOCK) {
+                        return d; // first block wins
+                    }
+                }
+                return ToolCallDecision.allow();
+            }
+        };
+    }
+
+    private PromptInterceptor composePromptInterceptor() {
+        final List<PromptInterceptor> hooks = new ArrayList<PromptInterceptor>(userPromptSubmit);
+        return new PromptInterceptor() {
+            @Override
+            public PromptDecision beforePrompt(String input, AgentContext context) {
+                for (PromptInterceptor h : hooks) {
+                    PromptDecision d = h.beforePrompt(input, context);
+                    if (d != null && d.getType() != PromptDecision.Type.ALLOW) {
+                        return d; // first block/modify wins
+                    }
+                }
+                return PromptDecision.allow();
+            }
+        };
+    }
+
+    private AgentLifecycleHook composeLifecycleHook() {
+        final Map<AgentLifecycleEventType, List<ObserveHook>> snapshot = new LinkedHashMap<AgentLifecycleEventType, List<ObserveHook>>();
+        for (Map.Entry<AgentLifecycleEventType, List<ObserveHook>> e : observe.entrySet()) {
+            snapshot.put(e.getKey(), new ArrayList<ObserveHook>(e.getValue()));
+        }
+        return new AgentLifecycleHook() {
+            @Override
+            public String name() {
+                return "agent-hooks-observe";
+            }
+
+            @Override
+            public void onEvent(AgentLifecycleEvent event) {
+                if (event == null || event.getType() == null) {
+                    return;
+                }
+                List<ObserveHook> hooks = snapshot.get(event.getType());
+                if (hooks == null) {
+                    return;
+                }
+                for (ObserveHook h : hooks) {
+                    try {
+                        h.onEvent(event);
+                    } catch (Exception ignored) {
+                        // an observe hook must not break the run
+                    }
+                }
+            }
+        };
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ObserveHook.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ObserveHook.java
@@ -1,0 +1,14 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
+
+/**
+ * Functional interface for an observe (side-effect) handler — the void notification shape, so the
+ * {@link AgentHooks} facade can accept a lambda for {@code stop} / {@code preCompact} /
+ * {@code sessionStart} / {@code sessionEnd} without implementing the two-method
+ * {@code AgentLifecycleHook} ({@code name()} + {@code onEvent()}).
+ */
+@FunctionalInterface
+public interface ObserveHook {
+    void onEvent(AgentLifecycleEvent event);
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PostToolUseHook.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/PostToolUseHook.java
@@ -1,0 +1,15 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+/**
+ * Functional interface for a PostToolUse handler (the {@link ToolInterceptor#afterToolCall} shape),
+ * so the {@link AgentHooks} facade can accept a lambda for {@code postToolUse} without forcing an
+ * anonymous class. Returns a {@link ToolCallDecision} (use {@link ToolCallDecision#block} to veto
+ * the result, {@link ToolCallDecision#allow} to keep it).
+ */
+@FunctionalInterface
+public interface PostToolUseHook {
+    ToolCallDecision afterToolCall(AgentToolCall call, String output, AgentContext context);
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooksTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooksTest.java
@@ -1,0 +1,98 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link AgentHooks} facade (the pi-like named per-event sugar): preToolUse / postToolUse
+ * compose into one ToolInterceptor, userPromptSubmit into a PromptInterceptor, and observe events
+ * (stop) into a lifecycle hook — all from a single {@code .hooks(...)} call.
+ */
+public class AgentHooksTest {
+
+    private static AgentToolCall toolCall() {
+        return AgentToolCall.builder().name("do_thing").callId("c1").arguments("{\"x\":1}").build();
+    }
+
+    private static ToolInterceptorTest.ScriptedModelClient toolThenFinal() {
+        return new ToolInterceptorTest.ScriptedModelClient(Arrays.asList(
+                AgentModelResult.builder().toolCalls(Collections.singletonList(toolCall())).build(),
+                AgentModelResult.builder().outputText("done").build()));
+    }
+
+    private static ToolInterceptorTest.ScriptedModelClient finalOnly() {
+        return new ToolInterceptorTest.ScriptedModelClient(Collections.singletonList(
+                AgentModelResult.builder().outputText("done").build()));
+    }
+
+    @Test
+    public void preToolUseViaFacadeBlocksTheCall() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = toolThenFinal();
+        ToolInterceptorTest.RecordingExecutor exec = new ToolInterceptorTest.RecordingExecutor();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .toolExecutor(exec).toolRegistry(ToolInterceptorTest.registry())
+                .hooks(h -> h.preToolUse((call, ctx) -> ToolCallDecision.block("vetoed")))
+                .build();
+        agent.newSession().run("do it");
+        assertEquals("preToolUse block must skip the executor", 0, exec.executed.size());
+        assertTrue(JSON.toJSONString(model.prompts.get(1)).contains("TOOL_BLOCKED"));
+    }
+
+    @Test
+    public void postToolUseViaFacadeBlocksTheResult() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = toolThenFinal();
+        ToolInterceptorTest.RecordingExecutor exec = new ToolInterceptorTest.RecordingExecutor();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .toolExecutor(exec).toolRegistry(ToolInterceptorTest.registry())
+                .hooks(h -> h.postToolUse((call, out, ctx) -> ToolCallDecision.block("bad output")))
+                .build();
+        agent.newSession().run("do it");
+        assertEquals("tool still runs (post-block is after execution)", 1, exec.executed.size());
+        assertTrue(JSON.toJSONString(model.prompts.get(1)).contains("TOOL_BLOCKED"));
+    }
+
+    @Test
+    public void userPromptSubmitViaFacadeBlocksBeforeModel() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = finalOnly();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .hooks(h -> h.userPromptSubmit((input, ctx) -> PromptDecision.block("forbidden")))
+                .build();
+        AgentResult result = agent.newSession().run("hello");
+        assertEquals(0, model.prompts.size());
+        assertTrue(result.getOutputText().contains("PROMPT_BLOCKED"));
+    }
+
+    @Test
+    public void stopObserveFiresAndComposesAlongsideInterception() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = toolThenFinal();
+        ToolInterceptorTest.RecordingExecutor exec = new ToolInterceptorTest.RecordingExecutor();
+        final List<AgentLifecycleEvent> stopEvents = new ArrayList<AgentLifecycleEvent>();
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .toolExecutor(exec).toolRegistry(ToolInterceptorTest.registry())
+                .hooks(h -> h
+                        .preToolUse((call, ctx) -> ToolCallDecision.allow())
+                        .stop(ev -> stopEvents.add(ev)))
+                .build();
+        agent.newSession().run("do it");
+        assertEquals("interception (allow) lets the tool run", 1, exec.executed.size());
+        assertTrue("observe (stop) must fire on turn end", !stopEvents.isEmpty());
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ToolInterceptorTest.java
@@ -37,7 +37,7 @@ public class ToolInterceptorTest {
         return AgentToolCall.builder().name("do_thing").callId("c1").arguments(args).build();
     }
 
-    private static AgentToolRegistry registry() {
+    static AgentToolRegistry registry() {
         Tool.Function fn = new Tool.Function();
         fn.setName("do_thing");
         fn.setDescription("does a thing");

--- a/docs-site/docs/agent/tool-interceptor.md
+++ b/docs-site/docs/agent/tool-interceptor.md
@@ -15,6 +15,35 @@ control-flow interfaces plus the existing observe-only [lifecycle hooks](/docs/a
 This is the layer library users need to build policy, safety, or prompt-shaping into their own agent
 systems. It aligns ai4j with pi and Claude Code, and one decision — `routeTo` — surpasses them.
 
+## Quick start: the `hooks` facade (recommended)
+
+One entry point, every event, IDE-discoverable, compile-time typed. `AgentHooks` composes your
+lambdas into the runtime's interceptor slots — no need to remember which interface goes where:
+
+```java
+Agent agent = Agents.react()
+        .anthropicMessages(key, baseUrl).model("glm-5.1")
+        .toolExecutor(executor)
+        .hooks(h -> h
+                .preToolUse((call, ctx)   -> isDangerous(call) ? ToolCallDecision.block("no") : ToolCallDecision.allow())
+                .postToolUse((call, out, ctx) -> leaksSecret(out) ? ToolCallDecision.block("secret") : ToolCallDecision.allow())
+                .userPromptSubmit((input, ctx) -> looksLikeInjection(input) ? PromptDecision.block("injection") : PromptDecision.allow())
+                .stop(ev -> metrics.turnEnd())
+                .sessionStart(ev -> log.info("session start")))
+        .build();
+```
+
+| facade method | event | decision power |
+| --- | --- | --- |
+| `preToolUse` | PreToolUse | allow / block / modify / routeTo |
+| `postToolUse` | PostToolUse | allow / block (the result) |
+| `userPromptSubmit` | UserPromptSubmit | allow / block / modify (the prompt) |
+| `stop` / `preCompact` / `sessionStart` / `sessionEnd` | observe | side-effect only |
+
+Semantics: first non-allow decision wins (pre/post/prompt); observe handlers all run. Pre and Post
+compose into one `ToolInterceptor` so you can register both. The sections below cover the underlying
+interfaces and decisions in depth — use them directly if you prefer.
+
 ## The four decisions
 
 ```java


### PR DESCRIPTION
A pi-like 'one place, all events' facade. `AgentBuilder.hooks(Consumer<AgentHooks>)` lets you register every hook event with a typed lambda from a single discoverable entry point — no need to remember which interface (`toolInterceptor` / `promptInterceptor` / `lifecycleHook`) goes where. Responds to the ergonomic gap vs pi's unified `pi.on(event, handler)` while keeping Java's compile-time type safety.

## What

- **`AgentHooks`** facade: `preToolUse` / `postToolUse` / `userPromptSubmit` / `stop` / `preCompact` / `sessionStart` / `sessionEnd`. Each takes the right typed functional interface (compile-time safe). Composes pre+post into one `ToolInterceptor` (the runtime takes one), `userPromptSubmit` into a `PromptInterceptor`, observe events into one `AgentLifecycleHook`. First non-allow decision wins (interception); observe handlers all run; observe errors swallowed.
- New functional interfaces **`PostToolUseHook`** + **`ObserveHook`** so post/observe accept lambdas without anonymous classes.
- **Pure sugar**: the underlying `ToolInterceptor` / `PromptInterceptor` / `AgentLifecycleHook` stay the source of truth; no runtime change, no type safety lost.

## Why

pi's unified `pi.on(event, handler)` is genuinely more convenient — but it's a TypeScript gift (one function type, flexible return per event). In Java the unified model degrades to `Object` returns + casts (type-unsafe). This facade gives pi-like discoverability (one entry point, all events, IDE autocomplete) without sacrificing Java's compile-time decision safety. End users (CLI file-config) already had this convenience; this extends it to Java embedders.

## Docs

`tool-interceptor.md` gets a 'Quick start: the hooks facade' section as the recommended API (with the event/power table), keeping the deep interface sections below.

## Verification

4 facade tests (preToolUse block, postToolUse block, userPromptSubmit block, stop observe fires + composes alongside interception). ai4j-agent full module **186 tests, 0 failures**. `git diff --check` clean.