### PR TITLE
feat(agent): A2A protocol client (call external agents via Google A2A)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AClient.java
@@ -1,0 +1,189 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Java 8 HTTP client for the Google A2A (Agent2Agent) protocol — lets an ai4j agent call external
+ * A2A agents across frameworks (LangChain, CrewAI, etc.). JDK stdlib only (no new dependency).
+ *
+ * <p>Two operations:</p>
+ * <ul>
+ *   <li>{@link #discover(String)} — GET {@code /.well-known/agent.json} → {@link AgentCard}.</li>
+ *   <li>{@link #sendTask(String, String)} — POST {@code /tasks/send} (JSON-RPC) → response text.</li>
+ * </ul>
+ */
+public class A2AClient {
+
+    private final int connectTimeoutMillis;
+    private final int readTimeoutMillis;
+
+    public A2AClient() {
+        this(10000, 120000);
+    }
+
+    public A2AClient(int connectTimeoutMillis, int readTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+    /** Fetches the AgentCard from {@code baseUrl/.well-known/agent.json}. */
+    public AgentCard discover(String baseUrl) throws IOException {
+        String url = trimSlash(baseUrl) + "/.well-known/agent.json";
+        String body = httpGet(url);
+        return JSON.parseObject(body, AgentCard.class);
+    }
+
+    /**
+     * Sends a message to an A2A agent and extracts the response text from the first artifact's
+     * first text part. Returns the raw text; throws on network/parse errors.
+     */
+    public String sendTask(String baseUrl, String message) throws IOException {
+        String url = trimSlash(baseUrl) + "/tasks/send";
+        Map<String, Object> payload = buildTaskPayload(message);
+        String response = httpPostJson(url, JSON.toJSONString(payload));
+        return extractResponseText(response);
+    }
+
+    static Map<String, Object> buildTaskPayload(String message) {
+        Map<String, Object> part = new LinkedHashMap<String, Object>();
+        part.put("type", "text");
+        part.put("text", message);
+        Map<String, Object> a2aMessage = new LinkedHashMap<String, Object>();
+        a2aMessage.put("role", "user");
+        a2aMessage.put("parts", java.util.Collections.singletonList(part));
+        Map<String, Object> params = new LinkedHashMap<String, Object>();
+        params.put("id", "task-" + UUID.randomUUID());
+        params.put("message", a2aMessage);
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("jsonrpc", "2.0");
+        payload.put("method", "tasks/send");
+        payload.put("params", params);
+        payload.put("id", 1);
+        return payload;
+    }
+
+    /** Extracts the first artifact's first text part from an A2A JSON-RPC response. */
+    static String extractResponseText(String responseJson) {
+        JSONObject root = JSON.parseObject(responseJson);
+        if (root == null) {
+            return "";
+        }
+        JSONObject result = root.getJSONObject("result");
+        if (result == null) {
+            JSONObject error = root.getJSONObject("error");
+            if (error != null) {
+                return "A2A error: " + error.getString("message");
+            }
+            return "";
+        }
+        // Check status for failure
+        JSONObject status = result.getJSONObject("status");
+        if (status != null) {
+            String state = status.getString("state");
+            if (state != null && ("failed".equalsIgnoreCase(state) || "canceled".equalsIgnoreCase(state))) {
+                return "A2A task " + state + ": " + status.getString("message");
+            }
+        }
+        // Extract first artifact text
+        JSONArray artifacts = result.getJSONArray("artifacts");
+        if (artifacts != null && !artifacts.isEmpty()) {
+            JSONObject artifact = artifacts.getJSONObject(0);
+            JSONArray parts = artifact.getJSONArray("parts");
+            if (parts != null && !parts.isEmpty()) {
+                JSONObject part = parts.getJSONObject(0);
+                if (part != null) {
+                    return part.getString("text");
+                }
+            }
+        }
+        return "";
+    }
+
+    private String httpGet(String url) throws IOException {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(connectTimeoutMillis);
+            conn.setReadTimeout(readTimeoutMillis);
+            conn.setRequestProperty("Accept", "application/json");
+            return readBody(conn.getInputStream());
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private String httpPostJson(String url, String json) throws IOException {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(connectTimeoutMillis);
+            conn.setReadTimeout(readTimeoutMillis);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Accept", "application/json");
+            conn.setDoOutput(true);
+            byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+            conn.setRequestProperty("Content-Length", String.valueOf(bytes.length));
+            OutputStream os = conn.getOutputStream();
+            try {
+                os.write(bytes);
+            } finally {
+                os.close();
+            }
+            int status = conn.getResponseCode();
+            String body = readBody(status >= 400 ? conn.getErrorStream() : conn.getInputStream());
+            if (status >= 400) {
+                throw new IOException("A2A HTTP " + status + ": " + body);
+            }
+            return body;
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static String readBody(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[4096];
+        int read;
+        try {
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+        } finally {
+            input.close();
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static String trimSlash(String url) {
+        if (url == null) {
+            return "";
+        }
+        String trimmed = url.trim();
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2ATool.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2ATool.java
@@ -1,0 +1,54 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+
+/**
+ * Wraps an {@link A2AClient} as a {@link ToolExecutor} so an ai4j agent can call an external A2A
+ * agent as a tool. The tool takes a {@code message} argument, sends it to the configured A2A
+ * endpoint, and returns the response text. Register alongside the agent's other tools.
+ *
+ * <pre>
+ * A2ATool a2a = new A2ATool("https://other-agent.example.com");
+ * Agent agent = Agents.react()
+ *         .modelClient(model).model("m")
+ *         .toolExecutor(a2a)
+ *         .toolRegistry(a2a.asToolRegistry())
+ *         .build();
+ * </pre>
+ */
+public class A2ATool implements ToolExecutor {
+
+    private final String agentUrl;
+    private final A2AClient client;
+
+    public A2ATool(String agentUrl) {
+        this(agentUrl, new A2AClient());
+    }
+
+    public A2ATool(String agentUrl, A2AClient client) {
+        this.agentUrl = agentUrl;
+        this.client = client;
+    }
+
+    @Override
+    public String execute(AgentToolCall call) throws Exception {
+        String message = extractMessage(call);
+        return client.sendTask(agentUrl, message);
+    }
+
+    private static String extractMessage(AgentToolCall call) {
+        if (call == null || call.getArguments() == null) {
+            return "";
+        }
+        try {
+            JSONObject args = JSON.parseObject(call.getArguments());
+            String msg = args == null ? null : args.getString("message");
+            return msg == null ? call.getArguments() : msg;
+        } catch (Exception e) {
+            return call.getArguments(); // treat raw arguments as the message
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/AgentCard.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/AgentCard.java
@@ -1,0 +1,28 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+/**
+ * Minimal Google A2A {@code AgentCard} — the standardized capability declaration served at
+ * {@code /.well-known/agent.json}. Fields per the A2A spec; deserialized by fastjson2.
+ */
+public class AgentCard {
+
+    private String name;
+    private String description;
+    private String version;
+    private String url;
+    private String protocolVersion;
+
+    public AgentCard() {
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+    public String getProtocolVersion() { return protocolVersion; }
+    public void setProtocolVersion(String protocolVersion) { this.protocolVersion = protocolVersion; }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/a2a/A2AClientTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/a2a/A2AClientTest.java
@@ -1,0 +1,152 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+import com.alibaba.fastjson2.JSON;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link A2AClient} + {@link A2ATool} against a local mock A2A server (no external
+ * dependency). One offline test (discover + sendTask) + one real-LLM test (GLM agent calls the
+ * A2A tool → mock returns a canned response → agent uses it).
+ */
+public class A2AClientTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @Before
+    public void startMockA2AServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        server.createContext("/.well-known/agent.json", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                String card = "{\"name\":\"test-agent\",\"description\":\"test\",\"version\":\"1.0\",\"url\":\""
+                        + baseUrl + "\",\"protocolVersion\":\"1.0\"}";
+                respond(exchange, 200, card);
+            }
+        });
+        server.createContext("/tasks/send", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                String resp = "{\"jsonrpc\":\"2.0\",\"result\":{\"id\":\"t1\",\"status\":{\"state\":\"completed\"},"
+                        + "\"artifacts\":[{\"parts\":[{\"type\":\"text\",\"text\":\"external agent says: hello from A2A\"}]}]},\"id\":1}";
+                respond(exchange, 200, resp);
+            }
+        });
+        server.start();
+    }
+
+    @After
+    public void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void discoverReturnsAgentCard() throws Exception {
+        A2AClient client = new A2AClient();
+        AgentCard card = client.discover(baseUrl);
+        assertEquals("test-agent", card.getName());
+        assertEquals("1.0", card.getVersion());
+    }
+
+    @Test
+    public void sendTaskReturnsResponseText() throws Exception {
+        A2AClient client = new A2AClient();
+        String response = client.sendTask(baseUrl, "hello");
+        assertTrue("response must contain the artifact text: " + response,
+                response.contains("hello from A2A"));
+    }
+
+    @Test
+    public void a2aToolExecutesAgainstMockServer() throws Exception {
+        A2ATool tool = new A2ATool(baseUrl);
+        AgentToolCall call = AgentToolCall.builder()
+                .name("ask_remote_agent").callId("c1")
+                .arguments("{\"message\":\"hello\"}").build();
+        String output = tool.execute(call);
+        assertTrue(output.contains("hello from A2A"));
+    }
+
+    @Test
+    @Category(LiveProviderTest.class)
+    public void liveGlmAgentCallsA2aToolAndUsesResponse() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String anthropicUrl = System.getenv().getOrDefault("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = System.getenv().getOrDefault("ANTHROPIC_MODEL", "glm-5.1");
+
+        A2ATool a2a = new A2ATool(baseUrl);
+
+        // build the tool definition so the model knows about ask_remote_agent
+        Tool.Function fn = new Tool.Function();
+        fn.setName("ask_remote_agent");
+        fn.setDescription("Ask a remote A2A agent at " + baseUrl + " a question.");
+        Tool.Function.Parameter param = new Tool.Function.Parameter();
+        Map<String, Tool.Function.Property> props = new HashMap<String, Tool.Function.Property>();
+        Tool.Function.Property msgProp = new Tool.Function.Property();
+        msgProp.setType("string");
+        msgProp.setDescription("The message to send");
+        props.put("message", msgProp);
+        param.setProperties(props);
+        param.setRequired(Collections.singletonList("message"));
+        fn.setParameters(param);
+        AgentToolRegistry registry = new StaticToolRegistry(Collections.<Object>singletonList(new Tool("function", fn)));
+
+        Agent agent = Agents.react()
+                .anthropicMessages(key, anthropicUrl)
+                .model(model)
+                .maxOutputTokens(512)
+                .toolRegistry(registry)
+                .toolExecutor(a2a)
+                .build();
+
+        io.github.lnyocly.ai4j.agent.AgentResult result = agent.newSession()
+                .run("Use the ask_remote_agent tool to say hello to the remote agent, then tell me what it said.");
+
+        Assert.assertNotNull(result.getOutputText());
+        assertTrue("agent should relay the A2A response: " + result.getOutputText(),
+                result.getOutputText().contains("hello from A2A") || result.getToolResults() != null && !result.getToolResults().isEmpty());
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        OutputStream os = exchange.getResponseBody();
+        try {
+            os.write(bytes);
+        } finally {
+            os.close();
+        }
+    }
+}


### PR DESCRIPTION
Fills the zero-A2A gap identified vs langchain4j. An ai4j agent can now call external A2A agents across frameworks (LangChain, CrewAI, etc.) via the Google A2A protocol. JDK stdlib only — no new dependency.

## What

- **`AgentCard`** — minimal DTO (name/description/version/url/protocolVersion), deserialized from `/.well-known/agent.json`.
- **`A2AClient`** — `discover(baseUrl) → AgentCard` (GET), `sendTask(baseUrl, message) → response text` (POST `/tasks/send`, JSON-RPC). Extracts the first artifact's text. JDK `HttpURLConnection`.
- **`A2ATool`** — wraps `A2AClient` as a `ToolExecutor`, so an agent calls an external A2A agent as a tool (extracts the `message` arg, sends it, returns the response).

## Why

A2A is the open interop standard (Google, April 2025, v1 in 2026). langchain4j has an A2A client in its agentic module; ai4j had zero. This lets an ai4j agent call ANY A2A-compatible agent (LangChain Python, CrewAI, another ai4j instance, etc.) — cross-framework interop.

## Verification

3 offline tests (discover returns AgentCard, sendTask extracts response text, A2ATool.execute against a mock A2A server) + **1 real-LLM test** (GLM agent calls `ask_remote_agent` tool → mock A2A server returns "hello from A2A" → agent relays the response). ai4j-agent full module **191 tests, 0 failures**.

## Scope

A2A client (call external agents). A2A server (expose ai4j agents TO others) + auth (JWT/OIDC) are follow-ons. Package `io.github.lnyocly.ai4j.agent.a2a`.