### PR TITLE
feat(agent): A2A server (expose agent) + compaction shouldCompact gate

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AServer.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AServer.java
@@ -1,0 +1,182 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Exposes an ai4j {@link Agent} as a Google A2A (Agent2Agent) HTTP service so external agents
+ * (LangChain, CrewAI, etc.) can call it. Complement to {@link A2AClient}.
+ *
+ * <p>Serves two endpoints:</p>
+ * <ul>
+ *   <li>{@code GET /.well-known/agent.json} — the {@link AgentCard}.</li>
+ *   <li>{@code POST /tasks/send} — JSON-RPC: extracts the message text, runs
+ *       {@code agent.newSession().run(message)}, returns the output as an A2A artifact.</li>
+ * </ul>
+ *
+ * <pre>
+ * A2AServer server = new A2AServer(myAgent, 0, "my-agent", "does stuff");
+ * // other agents can now call http://localhost:PORT/.well-known/agent.json
+ * server.close(); // stop
+ * </pre>
+ */
+public class A2AServer implements AutoCloseable {
+
+    private final HttpServer server;
+    private final Agent agent;
+    private final AgentCard card;
+
+    public A2AServer(Agent agent, int port, String name, String description) throws IOException {
+        this.agent = agent;
+        this.server = HttpServer.create(new InetSocketAddress(port), 0);
+        int actualPort = server.getAddress().getPort();
+
+        this.card = new AgentCard();
+        card.setName(name == null ? "ai4j-agent" : name);
+        card.setDescription(description == null ? "" : description);
+        card.setVersion("1.0");
+        card.setUrl("http://localhost:" + actualPort);
+        card.setProtocolVersion("1.0");
+
+        server.createContext("/.well-known/agent.json", new CardHandler());
+        server.createContext("/tasks/send", new TaskHandler());
+        server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
+        server.start();
+    }
+
+    public String getBaseUrl() {
+        return card.getUrl();
+    }
+
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private final class CardHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            byte[] body = JSON.toJSONString(card).getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            OutputStream os = exchange.getResponseBody();
+            try {
+                os.write(body);
+            } finally {
+                os.close();
+            }
+        }
+    }
+
+    private final class TaskHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String request = readBody(exchange.getRequestBody());
+            String message = extractMessage(request);
+            String responseText;
+            try {
+                AgentResult result = agent.newSession().run(message);
+                responseText = result == null || result.getOutputText() == null ? "" : result.getOutputText();
+            } catch (Exception e) {
+                responseText = "error: " + (e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+            }
+            String a2aResponse = buildA2AResponse(responseText, extractRequestId(request));
+            byte[] body = a2aResponse.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            OutputStream os = exchange.getResponseBody();
+            try {
+                os.write(body);
+            } finally {
+                os.close();
+            }
+        }
+    }
+
+    private static String extractMessage(String jsonRpcRequest) {
+        try {
+            JSONObject root = JSON.parseObject(jsonRpcRequest);
+            if (root == null) return "";
+            JSONObject params = root.getJSONObject("params");
+            if (params == null) return "";
+            JSONObject a2aMessage = params.getJSONObject("message");
+            if (a2aMessage == null) return "";
+            JSONArray parts = a2aMessage.getJSONArray("parts");
+            if (parts != null && !parts.isEmpty()) {
+                JSONObject part = parts.getJSONObject(0);
+                if (part != null) {
+                    return part.getString("text");
+                }
+            }
+            return "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String extractRequestId(String jsonRpcRequest) {
+        try {
+            JSONObject root = JSON.parseObject(jsonRpcRequest);
+            if (root == null) return "task-" + UUID.randomUUID();
+            Object id = root.get("id");
+            return id == null ? "task-" + UUID.randomUUID() : String.valueOf(id);
+        } catch (Exception e) {
+            return "task-" + UUID.randomUUID();
+        }
+    }
+
+    private static String buildA2AResponse(String text, String requestId) {
+        Map<String, Object> part = new LinkedHashMap<String, Object>();
+        part.put("type", "text");
+        part.put("text", text);
+        Map<String, Object> artifact = new LinkedHashMap<String, Object>();
+        artifact.put("parts", java.util.Collections.singletonList(part));
+        Map<String, Object> status = new LinkedHashMap<String, Object>();
+        status.put("state", "completed");
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("id", "task-" + UUID.randomUUID());
+        result.put("status", status);
+        result.put("artifacts", java.util.Collections.singletonList(artifact));
+        Map<String, Object> response = new LinkedHashMap<String, Object>();
+        response.put("jsonrpc", "2.0");
+        response.put("result", result);
+        response.put("id", requestId);
+        return JSON.toJSONString(response);
+    }
+
+    private static String readBody(InputStream input) throws IOException {
+        if (input == null) return "";
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[4096];
+        int read;
+        try {
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+        } finally {
+            input.close();
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/StructuredSummaryCompactPolicy.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/StructuredSummaryCompactPolicy.java
@@ -23,6 +23,15 @@ public class StructuredSummaryCompactPolicy implements CompactPolicy {
     }
 
     @Override
+    public boolean shouldCompact(MemorySnapshot snapshot) {
+        if (snapshot == null || snapshot.getItems() == null) {
+            return false;
+        }
+        int maxItems = budget == null || budget.getMaxItems() == null ? Integer.MAX_VALUE : budget.getMaxItems();
+        return snapshot.getItems().size() > maxItems;
+    }
+
+    @Override
     public CompactResult compact(MemorySnapshot snapshot) {
         MemorySnapshot source = snapshot == null ? MemorySnapshot.from(new ArrayList<Object>(), null) : MemorySnapshot.from(snapshot.getItems(), snapshot.getSummary());
         ContextProjection projection = projector.project(source.getItems(), budget);

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/a2a/A2AServerTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/a2a/A2AServerTest.java
@@ -1,0 +1,79 @@
+package io.github.lnyocly.ai4j.agent.a2a;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests {@link A2AServer} — an ai4j agent exposed as an A2A HTTP service, called by {@link A2AClient}. */
+public class A2AServerTest {
+
+    private A2AServer server;
+
+    @After
+    public void stop() {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @Test
+    public void serverRespondsToDiscoverAndSendTask() throws Exception {
+        // fake agent that always says "bonjour"
+        Agent agent = Agents.react()
+                .modelClient(new FixedModelClient("server agent says: bonjour"))
+                .model("test-model")
+                .build();
+        server = new A2AServer(agent, 0, "test-server", "a test agent");
+
+        A2AClient client = new A2AClient();
+        AgentCard card = client.discover(server.getBaseUrl());
+        assertEquals("test-server", card.getName());
+
+        String response = client.sendTask(server.getBaseUrl(), "hello");
+        assertTrue("server must relay the agent's response: " + response, response.contains("bonjour"));
+    }
+
+    @Test
+    @Category(LiveProviderTest.class)
+    public void liveGlmAgentServedViaA2a() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String anthropicUrl = System.getenv().getOrDefault("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = System.getenv().getOrDefault("ANTHROPIC_MODEL", "glm-5.1");
+
+        Agent agent = Agents.react()
+                .anthropicMessages(key, anthropicUrl)
+                .model(model)
+                .maxOutputTokens(256)
+                .build();
+        server = new A2AServer(agent, 0, "ai4j-glm", "GLM via A2A");
+
+        A2AClient client = new A2AClient();
+        String response = client.sendTask(server.getBaseUrl(), "Say exactly: A2A round-trip OK");
+        assertTrue("live GLM via A2A must respond: " + response,
+                response != null && !response.trim().isEmpty());
+    }
+
+    private static final class FixedModelClient implements AgentModelClient {
+        private final String fixedOutput;
+        FixedModelClient(String fixedOutput) { this.fixedOutput = fixedOutput; }
+        public AgentModelResult create(AgentPrompt prompt) {
+            return AgentModelResult.builder().outputText(fixedOutput).build();
+        }
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return AgentModelResult.builder().outputText(fixedOutput).build();
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/StructuredSummaryCompactPolicyTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/StructuredSummaryCompactPolicyTest.java
@@ -1,0 +1,43 @@
+package io.github.lnyocly.ai4j.agent.compact;
+
+import io.github.lnyocly.ai4j.agent.context.ContextBudget;
+import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests {@link StructuredSummaryCompactPolicy#shouldCompact} — the auto-trigger gate. */
+public class StructuredSummaryCompactPolicyTest {
+
+    @Test
+    public void shouldCompactWhenItemsExceedMaxItems() {
+        StructuredSummaryCompactPolicy policy = new StructuredSummaryCompactPolicy(
+                ContextBudget.maxItems(3));
+
+        assertTrue("should compact when items > maxItems",
+                policy.shouldCompact(MemorySnapshot.from(Arrays.asList("a", "b", "c", "d"), null)));
+    }
+
+    @Test
+    public void shouldNotCompactWhenItemsAtOrBelowMaxItems() {
+        StructuredSummaryCompactPolicy policy = new StructuredSummaryCompactPolicy(
+                ContextBudget.maxItems(3));
+
+        assertFalse("should not compact when items <= maxItems",
+                policy.shouldCompact(MemorySnapshot.from(Arrays.asList("a", "b"), null)));
+        assertFalse("should not compact at boundary",
+                policy.shouldCompact(MemorySnapshot.from(Arrays.asList("a", "b", "c"), null)));
+    }
+
+    @Test
+    public void shouldNotCompactOnNullSnapshot() {
+        StructuredSummaryCompactPolicy policy = new StructuredSummaryCompactPolicy(
+                ContextBudget.maxItems(1));
+        assertFalse(policy.shouldCompact(null));
+        assertFalse(policy.shouldCompact(MemorySnapshot.from(Collections.emptyList(), null)));
+    }
+}


### PR DESCRIPTION
Two completions for the features shipped in #159/#160.

## A2A server
- **`A2AServer`** wraps an ai4j `Agent` as a Google A2A HTTP service: serves `/.well-known/agent.json` + `/tasks/send`. External agents (LangChain, CrewAI, etc.) can call the ai4j agent via the A2A protocol. JDK `HttpServer`, no new dependency. Complement to the `A2AClient` from #160 — ai4j is now both an A2A caller AND an A2A service.
- Verified: offline round-trip (fake agent served, called by A2AClient → correct response) + **real-LLM** (GLM agent served via A2A, A2AClient gets a response).

## Compaction shouldCompact
- **`StructuredSummaryCompactPolicy.shouldCompact`** override — returns true when items exceed the budget's maxItems. This makes the auto-trigger from #159 actually fire with the built-in policy (previously default-false = never auto-triggered).
- Verified: 3 unit tests (compact when items > max, not when ≤, null safety).

## Verification
ai4j-agent full module **195 tests, 0 failures**.