### PR TITLE
chore: bump version to 2.4.0

### DIFF
--- a/ai4j-agent/pom.xml
+++ b/ai4j-agent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-agent</artifactId>

--- a/ai4j-bom/pom.xml
+++ b/ai4j-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-bom</artifactId>

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-cli</artifactId>

--- a/ai4j-coding/pom.xml
+++ b/ai4j-coding/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-coding</artifactId>

--- a/ai4j-extension-api/pom.xml
+++ b/ai4j-extension-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-extension-api</artifactId>

--- a/ai4j-flowgram-demo/pom.xml
+++ b/ai4j-flowgram-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-flowgram-demo</artifactId>

--- a/ai4j-flowgram-spring-boot-starter/pom.xml
+++ b/ai4j-flowgram-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-flowgram-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
 
     <name>ai4j-flowgram-spring-boot-starter</name>
     <description>ai4j FlowGram 的 Spring Boot Starter，支持流程应用与 trace 集成。 Spring Boot starter for ai4j FlowGram workflow applications and trace integration.</description>

--- a/ai4j-plugin-ask-user/pom.xml
+++ b/ai4j-plugin-ask-user/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>ai4j-plugin-ask-user</artifactId>

--- a/ai4j-spring-boot-starter/pom.xml
+++ b/ai4j-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
 
     <name>ai4j-spring-boot-starter</name>
     <description>ai4j 核心 SDK 的 Spring Boot Starter，简化自动配置与集成。 Spring Boot starter for configuring and integrating the ai4j core SDK.</description>

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
 
     <name>ai4j</name>
     <description>ai4j 核心 Java SDK，提供统一大模型接入、Tool Call、RAG 与 MCP 能力。 Core Java SDK for unified LLM access, tool calling, RAG, and MCP integration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-sdk</artifactId>
 
-    <version>2.3.0</version>
+    <version>2.4.0</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Bump parent + all 10 modules 2.3.0 → 2.4.0. Prepares the release bundling IMessagesService, Redis vector store (#168), observability 4 phases, hooks, compaction, A2A, structured output, token usage, PgVector live test (#170). Merge + tag v2.4.0, then release to Central (central-publishing + GPG).