### PR TITLE
feat(agent): A2A shared-secret auth + beforeModelRequest interception hook

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -36,6 +36,7 @@ import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.AgentHooks;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
+import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.platform.anthropic.chat.AnthropicMessagesService;
@@ -73,6 +74,7 @@ public class AgentBuilder {
     private PromptInterceptor promptInterceptor;
     private SandboxProvider sandboxProvider;
     private CompactPolicy compactPolicy;
+    private ModelRequestHook modelRequestHook;
     private final List<AgentLifecycleHook> additionalLifecycleHooks = new ArrayList<AgentLifecycleHook>();
     private CodeExecutor codeExecutor;
     private Supplier<AgentMemory> memorySupplier;
@@ -303,6 +305,11 @@ public class AgentBuilder {
         return this;
     }
 
+    public AgentBuilder modelRequestHook(ModelRequestHook modelRequestHook) {
+        this.modelRequestHook = modelRequestHook;
+        return this;
+    }
+
     public AgentBuilder codeExecutor(CodeExecutor codeExecutor) {
         this.codeExecutor = codeExecutor;
         return this;
@@ -483,6 +490,7 @@ public class AgentBuilder {
                 .promptInterceptor(promptInterceptor)
                 .sandboxProvider(sandboxProvider)
                 .compactPolicy(compactPolicy)
+                .modelRequestHook(modelRequestHook)
                 .codeExecutor(resolvedCodeExecutor)
                 .memory(memory)
                 .options(resolvedOptions)

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -15,6 +15,7 @@ import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
+import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import lombok.Builder;
 import lombok.Data;
@@ -37,6 +38,7 @@ public class AgentContext {
 
     private SandboxProvider sandboxProvider;
     private CompactPolicy compactPolicy;
+    private ModelRequestHook modelRequestHook;
 
     private CodeExecutor codeExecutor;
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AClient.java
@@ -29,14 +29,24 @@ public class A2AClient {
 
     private final int connectTimeoutMillis;
     private final int readTimeoutMillis;
+    private final String apiKey;
 
     public A2AClient() {
-        this(10000, 120000);
+        this(null);
+    }
+
+    public A2AClient(String apiKey) {
+        this(apiKey, 10000, 120000);
+    }
+
+    public A2AClient(String apiKey, int connectTimeoutMillis, int readTimeoutMillis) {
+        this.apiKey = apiKey;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
     }
 
     public A2AClient(int connectTimeoutMillis, int readTimeoutMillis) {
-        this.connectTimeoutMillis = connectTimeoutMillis;
-        this.readTimeoutMillis = readTimeoutMillis;
+        this(null, connectTimeoutMillis, readTimeoutMillis);
     }
 
     /** Fetches the AgentCard from {@code baseUrl/.well-known/agent.json}. */
@@ -120,6 +130,7 @@ public class A2AClient {
             conn.setConnectTimeout(connectTimeoutMillis);
             conn.setReadTimeout(readTimeoutMillis);
             conn.setRequestProperty("Accept", "application/json");
+            setAuth(conn);
             return readBody(conn.getInputStream());
         } finally {
             if (conn != null) {
@@ -137,6 +148,7 @@ public class A2AClient {
             conn.setReadTimeout(readTimeoutMillis);
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json");
+            setAuth(conn);
             conn.setDoOutput(true);
             byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
             conn.setRequestProperty("Content-Length", String.valueOf(bytes.length));
@@ -174,6 +186,12 @@ public class A2AClient {
             input.close();
         }
         return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private void setAuth(HttpURLConnection conn) {
+        if (apiKey != null && !apiKey.trim().isEmpty()) {
+            conn.setRequestProperty("X-API-Key", apiKey);
+        }
     }
 
     private static String trimSlash(String url) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AServer.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/a2a/A2AServer.java
@@ -42,9 +42,15 @@ public class A2AServer implements AutoCloseable {
     private final HttpServer server;
     private final Agent agent;
     private final AgentCard card;
+    private final String apiKey;
 
     public A2AServer(Agent agent, int port, String name, String description) throws IOException {
+        this(agent, port, name, description, null);
+    }
+
+    public A2AServer(Agent agent, int port, String name, String description, String apiKey) throws IOException {
         this.agent = agent;
+        this.apiKey = apiKey;
         this.server = HttpServer.create(new InetSocketAddress(port), 0);
         int actualPort = server.getAddress().getPort();
 
@@ -74,6 +80,26 @@ public class A2AServer implements AutoCloseable {
         server.stop(0);
     }
 
+    private boolean checkAuth(HttpExchange exchange) {
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            return true; // no auth configured
+        }
+        String provided = exchange.getRequestHeaders().getFirst("X-API-Key");
+        return apiKey.equals(provided);
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        OutputStream os = exchange.getResponseBody();
+        try {
+            os.write(bytes);
+        } finally {
+            os.close();
+        }
+    }
+
     private final class CardHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
@@ -92,6 +118,10 @@ public class A2AServer implements AutoCloseable {
     private final class TaskHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
+            if (!checkAuth(exchange)) {
+                respond(exchange, 401, "{\"error\":\"unauthorized\"}");
+                return;
+            }
             String request = readBody(exchange.getRequestBody());
             String message = extractMessage(request);
             String responseText;

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooks.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/AgentHooks.java
@@ -2,6 +2,7 @@ package io.github.lnyocly.ai4j.agent.interceptor;
 
 import io.github.lnyocly.ai4j.agent.AgentBuilder;
 import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEvent;
 import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
@@ -39,6 +40,7 @@ public final class AgentHooks {
     private final List<ToolInterceptor> preToolUse = new ArrayList<ToolInterceptor>();
     private final List<PostToolUseHook> postToolUse = new ArrayList<PostToolUseHook>();
     private final List<PromptInterceptor> userPromptSubmit = new ArrayList<PromptInterceptor>();
+    private final List<ModelRequestHook> modelRequestHooks = new ArrayList<ModelRequestHook>();
     private final Map<AgentLifecycleEventType, List<ObserveHook>> observe = new LinkedHashMap<AgentLifecycleEventType, List<ObserveHook>>();
 
     public AgentHooks preToolUse(ToolInterceptor hook) {
@@ -58,6 +60,13 @@ public final class AgentHooks {
     public AgentHooks userPromptSubmit(PromptInterceptor hook) {
         if (hook != null) {
             userPromptSubmit.add(hook);
+        }
+        return this;
+    }
+
+    public AgentHooks beforeModelRequest(ModelRequestHook hook) {
+        if (hook != null) {
+            modelRequestHooks.add(hook);
         }
         return this;
     }
@@ -101,13 +110,17 @@ public final class AgentHooks {
         if (!userPromptSubmit.isEmpty()) {
             builder.promptInterceptor(composePromptInterceptor());
         }
+        if (!modelRequestHooks.isEmpty()) {
+            builder.modelRequestHook(composeModelRequestHook());
+        }
         if (!observe.isEmpty()) {
             builder.lifecycleHook(composeLifecycleHook());
         }
     }
 
     boolean isEmpty() {
-        return preToolUse.isEmpty() && postToolUse.isEmpty() && userPromptSubmit.isEmpty() && observe.isEmpty();
+        return preToolUse.isEmpty() && postToolUse.isEmpty() && userPromptSubmit.isEmpty()
+                && modelRequestHooks.isEmpty() && observe.isEmpty();
     }
 
     private ToolInterceptor composeToolInterceptor() {
@@ -150,6 +163,23 @@ public final class AgentHooks {
                     }
                 }
                 return PromptDecision.allow();
+            }
+        };
+    }
+
+    private ModelRequestHook composeModelRequestHook() {
+        final List<ModelRequestHook> hooks = new ArrayList<ModelRequestHook>(modelRequestHooks);
+        return new ModelRequestHook() {
+            @Override
+            public AgentPrompt beforeModelRequest(AgentPrompt prompt, AgentContext context) {
+                AgentPrompt current = prompt;
+                for (ModelRequestHook h : hooks) {
+                    AgentPrompt modified = h.beforeModelRequest(current, context);
+                    if (modified != null) {
+                        current = modified;
+                    }
+                }
+                return current;
             }
         };
     }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ModelRequestHook.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/interceptor/ModelRequestHook.java
@@ -1,0 +1,17 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+
+/**
+ * Interception hook that runs before each model request and can modify the full {@link AgentPrompt}
+ * — system prompt, items, tools, temperature, etc. This is ai4j's equivalent of pi's
+ * {@code context} + {@code before_provider_request} events combined (modify what's sent to the model).
+ *
+ * <p>Register via {@code AgentBuilder.modelRequestHook(...)} or the {@link AgentHooks} facade
+ * ({@code .beforeModelRequest(...)}). Return the original prompt to pass through unchanged.</p>
+ */
+@FunctionalInterface
+public interface ModelRequestHook {
+    AgentPrompt beforeModelRequest(AgentPrompt prompt, AgentContext context);
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -30,6 +30,7 @@ import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
 import io.github.lnyocly.ai4j.agent.compact.CompactResult;
+import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.extension.lifecycle.AgentLifecycleEventType;
@@ -358,6 +359,14 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
     }
 
     protected AgentModelResult executeModel(AgentContext context, AgentPrompt prompt, AgentListener listener, int step, boolean stream, String runId, String sessionId, String turnId) throws Exception {
+        // beforeModelRequest interception: allow modifying the full prompt (system, items, temperature, etc.)
+        ModelRequestHook modelHook = context == null ? null : context.getModelRequestHook();
+        if (modelHook != null) {
+            AgentPrompt modified = modelHook.beforeModelRequest(prompt, context);
+            if (modified != null) {
+                prompt = modified;
+            }
+        }
         dispatchLifecycle(context, AgentLifecycleEventType.BEFORE_MODEL_REQUEST, step, runtimeName(), prompt);
         publish(context, listener, AgentEventType.MODEL_REQUEST, step, null, prompt, runId, sessionId, turnId);
         AgentModelResult result;

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ModelRequestHookTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/interceptor/ModelRequestHookTest.java
@@ -1,0 +1,59 @@
+package io.github.lnyocly.ai4j.agent.interceptor;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests {@link ModelRequestHook} — modify the full AgentPrompt before the model call. */
+public class ModelRequestHookTest {
+
+    @Test
+    public void beforeModelRequestCanModifyTemperature() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = new ToolInterceptorTest.ScriptedModelClient(
+                Collections.singletonList(AgentModelResult.builder().outputText("done").build()));
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .modelRequestHook((prompt, ctx) -> prompt.toBuilder().temperature(0.0).build())
+                .build();
+        agent.newSession().run("hello");
+
+        assertEquals(1, model.prompts.size());
+        assertEquals(Double.valueOf(0.0), model.prompts.get(0).getTemperature());
+    }
+
+    @Test
+    public void beforeModelRequestViaFacade() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = new ToolInterceptorTest.ScriptedModelClient(
+                Collections.singletonList(AgentModelResult.builder().outputText("done").build()));
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .hooks(h -> h.beforeModelRequest((prompt, ctx) ->
+                        prompt.toBuilder().systemPrompt("injected").build()))
+                .build();
+        agent.newSession().run("hello");
+
+        assertEquals(1, model.prompts.size());
+        assertEquals("injected", model.prompts.get(0).getSystemPrompt());
+    }
+
+    @Test
+    public void nullReturnKeepsOriginalPrompt() throws Exception {
+        ToolInterceptorTest.ScriptedModelClient model = new ToolInterceptorTest.ScriptedModelClient(
+                Collections.singletonList(AgentModelResult.builder().outputText("done").build()));
+        Agent agent = Agents.react()
+                .modelClient(model).model("test-model")
+                .modelRequestHook((prompt, ctx) -> null) // pass-through
+                .build();
+        AgentResult result = agent.newSession().run("hello");
+        assertTrue(result.getOutputText().contains("done"));
+    }
+}


### PR DESCRIPTION
Two detail completions for the pi-alignment / A2A roadmap.

## A2A basic auth (shared-secret)
- **`A2AClient`**: optional `apiKey` constructor → sends `X-API-Key` header on all requests. Backward-compatible (no-arg constructor = no auth).
- **`A2AServer`**: optional `apiKey` constructor → validates `X-API-Key` on `/tasks/send` (401 if wrong). AgentCard endpoint always open (discovery should be public).

## beforeModelRequest interception (pi's context + before_provider_request)
- **`ModelRequestHook`** functional interface: `beforeModelRequest(AgentPrompt, ctx) → AgentPrompt`. Runs in `executeModel` before the model call; can modify the full prompt (system, items, temperature, tools).
- **`AgentContext`/`AgentBuilder`**: `modelRequestHook` field + builder method.
- **`AgentHooks`** facade: `.beforeModelRequest(...)` composes like the other events.
- This is the last pi-equivalent interception event — pi modifies the provider payload; ai4j modifies the AgentPrompt that becomes the payload (right abstraction for Java).

## Verification
3 model-hook tests (modify temperature, modify systemPrompt via facade, null passthrough) + existing A2A tests still pass. ai4j-agent **199 tests, 0 failures**.