### PR TITLE
fix(agent): preserve raw response across null stream payloads

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureAgentListener.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/IoCaptureAgentListener.java
@@ -107,11 +107,12 @@ public class IoCaptureAgentListener implements AgentListener {
         if (message != null && !message.isEmpty()) {
             b.outputText(appendText(b.getOutputText(), message));
         }
-        // Keep the latest raw response payload; streamed deltas may still carry one.
-        b.outputs(event.getPayload());
-        // best-effort token extraction from the raw response usage block (provider-agnostic)
-        if (event.getPayload() != null) {
-            long[] usage = extractUsage(event.getPayload());
+        // Keep the latest non-null raw response payload; streamed text deltas may not carry one.
+        Object payload = event.getPayload();
+        if (payload != null) {
+            b.outputs(payload);
+            // best-effort token extraction from the raw response usage block (provider-agnostic)
+            long[] usage = extractUsage(payload);
             if (usage != null) {
                 if (usage[0] >= 0) { b.inputTokens(usage[0]); }
                 if (usage[1] >= 0) { b.outputTokens(usage[1]); }

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/NodeIoCaptureReplayTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/replay/NodeIoCaptureReplayTest.java
@@ -97,6 +97,22 @@ public class NodeIoCaptureReplayTest {
     }
 
     @Test
+    public void nullStreamPayloadMustNotEraseLastRawResponse() {
+        InMemoryIoCaptureSink sink = new InMemoryIoCaptureSink();
+        IoCaptureAgentListener listener = new IoCaptureAgentListener(sink);
+
+        listener.onEvent(ev(AgentEventType.MODEL_REQUEST, 1,
+                AgentPrompt.builder().model("m").build(), null));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 1, "raw-response", null));
+        listener.onEvent(ev(AgentEventType.MODEL_RESPONSE, 1, null, "streamed delta"));
+        listener.onEvent(ev(AgentEventType.STEP_END, 1, null, null));
+
+        NodeIoRecord record = sink.records(NodeIoRecord.NodeType.MODEL).get(0);
+        assertEquals("raw-response", record.getOutputs());
+        assertEquals("streamed delta", record.getOutputText());
+    }
+
+    @Test
     public void replayerMockShouldFallBackToOutputTextWhenRawResponseMissing() {
         NodeIoRecord record = NodeIoRecord.builder(NodeIoRecord.NodeType.MODEL)
                 .nodeId("model@fallback")


### PR DESCRIPTION
Preserve the latest non-null raw MODEL_RESPONSE payload across streamed events with null payloads. Adds a regression test. Verified with targeted NodeIoCaptureReplayTest (12 tests) and full ai4j-agent -am test (extension API 26, core 168, agent 228 tests).