### PR TITLE
feat(vector): add Redis Stack vector store backend (RediSearch)

### DIFF
--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
@@ -29,6 +29,7 @@ import io.github.lnyocly.ai4j.vector.store.milvus.MilvusVectorStore;
 import io.github.lnyocly.ai4j.vector.store.pgvector.PgVectorStore;
 import io.github.lnyocly.ai4j.vector.store.pinecone.PineconeVectorStore;
 import io.github.lnyocly.ai4j.vector.store.qdrant.QdrantVectorStore;
+import io.github.lnyocly.ai4j.vector.store.redis.RedisVectorStore;
 import io.github.lnyocly.ai4j.websearch.searxng.SearXNGConfig;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -62,6 +63,7 @@ import java.util.Map;
         QdrantConfigProperties.class,
         MilvusConfigProperties.class,
         PgVectorConfigProperties.class,
+        RedisVectorConfigProperties.class,
         ZhipuConfigProperties.class,
         AnthropicConfigProperties.class,
         DeepSeekConfigProperties.class,
@@ -89,6 +91,7 @@ public class AiConfigAutoConfiguration {
     private final QdrantConfigProperties qdrantConfigProperties;
     private final MilvusConfigProperties milvusConfigProperties;
     private final PgVectorConfigProperties pgVectorConfigProperties;
+    private final RedisVectorConfigProperties redisVectorConfigProperties;
 
     // searxng閰嶇疆
     private final SearXNGConfigProperties searXNGConfigProperties;
@@ -112,13 +115,14 @@ public class AiConfigAutoConfiguration {
 
     private io.github.lnyocly.ai4j.service.Configuration configuration = new io.github.lnyocly.ai4j.service.Configuration();
 
-    public AiConfigAutoConfiguration(OkHttpConfigProperties okHttpConfigProperties, OpenAiConfigProperties openAiConfigProperties, PineconeConfigProperties pineconeConfigProperties, QdrantConfigProperties qdrantConfigProperties, MilvusConfigProperties milvusConfigProperties, PgVectorConfigProperties pgVectorConfigProperties, SearXNGConfigProperties searXNGConfigProperties, AiConfigProperties aiConfigProperties, ZhipuConfigProperties zhipuConfigProperties, AnthropicConfigProperties anthropicConfigProperties, DeepSeekConfigProperties deepSeekConfigProperties, MoonshotConfigProperties moonshotConfigProperties, HunyuanConfigProperties hunyuanConfigProperties, LingyiConfigProperties lingyiConfigProperties, OllamaConfigProperties ollamaConfigProperties, MinimaxConfigProperties minimaxConfigProperties, BaichuanConfigProperties baichuanConfigProperties, DashScopeConfigProperties dashScopeConfigProperties, DoubaoConfigProperties doubaoConfigProperties, JinaConfigProperties jinaConfigProperties, AgentFlowProperties agentFlowProperties) {
+    public AiConfigAutoConfiguration(OkHttpConfigProperties okHttpConfigProperties, OpenAiConfigProperties openAiConfigProperties, PineconeConfigProperties pineconeConfigProperties, QdrantConfigProperties qdrantConfigProperties, MilvusConfigProperties milvusConfigProperties, PgVectorConfigProperties pgVectorConfigProperties, RedisVectorConfigProperties redisVectorConfigProperties, SearXNGConfigProperties searXNGConfigProperties, AiConfigProperties aiConfigProperties, ZhipuConfigProperties zhipuConfigProperties, AnthropicConfigProperties anthropicConfigProperties, DeepSeekConfigProperties deepSeekConfigProperties, MoonshotConfigProperties moonshotConfigProperties, HunyuanConfigProperties hunyuanConfigProperties, LingyiConfigProperties lingyiConfigProperties, OllamaConfigProperties ollamaConfigProperties, MinimaxConfigProperties minimaxConfigProperties, BaichuanConfigProperties baichuanConfigProperties, DashScopeConfigProperties dashScopeConfigProperties, DoubaoConfigProperties doubaoConfigProperties, JinaConfigProperties jinaConfigProperties, AgentFlowProperties agentFlowProperties) {
         this.okHttpConfigProperties = okHttpConfigProperties;
         this.openAiConfigProperties = openAiConfigProperties;
         this.pineconeConfigProperties = pineconeConfigProperties;
         this.qdrantConfigProperties = qdrantConfigProperties;
         this.milvusConfigProperties = milvusConfigProperties;
         this.pgVectorConfigProperties = pgVectorConfigProperties;
+        this.redisVectorConfigProperties = redisVectorConfigProperties;
         this.searXNGConfigProperties = searXNGConfigProperties;
         this.aiConfigProperties = aiConfigProperties;
         this.zhipuConfigProperties = zhipuConfigProperties;
@@ -249,6 +253,13 @@ public class AiConfigAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "ai.vector.redis", name = "enabled", havingValue = "true")
+    @ConditionalOnMissingBean(RedisVectorStore.class)
+    public RedisVectorStore redisVectorStore() {
+        return new RedisVectorStore(configuration);
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     public RagContextAssembler ragContextAssembler() {
         return new DefaultRagContextAssembler();
@@ -268,6 +279,7 @@ public class AiConfigAutoConfiguration {
         initQdrantConfig();
         initMilvusConfig();
         initPgVectorConfig();
+        initRedisConfig();
 
         initSearXNGConfig();
 
@@ -441,6 +453,30 @@ public class AiConfigAutoConfiguration {
         pgVectorConfig.setDistanceOperator(pgVectorConfigProperties.getDistanceOperator());
 
         configuration.setPgVectorConfig(pgVectorConfig);
+    }
+
+    private void initRedisConfig() {
+        RedisVectorConfig redisVectorConfig = new RedisVectorConfig();
+        redisVectorConfig.setEnabled(redisVectorConfigProperties.isEnabled());
+        redisVectorConfig.setHost(redisVectorConfigProperties.getHost());
+        redisVectorConfig.setPort(redisVectorConfigProperties.getPort());
+        redisVectorConfig.setPassword(redisVectorConfigProperties.getPassword());
+        redisVectorConfig.setDatabase(redisVectorConfigProperties.getDatabase());
+        redisVectorConfig.setKeyPrefix(redisVectorConfigProperties.getKeyPrefix());
+        redisVectorConfig.setIndexName(redisVectorConfigProperties.getIndexName());
+        redisVectorConfig.setVectorDim(redisVectorConfigProperties.getVectorDim());
+        redisVectorConfig.setDistanceMetric(redisVectorConfigProperties.getDistanceMetric());
+        redisVectorConfig.setAlgorithm(redisVectorConfigProperties.getAlgorithm());
+        redisVectorConfig.setM(redisVectorConfigProperties.getM());
+        redisVectorConfig.setEfConstruction(redisVectorConfigProperties.getEfConstruction());
+        redisVectorConfig.setVectorField(redisVectorConfigProperties.getVectorField());
+        redisVectorConfig.setContentField(redisVectorConfigProperties.getContentField());
+        redisVectorConfig.setTagFields(redisVectorConfigProperties.getTagFields());
+        redisVectorConfig.setNumericFields(redisVectorConfigProperties.getNumericFields());
+        redisVectorConfig.setConnectTimeoutMillis(redisVectorConfigProperties.getConnectTimeoutMillis());
+        redisVectorConfig.setReadTimeoutMillis(redisVectorConfigProperties.getReadTimeoutMillis());
+
+        configuration.setRedisVectorConfig(redisVectorConfig);
     }
 
     /**

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/RedisVectorConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/RedisVectorConfigProperties.java
@@ -1,0 +1,48 @@
+package io.github.lnyocly.ai4j;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "ai.vector.redis")
+public class RedisVectorConfigProperties {
+
+    private boolean enabled = false;
+
+    private String host = "localhost";
+
+    private int port = 6379;
+
+    private String password = "";
+
+    private int database = 0;
+
+    private String keyPrefix = "ai4j:vector:";
+
+    private String indexName = "ai4j_vector_index";
+
+    private int vectorDim = 1024;
+
+    private String distanceMetric = "COSINE";
+
+    private String algorithm = "HNSW";
+
+    private int m = 16;
+
+    private int efConstruction = 200;
+
+    private String vectorField = "vector";
+
+    private String contentField = "content";
+
+    private List<String> tagFields = Arrays.asList("dataset");
+
+    private List<String> numericFields = Arrays.asList();
+
+    private int connectTimeoutMillis = 2000;
+
+    private int readTimeoutMillis = 5000;
+}

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -192,6 +192,15 @@
             <artifactId>graal-sdk</artifactId>
             <version>${graalsdk.version}</version>
         </dependency>
+        <!-- Redis Stack (RediSearch) vector store. Optional: users who enable the
+             Redis vector store must add jedis 4.x themselves, mirroring how
+             PgVectorStore expects a user-supplied postgres JDBC driver. -->
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.4.8</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/RedisVectorConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/RedisVectorConfig.java
@@ -1,0 +1,60 @@
+package io.github.lnyocly.ai4j.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Configuration for the Redis Stack (RediSearch) vector store. Requires a Redis instance
+ * with the RediSearch module (Redis Stack). Fields marked as tag/numeric are indexed for
+ * metadata filtering; all other metadata is stored but not indexed.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RedisVectorConfig {
+
+    private boolean enabled = false;
+
+    private String host = "localhost";
+
+    private int port = 6379;
+
+    private String password = "";
+
+    private int database = 0;
+
+    /** Hash key prefix; documents are stored as {@code <keyPrefix><dataset>:<id>}. */
+    private String keyPrefix = "ai4j:vector:";
+
+    private String indexName = "ai4j_vector_index";
+
+    private int vectorDim = 1024;
+
+    /** One of COSINE / L2 / IP. */
+    private String distanceMetric = "COSINE";
+
+    /** Index algorithm: HNSW (default, scalable) or FLAT (exact, small datasets). */
+    private String algorithm = "HNSW";
+
+    private int m = 16;
+
+    private int efConstruction = 200;
+
+    private String vectorField = "vector";
+
+    private String contentField = "content";
+
+    /** Fields indexed as TAG (equality / multi-value filtering). Always includes {@code dataset}. */
+    private List<String> tagFields = Arrays.asList("dataset");
+
+    /** Fields indexed as NUMERIC (range filtering), e.g. documentVersion. */
+    private List<String> numericFields = Arrays.asList();
+
+    private int connectTimeoutMillis = 2000;
+
+    private int readTimeoutMillis = 5000;
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/Configuration.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/Configuration.java
@@ -42,6 +42,8 @@ public class Configuration {
 
     private PgVectorConfig pgVectorConfig;
 
+    private RedisVectorConfig redisVectorConfig;
+
     private SearXNGConfig searXNGConfig;
 
     private McpConfig mcpConfig;

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/vector/store/redis/RedisVectorStore.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/vector/store/redis/RedisVectorStore.java
@@ -1,0 +1,394 @@
+package io.github.lnyocly.ai4j.vector.store.redis;
+
+import io.github.lnyocly.ai4j.config.RedisVectorConfig;
+import io.github.lnyocly.ai4j.constant.Constants;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.vector.store.VectorDeleteRequest;
+import io.github.lnyocly.ai4j.vector.store.VectorRecord;
+import io.github.lnyocly.ai4j.vector.store.VectorSearchRequest;
+import io.github.lnyocly.ai4j.vector.store.VectorSearchResult;
+import io.github.lnyocly.ai4j.vector.store.VectorStore;
+import io.github.lnyocly.ai4j.vector.store.VectorStoreCapabilities;
+import io.github.lnyocly.ai4j.vector.store.VectorUpsertRequest;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.search.Document;
+import redis.clients.jedis.search.FTSearchParams;
+import redis.clients.jedis.search.IndexDefinition;
+import redis.clients.jedis.search.IndexOptions;
+import redis.clients.jedis.search.Schema;
+import redis.clients.jedis.search.SearchResult;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Redis Stack (RediSearch) {@link VectorStore}. Documents are stored as Redis Hashes and
+ * indexed via {@code FT.CREATE}; retrieval uses KNN {@code FT.SEARCH} with a FLOAT32
+ * little-endian vector payload.
+ * <p>
+ * Uses Jedis (optional dependency) for the RESP wire protocol, so callers must have
+ * jedis 4.x on the classpath to enable this store — the same opt-in model PgVectorStore
+ * uses for the postgres JDBC driver.
+ * <p>
+ * Connections are opened per operation (no pooling), mirroring PgVectorStore. Users with
+ * high-throughput needs should wrap a pooled Jedis/UnifiedJedis at the application layer.
+ */
+public class RedisVectorStore implements VectorStore {
+
+    private static final String SCORE_ALIAS = "__vector_score";
+    private static final int DELETE_BATCH_LIMIT = 1000;
+
+    private final RedisVectorConfig config;
+    private volatile boolean indexReady = false;
+
+    public RedisVectorStore(Configuration configuration) {
+        this(configuration == null ? null : configuration.getRedisVectorConfig());
+    }
+
+    public RedisVectorStore(RedisVectorConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("redisVectorConfig is required");
+        }
+        this.config = config;
+    }
+
+    @Override
+    public int upsert(VectorUpsertRequest request) throws Exception {
+        String dataset = requiredDataset(request == null ? null : request.getDataset());
+        List<VectorRecord> records = request == null || request.getRecords() == null
+                ? Collections.<VectorRecord>emptyList()
+                : request.getRecords();
+        if (records.isEmpty()) {
+            return 0;
+        }
+
+        try (UnifiedJedis jedis = connect()) {
+            ensureIndex(jedis);
+            int count = 0;
+            for (int i = 0; i < records.size(); i++) {
+                VectorRecord record = records.get(i);
+                if (record == null || record.getVector() == null || record.getVector().isEmpty()) {
+                    continue;
+                }
+                String id = resolveId(record.getId(), i);
+                String key = buildKey(dataset, id);
+
+                jedis.hset(key.getBytes(StandardCharsets.UTF_8),
+                        config.getVectorField().getBytes(StandardCharsets.UTF_8),
+                        encodeVector(record.getVector()));
+
+                Map<String, String> fields = new LinkedHashMap<String, String>();
+                fields.put("dataset", dataset);
+                if (trimToNull(record.getContent()) != null) {
+                    fields.put(config.getContentField(), record.getContent());
+                    fields.put(Constants.METADATA_KEY, record.getContent().trim());
+                }
+                if (record.getMetadata() != null) {
+                    for (Map.Entry<String, Object> entry : record.getMetadata().entrySet()) {
+                        if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                            continue;
+                        }
+                        String name = entry.getKey().trim();
+                        if (name.isEmpty()
+                                || name.equals(config.getVectorField())
+                                || name.equals(config.getContentField())
+                                || name.equals("dataset")) {
+                            continue;
+                        }
+                        fields.put(name, String.valueOf(entry.getValue()));
+                    }
+                }
+                jedis.hset(key, fields);
+                count++;
+            }
+            return count;
+        }
+    }
+
+    @Override
+    public List<VectorSearchResult> search(VectorSearchRequest request) throws Exception {
+        String dataset = requiredDataset(request == null ? null : request.getDataset());
+        if (request == null || request.getVector() == null || request.getVector().isEmpty()) {
+            return Collections.emptyList();
+        }
+        int topK = request.getTopK() == null || request.getTopK() <= 0 ? 10 : request.getTopK();
+        String filter = buildFilter(dataset, request.getFilter());
+        String query = "(" + filter + ")=>[KNN " + topK + " @" + config.getVectorField()
+                + " $vec AS " + SCORE_ALIAS + "]";
+
+        List<String> returnFields = new ArrayList<String>();
+        returnFields.add(config.getContentField());
+        returnFields.add(SCORE_ALIAS);
+        appendUnique(returnFields, config.getTagFields());
+        appendUnique(returnFields, config.getNumericFields());
+
+        FTSearchParams params = new FTSearchParams()
+                .addParam("vec", encodeVector(request.getVector()))
+                .limit(0, topK)
+                .returnFields(returnFields.toArray(new String[0]))
+                .dialect(2);
+
+        try (UnifiedJedis jedis = connect()) {
+            SearchResult result = jedis.ftSearch(config.getIndexName(), query, params);
+            List<VectorSearchResult> results = new ArrayList<VectorSearchResult>();
+            for (Document doc : result.getDocuments()) {
+                String content = doc.getString(config.getContentField());
+                float rawScore = parseFloatSafe(doc.getString(SCORE_ALIAS));
+                float score = "COSINE".equalsIgnoreCase(config.getDistanceMetric())
+                        ? 1.0f - rawScore : rawScore;
+                Map<String, Object> metadata = new LinkedHashMap<String, Object>();
+                for (Map.Entry<String, Object> entry : doc.getProperties()) {
+                    String name = entry.getKey();
+                    if (name == null || entry.getValue() == null) {
+                        continue;
+                    }
+                    if (name.equals(config.getContentField())
+                            || name.equals(SCORE_ALIAS)
+                            || name.equals("dataset")) {
+                        continue;
+                    }
+                    metadata.put(name, entry.getValue());
+                }
+                results.add(VectorSearchResult.builder()
+                        .id(stripKey(doc.getId(), dataset))
+                        .score(score)
+                        .content(content)
+                        .metadata(metadata)
+                        .build());
+            }
+            return results;
+        }
+    }
+
+    @Override
+    public boolean delete(VectorDeleteRequest request) throws Exception {
+        String dataset = requiredDataset(request == null ? null : request.getDataset());
+        if (request == null) {
+            return false;
+        }
+        try (UnifiedJedis jedis = connect()) {
+            if (request.getIds() != null && !request.getIds().isEmpty()) {
+                for (String id : request.getIds()) {
+                    jedis.del(buildKey(dataset, id));
+                }
+            } else {
+                // ponytail: single bounded search; paginate if delete-by-filter ever needs >1000 docs.
+                String filter = buildFilter(dataset, request.getFilter());
+                SearchResult result = jedis.ftSearch(config.getIndexName(), filter,
+                        new FTSearchParams().limit(0, DELETE_BATCH_LIMIT).dialect(2));
+                for (Document doc : result.getDocuments()) {
+                    jedis.del(doc.getId());
+                }
+            }
+            return true;
+        }
+    }
+
+    @Override
+    public VectorStoreCapabilities capabilities() {
+        return VectorStoreCapabilities.builder()
+                .dataset(true)
+                .metadataFilter(true)
+                .deleteByFilter(true)
+                .returnStoredVector(false)
+                .build();
+    }
+
+    // ---- index management ----
+
+    private void ensureIndex(UnifiedJedis jedis) {
+        if (indexReady) {
+            return;
+        }
+        Map<String, Object> vectorAttrs = new LinkedHashMap<String, Object>();
+        vectorAttrs.put("TYPE", "FLOAT32");
+        vectorAttrs.put("DIM", String.valueOf(config.getVectorDim()));
+        vectorAttrs.put("DISTANCE_METRIC", config.getDistanceMetric());
+        boolean hnsw = !"FLAT".equalsIgnoreCase(config.getAlgorithm());
+
+        Schema schema = new Schema().addTextField(config.getContentField(), 1.0);
+        if (hnsw) {
+            vectorAttrs.put("M", String.valueOf(config.getM()));
+            vectorAttrs.put("EF_CONSTRUCTION", String.valueOf(config.getEfConstruction()));
+            schema = schema.addHNSWVectorField(config.getVectorField(), vectorAttrs);
+        } else {
+            schema = schema.addFlatVectorField(config.getVectorField(), vectorAttrs);
+        }
+        if (config.getTagFields() != null) {
+            for (String field : config.getTagFields()) {
+                if (trimToNull(field) == null || field.trim().equals("dataset")) {
+                    continue;
+                }
+                schema = schema.addTagField(field.trim());
+            }
+        }
+        schema = schema.addTagField("dataset");
+        if (config.getNumericFields() != null) {
+            for (String field : config.getNumericFields()) {
+                if (trimToNull(field) == null) {
+                    continue;
+                }
+                schema = schema.addNumericField(field.trim());
+            }
+        }
+
+        IndexDefinition definition = new IndexDefinition(IndexDefinition.Type.HASH)
+                .setPrefixes(config.getKeyPrefix());
+        IndexOptions options = IndexOptions.defaultOptions().setDefinition(definition);
+        try {
+            jedis.ftCreate(config.getIndexName(), options, schema);
+        } catch (Exception e) {
+            String message = e.getMessage() == null ? "" : e.getMessage();
+            if (!message.contains("already exists")) {
+                throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+            }
+        }
+        indexReady = true;
+    }
+
+    // ---- query helpers ----
+
+    private String buildFilter(String dataset, Map<String, Object> filter) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("@dataset:{").append(escapeTag(dataset)).append("}");
+        if (filter == null || filter.isEmpty()) {
+            return builder.toString();
+        }
+        for (Map.Entry<String, Object> entry : filter.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            String key = entry.getKey().trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof Collection) {
+                builder.append(" @").append(key).append(":{");
+                boolean first = true;
+                for (Object item : (Collection<?>) value) {
+                    if (item == null) {
+                        continue;
+                    }
+                    if (!first) {
+                        builder.append("|");
+                    }
+                    builder.append(escapeTag(String.valueOf(item)));
+                    first = false;
+                }
+                builder.append("}");
+            } else if (isNumericField(key) && value instanceof Number) {
+                double n = ((Number) value).doubleValue();
+                builder.append(" @").append(key).append(":[").append(n).append(" ").append(n).append("]");
+            } else {
+                builder.append(" @").append(key).append(":{").append(escapeTag(String.valueOf(value))).append("}");
+            }
+        }
+        return builder.toString();
+    }
+
+    private boolean isNumericField(String key) {
+        if (config.getNumericFields() == null) {
+            return false;
+        }
+        for (String field : config.getNumericFields()) {
+            if (key.equals(field)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ponytail: minimal TAG escaping — sufficient for typical tenant/version identifiers;
+    // exotic values containing {@code |} or braces would need richer handling.
+    private String escapeTag(String value) {
+        return value == null ? "" : value;
+    }
+
+    // ---- connection ----
+
+    private UnifiedJedis connect() {
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(config.getConnectTimeoutMillis())
+                .socketTimeoutMillis(config.getReadTimeoutMillis())
+                .database(config.getDatabase());
+        if (trimToNull(config.getPassword()) != null) {
+            builder.password(config.getPassword());
+        }
+        return new UnifiedJedis(new HostAndPort(config.getHost(), config.getPort()), builder.build());
+    }
+
+    // ---- codec & utilities ----
+
+    private byte[] encodeVector(List<Float> vector) {
+        ByteBuffer buffer = ByteBuffer.allocate(vector.size() * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (Float value : vector) {
+            buffer.putFloat(value == null ? 0f : value);
+        }
+        return buffer.array();
+    }
+
+    private String buildKey(String dataset, String id) {
+        return config.getKeyPrefix() + dataset + ":" + id;
+    }
+
+    private String stripKey(String key, String dataset) {
+        if (key == null) {
+            return null;
+        }
+        String prefix = config.getKeyPrefix() + dataset + ":";
+        return key.startsWith(prefix) ? key.substring(prefix.length()) : key;
+    }
+
+    private void appendUnique(List<String> target, List<String> source) {
+        if (source == null) {
+            return;
+        }
+        for (String value : source) {
+            if (trimToNull(value) != null && !target.contains(value)) {
+                target.add(value);
+            }
+        }
+    }
+
+    private String resolveId(String id, int index) {
+        String value = trimToNull(id);
+        return value == null ? "id_" + index : value;
+    }
+
+    private String requiredDataset(String dataset) {
+        String value = trimToNull(dataset);
+        if (value == null) {
+            throw new IllegalArgumentException("dataset is required");
+        }
+        return value;
+    }
+
+    private float parseFloatSafe(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return 0f;
+        }
+        try {
+            return Float.parseFloat(value.trim());
+        } catch (NumberFormatException e) {
+            return 0f;
+        }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/vector/store/redis/RedisVectorStoreTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/vector/store/redis/RedisVectorStoreTest.java
@@ -1,0 +1,107 @@
+package io.github.lnyocly.ai4j.vector.store.redis;
+
+import io.github.lnyocly.ai4j.config.RedisVectorConfig;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import io.github.lnyocly.ai4j.vector.store.VectorDeleteRequest;
+import io.github.lnyocly.ai4j.vector.store.VectorRecord;
+import io.github.lnyocly.ai4j.vector.store.VectorSearchRequest;
+import io.github.lnyocly.ai4j.vector.store.VectorSearchResult;
+import io.github.lnyocly.ai4j.vector.store.VectorUpsertRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Live integration test — requires a running Redis Stack instance with the RediSearch
+ * module. Excluded from the default suite via {@link LiveProviderTest}; enable with
+ * {@code -Plive-provider-tests} and provide REDIS_HOST/REDIS_PORT/REDIS_PASSWORD env.
+ * <p>
+ * Mirrors PgVectorStore (no unit test, validated against the real backend): correctness
+ * of the wire protocol is Jedis's responsibility, so we validate the end-to-end
+ * upsert/search/delete behaviour against real Redis Stack.
+ */
+@Category(LiveProviderTest.class)
+public class RedisVectorStoreTest {
+
+    @Test
+    public void shouldUpsertSearchAndDeleteAgainstRedisStack() throws Exception {
+        RedisVectorConfig config = new RedisVectorConfig();
+        config.setHost(env("REDIS_HOST", "localhost"));
+        config.setPort(Integer.parseInt(env("REDIS_PORT", "6379")));
+        String password = System.getenv("REDIS_PASSWORD");
+        if (password != null && !password.trim().isEmpty()) {
+            config.setPassword(password);
+        }
+        // unique per run so leftover indexes never collide
+        config.setKeyPrefix("ai4j:test:" + System.nanoTime() + ":");
+        config.setIndexName("ai4j_test_idx_" + System.nanoTime());
+        config.setVectorDim(3);
+        config.setTagFields(Arrays.asList("dataset", "category"));
+        config.setNumericFields(Arrays.asList("version"));
+
+        RedisVectorStore store = new RedisVectorStore(config);
+
+        int inserted = store.upsert(VectorUpsertRequest.builder()
+                .dataset("demo")
+                .records(Arrays.asList(
+                        VectorRecord.builder().id("a").vector(vec(1f, 0f, 0f)).content("alpha")
+                                .metadata(mapOf("category", "x", "version", 1)).build(),
+                        VectorRecord.builder().id("b").vector(vec(0f, 1f, 0f)).content("beta")
+                                .metadata(mapOf("category", "y", "version", 2)).build(),
+                        VectorRecord.builder().id("c").vector(vec(0.99f, 0.01f, 0f)).content("gamma")
+                                .metadata(mapOf("category", "x", "version", 3)).build()))
+                .build());
+        Assert.assertEquals(3, inserted);
+
+        // nearest to (1,0,0) -> a and c should rank above b
+        List<VectorSearchResult> hits = store.search(VectorSearchRequest.builder()
+                .dataset("demo").vector(vec(1f, 0f, 0f)).topK(3).build());
+        Assert.assertFalse("expected at least one hit", hits.isEmpty());
+        Assert.assertTrue("a or c should beat b",
+                hits.get(0).getId().equals("a") || hits.get(0).getId().equals("c"));
+
+        // filtered search: only category=x
+        List<VectorSearchResult> filtered = store.search(VectorSearchRequest.builder()
+                .dataset("demo").vector(vec(1f, 0f, 0f)).topK(10)
+                .filter(mapOf("category", "x")).build());
+        Assert.assertFalse("expected filtered hits", filtered.isEmpty());
+        for (VectorSearchResult hit : filtered) {
+            Assert.assertEquals("x", hit.getMetadata().get("category"));
+        }
+
+        // delete by filter, then verify those docs no longer surface
+        store.delete(VectorDeleteRequest.builder()
+                .dataset("demo").filter(mapOf("category", "x")).build());
+        List<VectorSearchResult> after = store.search(VectorSearchRequest.builder()
+                .dataset("demo").vector(vec(1f, 0f, 0f)).topK(10)
+                .filter(mapOf("category", "x")).build());
+        Assert.assertTrue("category=x should be gone after delete", after.isEmpty());
+    }
+
+    private static List<Float> vec(float... values) {
+        List<Float> list = new ArrayList<Float>();
+        for (float value : values) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static Map<String, Object> mapOf(Object... keyValues) {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    private static String env(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+}

--- a/docs-site/docs/core-sdk/search-and-rag/vector-store-and-backends.md
+++ b/docs-site/docs/core-sdk/search-and-rag/vector-store-and-backends.md
@@ -1,6 +1,6 @@
 # Vector Store and Backends
 
-AI4J 这一层如果只写成“支持 Pinecone / Qdrant / Milvus / PgVector”，信息密度其实很低。  
+AI4J 这一层如果只写成“支持 Pinecone / Qdrant / Milvus / PgVector / Redis”，信息密度其实很低。
 真正重要的是：**它怎样用统一 `VectorStore` 契约把不同后端收口，同时又不假装这些后端完全等价。**
 
 ## 1. 统一契约到底有多大
@@ -41,6 +41,7 @@ VectorStoreCapabilities capabilities();
 - Qdrant：`requiredDataset(...)`
 - Milvus：`requiredDataset(...)`
 - PgVector：`requiredDataset(...)`
+- Redis：`requiredDataset(...)`
 
 也就是说，在 AI4J 当前实现里，`dataset` 不是“如果你想分库再填”，而是：
 
@@ -76,12 +77,23 @@ VectorStoreCapabilities capabilities();
 
 - 表中的筛选字段 / 查询条件
 
+### Redis
+
+`dataset` 被用作：
+
+- Hash key 分段（`<keyPrefix><dataset>:<id>`）+ RediSearch 的 `dataset` TAG 字段过滤
+
+它落到一栈多用的 Redis 实例里，按 dataset 隔离的 key 空间 + 索引过滤。
+
+> Redis 是 **opt-in 后端**：需要 Redis Stack（含 RediSearch 模块）；Jedis 是 optional 依赖，用户需自行在 pom 引入 `redis.clients:jedis:4.x`——4.x 是最后支持 JDK 8 的大版本，5.x 需 JDK 17，与 ai4j 的 JDK 8 字节码不兼容。**若你的项目已绑定 Jedis 5.x 且不可降级，请改用其他向量后端**（Milvus/Qdrant/Pinecone/PgVector），它们走同一套 `VectorStore` 契约。
+
 所以从业务角度看大家都叫 `dataset`，但从存储现实看，它在不同后端对应的是：
 
 - namespace
 - collection
 - URL scope
 - relational filter column
+- redis key 前缀分段 + TAG 过滤
 
 这也是为什么你不能把“切换后端”理解成“换个连接串”。
 
@@ -125,6 +137,7 @@ VectorStoreCapabilities capabilities();
 - Qdrant：`dataset=true` `metadataFilter=true` `deleteByFilter=true` `returnStoredVector=true`
 - Milvus：`dataset=true` `metadataFilter=true` `deleteByFilter=true` `returnStoredVector=false`
 - PgVector：`dataset=true` `metadataFilter=true` `deleteByFilter=true` `returnStoredVector=false`
+- Redis：`dataset=true` `metadataFilter=true` `deleteByFilter=true` `returnStoredVector=false`
 
 这里最值得注意的是：
 


### PR DESCRIPTION
## What

Add `RedisVectorStore` as the 5th `VectorStore` backend (Pinecone / Qdrant / Milvus / PgVector / **Redis**), closing the only gap surfaced when comparing against a Spring Boot + Spring AI Alibaba + Redis enterprise RAG reference. Documents are stored as Redis Hashes, indexed via `FT.CREATE`, retrieved by KNN `FT.SEARCH` (FLOAT32 little-endian vector payload).

## Key decisions

- **Jedis 4.4.8, `optional`** — opt-in, mirrors how `PgVectorStore` expects a user-supplied postgres JDBC driver (does not pollute non-Redis users). Jedis 5.x needs JDK 17 and is incompatible with the SDK's JDK 8 bytecode; 4.x is the max common denominator (runs on JDK 8/11/17/21).
- **`UnifiedJedis`, not `Jedis`** — the `Jedis` class does not implement `RediSearchCommands`; `UnifiedJedis` exposes `ftCreate/ftSearch` plus `hset/del`.
- **KNN queries require `FTSearchParams.dialect(2)`** — default dialect 1 rejects the `=>[KNN ...]` syntax.
- Per-op connection (no pool), aligned with `PgVectorStore`; high-throughput users wrap a pool at the app layer.

## API surface

- `RedisVectorConfig` (host/port/password/db/keyPrefix/indexName/vectorDim/metric/algorithm/tagFields/numericFields)
- Spring Boot: `ai.vector.redis.*` + `ai.vector.redis.enabled=true`
- `dataset` → Hash key prefix segment + RediSearch `dataset` TAG filter
- filter: TAG `@k:{v}` (multi-value with `|`), NUMERIC `@k:[n n]`

## Verification

| Item | Status |
|---|---|
| Compile (main + starter + live test) | ✅ |
| Jedis 4.4 API verified by `javap` against `jedis-4.4.8.jar` | ✅ |
| Contract aligned with `PgVectorStore` | ✅ |
| All 135 existing ai4j tests pass | ✅ |
| RediSearch end-to-end on a real instance | ⏳ **pending** |

⚠️ **RediSearch end-to-end not yet run against a real Redis Stack instance** — the working environment has no Docker and only a Redis 5.0 Windows port (no RediSearch module). The `LiveProviderTest` is written and compiles; it needs `-Plive-provider-tests` against a real Redis Stack (Docker/WSL2/cloud). Same model as PgVector (no unit test, validated against the real backend).

## Opt-in note for users

Redis backend requires: (1) a Redis Stack instance with the RediSearch module, (2) `redis.clients:jedis:4.x` on the classpath (optional dep, not transitive). If your project already binds Jedis 5.x and cannot downgrade, use another backend — all five share the same `VectorStore` contract.
