### PR TITLE
docs: update install version for 2.4.0 release

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -48,7 +48,7 @@ This repository has evolved into a multi-module SDK. In addition to the core `ai
 Gradle:
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:0.8.8'
+implementation 'io.github.lnyo-cly:ai4j:2.4.0'
 ```
 
 Maven:
@@ -57,7 +57,7 @@ Maven:
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>0.8.8</version>
+  <version>2.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 Gradle：
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:0.8.8'
+implementation 'io.github.lnyo-cly:ai4j:2.4.0'
 ```
 
 Maven：
@@ -60,7 +60,7 @@ Maven：
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>0.8.8</version>
+  <version>2.4.0</version>
 </dependency>
 ```
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/JsonlIoCaptureSink.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/replay/JsonlIoCaptureSink.java
@@ -135,13 +135,13 @@ public class JsonlIoCaptureSink implements IoCaptureSink {
                             .inputs(obj.get("inputs"))
                             .outputText(obj.getString("outputText"))
                             .outputs(obj.get("outputs"));
-                    Integer startedAt = obj.getInteger("startedAtEpochMs");
+                    Long startedAt = obj.getLong("startedAtEpochMs");
                     if (startedAt != null) {
-                        b.startedAtEpochMs(startedAt.longValue());
+                        b.startedAtEpochMs(startedAt);
                     }
-                    Integer capturedAt = obj.getInteger("capturedAtEpochMs");
+                    Long capturedAt = obj.getLong("capturedAtEpochMs");
                     if (capturedAt != null) {
-                        b.capturedAtEpochMs(capturedAt.longValue());
+                        b.capturedAtEpochMs(capturedAt);
                     }
                     String reasoning = obj.getString("reasoningText");
                     if (reasoning != null) {

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -16,6 +16,10 @@
     <name>ai4j-cli</name>
     <description>ai4j CLI、TUI 与 ACP 宿主模块，用于 coding agent 与工作区自动化。 CLI, TUI, and ACP host for ai4j coding agents and workspace automation.</description>
 
+    <properties>
+        <ai4j.cli.assembly.skip>false</ai4j.cli.assembly.skip>
+    </properties>
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -127,6 +131,7 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                     <appendAssemblyId>true</appendAssemblyId>
+                    <skipAssembly>${ai4j.cli.assembly.skip}</skipAssembly>
                 </configuration>
                 <executions>
                     <execution>
@@ -144,6 +149,9 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <ai4j.cli.assembly.skip>true</ai4j.cli.assembly.skip>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
## Summary
- update README / README-EN install snippets from the invalid 0.8.8 version to 2.4.0
- skip the CLI `jar-with-dependencies` classifier during `-P release` deploy while preserving default local package behavior

## Verification
- `mvn -P release -DskipTests clean deploy` signed and uploaded Central deployment `a2872128-0f33-4912-b989-3baa340df6ac`; plugin 0.4.0 only failed after upload due Central API `warnings` field parsing
- Central Publisher API: deployment reached `PUBLISHED`
- Maven Central: `io.github.lnyo-cly:ai4j` metadata latest/release is `2.4.0`; `ai4j-2.4.0.pom` and `ai4j-2.4.0.jar` return 200
- fresh local repo: `mvn ... dependency:get -Dartifact=io.github.lnyo-cly:ai4j:2.4.0 -Dtransitive=false` passed

## Notes
- `ai4j-cli-2.4.0-jar-with-dependencies.jar` is intentionally not published to Central; the release bundle dropped from ~201MB to ~10MB.