### PR TITLE
feat(agent): compaction turn-boundary safe cut point

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
@@ -10,6 +10,7 @@ import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A {@link CompactPolicy} that uses an LLM to generate a structured summary of old conversation
@@ -64,9 +65,11 @@ public class LlmCompactPolicy implements CompactPolicy {
             return CompactResult.builder().memory(snapshot).build();
         }
 
-        int keepCount = Math.min(maxItems, items.size());
-        List<Object> toSummarize = new ArrayList<Object>(items.subList(0, items.size() - keepCount));
-        List<Object> toKeep = new ArrayList<Object>(items.subList(items.size() - keepCount, items.size()));
+        int naiveCut = items.size() - Math.min(maxItems, items.size());
+        int safeCut = findTurnBoundaryCut(items, naiveCut);
+
+        List<Object> toSummarize = new ArrayList<Object>(items.subList(0, safeCut));
+        List<Object> toKeep = new ArrayList<Object>(items.subList(safeCut, items.size()));
 
         String summary = generateSummary(toSummarize, snapshot.getSummary());
 
@@ -75,6 +78,34 @@ public class LlmCompactPolicy implements CompactPolicy {
                 .memory(compacted)
                 .summary(summary)
                 .build();
+    }
+
+    /**
+     * Walks backwards from the naive cut point to find a safe turn boundary (a user-role message).
+     * This prevents cutting mid-turn — never leaves assistant messages or tool results orphaned
+     * without their preceding context. If no user-role boundary is found, returns the naive cut
+     * (graceful fallback).
+     */
+    static int findTurnBoundaryCut(List<Object> items, int naiveCut) {
+        if (naiveCut <= 0 || naiveCut >= items.size()) {
+            return naiveCut;
+        }
+        for (int i = naiveCut; i > 0; i--) {
+            if (isTurnBoundary(items.get(i))) {
+                return i;
+            }
+        }
+        // can't find a user-role boundary — check if item 0 is a turn start
+        return isTurnBoundary(items.get(0)) ? 0 : naiveCut;
+    }
+
+    /** A turn boundary is a user-role message (the start of a new user turn). */
+    private static boolean isTurnBoundary(Object item) {
+        if (!(item instanceof Map)) {
+            return false;
+        }
+        Object role = ((Map<?, ?>) item).get("role");
+        return "user".equals(role);
     }
 
     private String generateSummary(List<Object> itemsToSummarize, String previousSummary) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/TurnBoundaryCutTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/TurnBoundaryCutTest.java
@@ -1,0 +1,135 @@
+package io.github.lnyocly.ai4j.agent.compact;
+
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link LlmCompactPolicy#findTurnBoundaryCut} — the safe cut point logic that prevents
+ * cutting mid-turn (between an assistant message and its tool results).
+ */
+public class TurnBoundaryCutTest {
+
+    private static Map<String, Object> user(String text) {
+        return AgentInputItem.userMessage(text);
+    }
+
+    private static Map<String, Object> assistant(String text) {
+        return AgentInputItem.message("assistant", text);
+    }
+
+    private static Map<String, Object> toolResult(String text) {
+        return AgentInputItem.message("tool", text);
+    }
+
+    @Test
+    public void naiveCutOnUserBoundaryStaysPut() {
+        // items: [user, asst, tool, user, asst, tool]
+        // naiveCut=3 → item[3] is user → safe, no adjustment
+        List<Object> items = new ArrayList<Object>();
+        items.add(user("hello"));
+        items.add(assistant("hi"));
+        items.add(toolResult("result"));
+        items.add(user("bye"));
+        items.add(assistant("bye"));
+        items.add(toolResult("result2"));
+
+        assertEquals(3, LlmCompactPolicy.findTurnBoundaryCut(items, 3));
+    }
+
+    @Test
+    public void naiveCutOnAssistantWalksBackToUserBoundary() {
+        // items: [user, asst, tool, user, asst, tool]
+        // naiveCut=4 → item[4] is assistant → walk back to item[3] (user) → safe
+        List<Object> items = new ArrayList<Object>();
+        items.add(user("hello"));
+        items.add(assistant("hi"));
+        items.add(toolResult("result"));
+        items.add(user("bye"));
+        items.add(assistant("bye"));
+        items.add(toolResult("result2"));
+
+        assertEquals(3, LlmCompactPolicy.findTurnBoundaryCut(items, 4));
+    }
+
+    @Test
+    public void naiveCutOnToolResultWalksBackToUserBoundary() {
+        // items: [user, asst, tool, user, asst, tool]
+        // naiveCut=5 → item[5] is tool → walk back to item[3] (user) → safe
+        List<Object> items = new ArrayList<Object>();
+        items.add(user("hello"));
+        items.add(assistant("hi"));
+        items.add(toolResult("result"));
+        items.add(user("bye"));
+        items.add(assistant("bye"));
+        items.add(toolResult("result2"));
+
+        assertEquals(3, LlmCompactPolicy.findTurnBoundaryCut(items, 5));
+    }
+
+    @Test
+    public void naiveCutOnFirstUserStaysAt0() {
+        List<Object> items = new ArrayList<Object>();
+        items.add(user("hello"));
+        items.add(assistant("hi"));
+
+        assertEquals(0, LlmCompactPolicy.findTurnBoundaryCut(items, 0));
+    }
+
+    @Test
+    public void noUserBoundaryFoundFallsBackToNaiveCut() {
+        // items: [asst, asst, asst] — no user-role messages
+        List<Object> items = new ArrayList<Object>();
+        items.add(assistant("a"));
+        items.add(assistant("b"));
+        items.add(assistant("c"));
+
+        assertEquals(1, LlmCompactPolicy.findTurnBoundaryCut(items, 1));
+    }
+
+    @Test
+    public void compactRespectsTurnBoundary() {
+        // Build a compact policy with a fake model client + maxItems=2.
+        // Items: [user, asst, tool, user, asst, tool] (6 items)
+        // naiveCut = 6 - 2 = 4 → item[4] is assistant → walks back to item[3] (user)
+        // So toKeep = items[3..6) = [user, asst, tool] (3 items, not 2 — conservative)
+        StubModelClient modelClient = new StubModelClient("summary");
+        LlmCompactPolicy policy = new LlmCompactPolicy(modelClient, "m", 2);
+
+        List<Object> items = new ArrayList<Object>();
+        items.add(user("hello"));
+        items.add(assistant("hi"));
+        items.add(toolResult("result"));
+        items.add(user("bye"));
+        items.add(assistant("bye"));
+        items.add(toolResult("result2"));
+
+        CompactResult result = policy.compact(
+                io.github.lnyocly.ai4j.agent.memory.MemorySnapshot.from(items, null));
+
+        // safe cut = 3, so keep = items[3..6) = 3 items
+        assertEquals(3, result.getMemory().getItems().size());
+        // first kept item should be the user message (turn start)
+        assertEquals("user", ((Map<?, ?>) result.getMemory().getItems().get(0)).get("role"));
+    }
+
+    static final class StubModelClient implements AgentModelClient {
+        private final String output;
+        StubModelClient(String output) { this.output = output; }
+        public AgentModelResult create(AgentPrompt prompt) {
+            return AgentModelResult.builder().outputText(output).build();
+        }
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return AgentModelResult.builder().outputText(output).build();
+        }
+    }
+}


### PR DESCRIPTION
Prevents mid-turn cuts in LlmCompactPolicy — the cut point walks backwards to the nearest user-role message, so assistant messages and tool results are never orphaned.

## What

- **`LlmCompactPolicy.findTurnBoundaryCut(items, naiveCut)`**: static helper that walks backwards from the naive cut to the nearest `role=user` message (start of a turn). Falls back to naiveCut if none found.
- **`compact()`** now uses the safe cut instead of naive subList split.
- **`isTurnBoundary(item)`**: checks if an item is a Map with `role=user`.

## Why

Same correctness guarantee pi makes: never cut between an assistant message and its tool results. The naive approach (just keep last N items) could split a turn — leaving a tool result without its tool call, or an assistant response without its user prompt.

## Verification

6 tests: naive cut on user boundary stays put; on assistant walks back to user; on tool result walks back to user; at index 0 stays; no user boundary found falls back; full compact() respects boundary (correct kept-item count + first kept item has role=user). ai4j-agent **205 tests, 0 failures**.