### PR TITLE
fix(release): remove obsolete central tokenAuth setting

### DIFF
--- a/ai4j-agent/pom.xml
+++ b/ai4j-agent/pom.xml
@@ -201,7 +201,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-bom/pom.xml
+++ b/ai4j-bom/pom.xml
@@ -144,7 +144,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -250,7 +250,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-coding/pom.xml
+++ b/ai4j-coding/pom.xml
@@ -175,7 +175,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-extension-api/pom.xml
+++ b/ai4j-extension-api/pom.xml
@@ -109,7 +109,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-flowgram-spring-boot-starter/pom.xml
+++ b/ai4j-flowgram-spring-boot-starter/pom.xml
@@ -221,7 +221,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-plugin-ask-user/pom.xml
+++ b/ai4j-plugin-ask-user/pom.xml
@@ -114,7 +114,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j-spring-boot-starter/pom.xml
+++ b/ai4j-spring-boot-starter/pom.xml
@@ -229,7 +229,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -375,7 +375,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>LnYo-Cly</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                             <excludeArtifacts>
                                 <excludeArtifact>ai4j-sdk</excludeArtifact>
                                 <excludeArtifact>ai4j-flowgram-demo</excludeArtifact>


### PR DESCRIPTION
## Summary
- Remove obsolete `<tokenAuth>true</tokenAuth>` from all Central Publishing Maven Plugin 0.11.0 release profile configs.
- Keeps `publishingServerId` credential lookup and 0.11.0 plugin upgrade from #195.

## Verification
- `mvn -P release -DskipTests clean verify` PASS (11 modules)
- No `tokenAuth`/unknown-parameter warning after removal
- `git diff --check` PASS

## Why
The first 2.4.1 deploy attempt was intentionally stopped before Central bundle upload because plugin 0.11.0 reported `tokenAuth` as an unknown parameter.