### PR TITLE
fix(release): prepare consistent 2.4.1 publication

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -48,7 +48,7 @@ This repository has evolved into a multi-module SDK. In addition to the core `ai
 Gradle:
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.0'
+implementation 'io.github.lnyo-cly:ai4j:2.4.1'
 ```
 
 Maven:
@@ -57,7 +57,7 @@ Maven:
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 Gradle：
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.0'
+implementation 'io.github.lnyo-cly:ai4j:2.4.1'
 ```
 
 Maven：
@@ -60,7 +60,7 @@ Maven：
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
 </dependency>
 ```
 

--- a/ai4j-agent/pom.xml
+++ b/ai4j-agent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-agent</artifactId>
@@ -197,7 +197,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-bom/pom.xml
+++ b/ai4j-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-bom</artifactId>
@@ -140,7 +140,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-cli</artifactId>
@@ -246,7 +246,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class CliExtensionCommand {
 
-    private static final String EXTENSION_API_VERSION = "2.4.0";
+    private static final String EXTENSION_API_VERSION = "2.4.1";
 
     private final Path currentDirectory;
 

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/ExtensionScaffoldGenerator.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/ExtensionScaffoldGenerator.java
@@ -478,7 +478,7 @@ final class ExtensionScaffoldGenerator {
             this.version = defaultIfBlank(builder.version, "1.0.0");
             this.className = requireClassName(defaultIfBlank(builder.className, classNameFromId(this.extensionId)));
             this.vendor = defaultIfBlank(builder.vendor, "example");
-            this.extensionApiVersion = defaultIfBlank(builder.extensionApiVersion, "2.4.0");
+            this.extensionApiVersion = defaultIfBlank(builder.extensionApiVersion, "2.4.1");
             this.namespace = namespaceFromId(this.extensionId);
             this.resourceSegment = resourceSegmentFromId(this.extensionId);
             this.toolName = this.namespace + ".echo";

--- a/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/Ai4jCliTest.java
+++ b/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/Ai4jCliTest.java
@@ -775,7 +775,7 @@ public class Ai4jCliTest {
         String testSource = read(plugin.resolve("src/test/java/com/example/ai4j/weather/WeatherPackExtensionTest.java"));
         String readme = read(plugin.resolve("README.md"));
         String service = read(plugin.resolve("src/main/resources/META-INF/services/io.github.lnyocly.ai4j.extension.Ai4jExtension"));
-        Assert.assertTrue(pom.contains("<version>2.4.0</version>"));
+        Assert.assertTrue(pom.contains("<version>2.4.1</version>"));
         Assert.assertTrue(extensionSource.contains("implements Ai4jExtension"));
         Assert.assertTrue(extensionSource.contains(".id(\"weather-pack\")"));
         Assert.assertTrue(extensionSource.contains(".capability(ExtensionCapability.TOOL)"));

--- a/ai4j-coding/pom.xml
+++ b/ai4j-coding/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-coding</artifactId>
@@ -171,7 +171,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-extension-api/pom.xml
+++ b/ai4j-extension-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-extension-api</artifactId>
@@ -105,7 +105,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-flowgram-demo/pom.xml
+++ b/ai4j-flowgram-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-flowgram-demo</artifactId>

--- a/ai4j-flowgram-spring-boot-starter/pom.xml
+++ b/ai4j-flowgram-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-flowgram-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 
     <name>ai4j-flowgram-spring-boot-starter</name>
     <description>ai4j FlowGram 的 Spring Boot Starter，支持流程应用与 trace 集成。 Spring Boot starter for ai4j FlowGram workflow applications and trace integration.</description>
@@ -217,7 +217,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-plugin-ask-user/pom.xml
+++ b/ai4j-plugin-ask-user/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>ai4j-plugin-ask-user</artifactId>
@@ -110,7 +110,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j-plugin-ask-user/src/main/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtension.java
+++ b/ai4j-plugin-ask-user/src/main/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtension.java
@@ -23,7 +23,7 @@ public final class AskUserExtension implements Ai4jExtension {
     public static final String SKILL_NAME = "ask-user-collaboration";
     public static final String PROMPT_NAME = "ask-user-question";
 
-    private static final String VERSION = "2.4.0";
+    private static final String VERSION = "2.4.1";
 
     public ExtensionManifest manifest() {
         return ExtensionManifest.builder()

--- a/ai4j-plugin-ask-user/src/test/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtensionTest.java
+++ b/ai4j-plugin-ask-user/src/test/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtensionTest.java
@@ -25,7 +25,7 @@ public class AskUserExtensionTest {
 
         Assert.assertEquals("ask-user", manifest.getId());
         Assert.assertEquals("Ask User", manifest.getName());
-        Assert.assertEquals("2.4.0", manifest.getVersion());
+        Assert.assertEquals("2.4.1", manifest.getVersion());
         Assert.assertEquals("ai4j", manifest.getVendor());
         Assert.assertTrue(manifest.hasCapability(ExtensionCapability.TOOL));
         Assert.assertTrue(manifest.hasCapability(ExtensionCapability.COMMAND));

--- a/ai4j-spring-boot-starter/pom.xml
+++ b/ai4j-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 
     <name>ai4j-spring-boot-starter</name>
     <description>ai4j 核心 SDK 的 Spring Boot Starter，简化自动配置与集成。 Spring Boot starter for configuring and integrating the ai4j core SDK.</description>
@@ -225,7 +225,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 
     <name>ai4j</name>
     <description>ai4j 核心 Java SDK，提供统一大模型接入、Tool Call、RAG 与 MCP 能力。 Core Java SDK for unified LLM access, tool calling, RAG, and MCP integration.</description>
@@ -371,7 +371,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>

--- a/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
+++ b/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
@@ -41,7 +41,7 @@ https://github.com/LnYo-Cly/ai4j-plugin-dynamic-workflow
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j-extension-api</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
 </dependency>
 ```
 

--- a/docs-site/docs/reference/release-and-artifacts.md
+++ b/docs-site/docs/reference/release-and-artifacts.md
@@ -17,7 +17,7 @@ AI4J 当前发布坐标使用：
 当前仓库版本为：
 
 ```xml
-<version>2.4.0</version>
+<version>2.4.1</version>
 ```
 
 ## 推荐依赖方式
@@ -28,7 +28,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 </dependency>
 ```
 
@@ -40,7 +40,7 @@ AI4J 当前发布坐标使用：
         <dependency>
             <groupId>io.github.lnyo-cly</groupId>
             <artifactId>ai4j-bom</artifactId>
-            <version>2.4.0</version>
+            <version>2.4.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -91,7 +91,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 </dependency>
 ```
 
@@ -111,7 +111,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-agent</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 </dependency>
 ```
 

--- a/docs-site/docs/reference/version-compatibility.md
+++ b/docs-site/docs/reference/version-compatibility.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 | 项 | 当前边界 |
 | --- | --- |
-| AI4J 版本 | `2.4.0` |
+| AI4J 版本 | `2.4.1` |
 | Maven groupId | `io.github.lnyo-cly` |
 | Java baseline | Java 8 source / target |
 | 构建工具 | Maven |

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-sdk</artifactId>
 
-    <version>2.4.0</version>
+    <version>2.4.1</version>
 
     <packaging>pom</packaging>
 
@@ -149,7 +149,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>


### PR DESCRIPTION
## Summary
- Bump Maven modules, README install snippets, docs-site release references, extension manifest/scaffold defaults to 2.4.1.
- Upgrade `central-publishing-maven-plugin` from 0.4.0 to 0.11.0.
- Preserve release-profile CLI assembly skip so Central does not receive `jar-with-dependencies`.

## Verification
- `mvn -pl ai4j-agent -am -Dtest=NodeIoCaptureReplayTest -DfailIfNoTests=false -DskipTests=false test` PASS (12 tests)
- `mvn -DskipTests package` PASS (11 modules)
- `mvn -P release -DskipTests clean verify` PASS (11 modules, signed artifacts)
- Release profile check: `ai4j-cli-2.4.1-jar-with-dependencies.jar` ABSENT
- `npm --prefix docs-site ci` then `npm --prefix docs-site run build` PASS
- `git diff --check` PASS

## Notes
- 2.4.1 supersedes 2.4.0 because Maven Central 2.4.0 artifacts were published before the final JSONL replay timestamp fix while GitHub release/tag pointed at the fixed merge.