### PR TITLE
fix(cli): mention lifecycle hooks in extension inspect tip

### DIFF
--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
@@ -241,7 +241,7 @@ public class CliExtensionCommand {
             printRuntime(snapshot, terminal);
         } else {
             terminal.println("runtime=not-inspected");
-            terminal.println("tip=use --runtime to list contributed tools, commands, skills, prompts, and guardrails");
+            terminal.println("tip=use --runtime to list contributed tools, commands, skills, prompts, guardrails, and lifecycle hooks");
         }
         return 0;
     }


### PR DESCRIPTION
## Summary

- mention lifecycle hooks in the non-runtime `extension inspect` tip

## Validation

- `git diff --check`