### PR TITLE
feat(agent): LlmCompactPolicy (LLM-powered summaries) + compaction docs

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
@@ -1,0 +1,102 @@
+package io.github.lnyocly.ai4j.agent.compact;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link CompactPolicy} that uses an LLM to generate a structured summary of old conversation
+ * items — matching pi's LLM-powered compaction (vs the mechanical {@link StructuredSummaryCompactPolicy}).
+ * Keeps the most recent N items intact and summarizes everything older into a concise summary.
+ *
+ * <pre>
+ * LlmCompactPolicy policy = new LlmCompactPolicy(modelClient, "glm-5.1", 10);
+ * Agent agent = Agents.react()
+ *         .modelClient(modelClient).model("glm-5.1")
+ *         .compactPolicy(policy)
+ *         .build();
+ * </pre>
+ */
+public class LlmCompactPolicy implements CompactPolicy {
+
+    private static final String SUMMARY_SYSTEM_PROMPT =
+            "You are a conversation summarizer. Produce a concise structured summary with these sections:\n"
+            + "## Goal\n## Progress\n## Key Decisions\n## Critical Context\n"
+            + "Keep it under 500 words. Preserve any file paths, error messages, or code snippets that are still relevant.";
+
+    private final AgentModelClient modelClient;
+    private final String modelName;
+    private final int maxItems;
+
+    /**
+     * @param modelClient the model client to use for summarization
+     * @param modelName   the model name (e.g. "glm-5.1")
+     * @param maxItems    auto-compact when memory items exceed this; keep this many recent items
+     */
+    public LlmCompactPolicy(AgentModelClient modelClient, String modelName, int maxItems) {
+        if (modelClient == null) {
+            throw new IllegalArgumentException("modelClient must not be null");
+        }
+        this.modelClient = modelClient;
+        this.modelName = modelName == null ? "" : modelName;
+        this.maxItems = maxItems;
+    }
+
+    @Override
+    public boolean shouldCompact(MemorySnapshot snapshot) {
+        if (snapshot == null || snapshot.getItems() == null) {
+            return false;
+        }
+        return snapshot.getItems().size() > maxItems;
+    }
+
+    @Override
+    public CompactResult compact(MemorySnapshot snapshot) {
+        List<Object> items = snapshot == null ? null : snapshot.getItems();
+        if (items == null || items.isEmpty()) {
+            return CompactResult.builder().memory(snapshot).build();
+        }
+
+        int keepCount = Math.min(maxItems, items.size());
+        List<Object> toSummarize = new ArrayList<Object>(items.subList(0, items.size() - keepCount));
+        List<Object> toKeep = new ArrayList<Object>(items.subList(items.size() - keepCount, items.size()));
+
+        String summary = generateSummary(toSummarize, snapshot.getSummary());
+
+        MemorySnapshot compacted = MemorySnapshot.from(toKeep, summary);
+        return CompactResult.builder()
+                .memory(compacted)
+                .summary(summary)
+                .build();
+    }
+
+    private String generateSummary(List<Object> itemsToSummarize, String previousSummary) {
+        StringBuilder userContent = new StringBuilder();
+        if (previousSummary != null && !previousSummary.trim().isEmpty()) {
+            userContent.append("Previous summary:\n").append(previousSummary.trim()).append("\n\n");
+        }
+        userContent.append("Conversation to summarize:\n").append(JSON.toJSONString(itemsToSummarize));
+
+        AgentPrompt prompt = AgentPrompt.builder()
+                .model(modelName)
+                .systemPrompt(SUMMARY_SYSTEM_PROMPT)
+                .items(Collections.<Object>singletonList(AgentInputItem.userMessage(userContent.toString())))
+                .build();
+        try {
+            AgentModelResult result = modelClient.create(prompt);
+            if (result != null && result.getOutputText() != null && !result.getOutputText().trim().isEmpty()) {
+                return result.getOutputText().trim();
+            }
+        } catch (Exception e) {
+            // summarization failure → fall back to a mechanical note
+        }
+        return "Compaction summary unavailable (LLM summarization failed). " + itemsToSummarize.size() + " items were summarized.";
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicyTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicyTest.java
@@ -1,0 +1,97 @@
+package io.github.lnyocly.ai4j.agent.compact;
+
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.MessagesModelClient;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IMessagesService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import okhttp3.OkHttpClient;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests {@link LlmCompactPolicy} — LLM-powered structured summaries. */
+public class LlmCompactPolicyTest {
+
+    @Test
+    public void shouldCompactWhenItemsExceedThreshold() {
+        LlmCompactPolicy policy = new LlmCompactPolicy(
+                new FixedModelClient("summary"), "m", 3);
+        assertTrue(policy.shouldCompact(MemorySnapshot.from(Arrays.asList("a", "b", "c", "d"), null)));
+        assertFalse(policy.shouldCompact(MemorySnapshot.from(Arrays.asList("a", "b"), null)));
+    }
+
+    @Test
+    @Category(LiveProviderTest.class)
+    public void liveLlmCompactGeneratesStructuredSummary() throws Exception {
+        String key = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: ANTHROPIC_API_KEY not set", key != null && !key.trim().isEmpty());
+        String baseUrl = System.getenv().getOrDefault("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic/");
+        String model = System.getenv().getOrDefault("ANTHROPIC_MODEL", "glm-5.1");
+
+        AgentModelClient modelClient = buildRealClient(key, baseUrl);
+        LlmCompactPolicy policy = new LlmCompactPolicy(modelClient, model, 3);
+
+        // simulate a 5-item conversation
+        List<Object> items = new ArrayList<Object>();
+        items.add(AgentInputItem.userMessage("What is 2+2?"));
+        items.add(AgentInputItem.message("assistant", "It's 4."));
+        items.add(AgentInputItem.userMessage("What about 3+3?"));
+        items.add(AgentInputItem.message("assistant", "That's 6."));
+        items.add(AgentInputItem.userMessage("And 10 times 10?"));
+        MemorySnapshot snapshot = MemorySnapshot.from(items, null);
+
+        CompactResult result = policy.compact(snapshot);
+
+        assertNotNull(result);
+        assertNotNull("summary must be generated", result.getSummary());
+        assertTrue("summary must be non-empty: " + result.getSummary(),
+                !result.getSummary().trim().isEmpty());
+        assertTrue("summary should look structured (mention a number or goal): " + result.getSummary(),
+                result.getSummary().length() > 20);
+        assertNotNull(result.getMemory());
+        assertTrue("should keep recent items (<= threshold)",
+                result.getMemory().getItems().size() <= 3);
+    }
+
+    private static AgentModelClient buildRealClient(String key, String baseUrl) {
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey(key);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        configuration.setOkHttpClient(new OkHttpClient.Builder()
+                .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(300, java.util.concurrent.TimeUnit.SECONDS)
+                .writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                .build());
+        IMessagesService service = new AnthropicMessagesService(configuration);
+        return new MessagesModelClient(service);
+    }
+
+    private static final class FixedModelClient implements AgentModelClient {
+        private final String output;
+        FixedModelClient(String output) { this.output = output; }
+        public io.github.lnyocly.ai4j.agent.model.AgentModelResult create(io.github.lnyocly.ai4j.agent.model.AgentPrompt prompt) {
+            return io.github.lnyocly.ai4j.agent.model.AgentModelResult.builder().outputText(output).build();
+        }
+        public io.github.lnyocly.ai4j.agent.model.AgentModelResult createStream(io.github.lnyocly.ai4j.agent.model.AgentPrompt prompt, io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener listener) {
+            return io.github.lnyocly.ai4j.agent.model.AgentModelResult.builder().outputText(output).build();
+        }
+    }
+}

--- a/docs-site/docs/agent/memory-compact-context.md
+++ b/docs-site/docs/agent/memory-compact-context.md
@@ -244,3 +244,24 @@ P0-B 是基础层，不包含：
 - [Memory and State](/docs/agent/memory-and-state)
 - [AI4J Agent SDK Roadmap](/docs/agent/sdk-roadmap)
 - [Coding Agent Compact and Checkpoint](/docs/coding-agent/compact-and-checkpoint)
+
+## Auto-compaction (runtime-triggered)
+
+The runtime auto-compacts at the top of each step when the configured `CompactPolicy.shouldCompact`
+returns true. Configure via `AgentBuilder.compactPolicy(...)`:
+
+```java
+// LLM-powered: uses the model to generate a structured summary of old items
+LlmCompactPolicy policy = new LlmCompactPolicy(modelClient, "glm-5.1", 10);
+Agent agent = Agents.react()
+        .modelClient(modelClient).model("glm-5.1")
+        .compactPolicy(policy)   // auto-compact when items > 10
+        .build();
+```
+
+`LlmCompactPolicy` keeps the most recent N items and asks the LLM to summarize everything older
+into a structured summary (Goal/Progress/Key Decisions/Critical Context). For a mechanical
+(non-LLM) option, use `StructuredSummaryCompactPolicy` with a `ContextBudget`.
+
+The `BEFORE_COMPACT` lifecycle hook fires before compaction (interception/customize);
+`ON_COMPACT` fires after (observe).


### PR DESCRIPTION
Adds a CompactPolicy that uses the LLM to generate structured summaries — matching pi's LLM-powered compaction quality (the existing StructuredSummaryCompactPolicy is mechanical).

## What
- **`LlmCompactPolicy`**: `shouldCompact(items > threshold)` + `compact()` (serializes old items → LLM summarization prompt → model call → structured Goal/Progress/Decisions/Context summary). Keeps the most recent N items intact; summarizes everything older. Falls back to a mechanical note if the LLM call fails.
- **Docs**: `memory-compact-context.md` gets an auto-compaction section (runtime auto-trigger + LlmCompactPolicy usage + BEFORE_COMPACT/ON_COMPACT hooks).

## Why
The compaction auto-trigger (#159) fires, but the built-in StructuredSummaryCompactPolicy produces mechanical text (truncation). pi uses the LLM for rich summaries. LlmCompactPolicy brings ai4j to parity — the model generates a Goal/Progress/Key Decisions/Critical Context summary of old conversation items.

## Verification
1 offline test (shouldCompact threshold) + 1 **real-LLM test** (GLM generates a structured summary from a 5-item conversation; verified non-empty + keeps ≤3 recent items). ai4j-agent **196 tests, 0 failures**.