### PR TITLE
docs: refresh README capability summary

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -23,13 +23,14 @@
 A Java AI Agentic development toolkit for JDK 8+, combining foundational AI capabilities with higher-level agent development capabilities.  
 It covers multi-provider model access, unified I/O, Tool Calling, MCP, RAG, unified `VectorStore`, ChatMemory, agent runtime, coding agent, CLI / TUI / ACP, FlowGram integration, and integration with published AgentFlow endpoints such as Dify, Coze, and n8n, helping Java applications grow from basic model integration to more complete agentic application development.
 
-This repository has evolved into a multi-module SDK. In addition to the core `ai4j` module, it now provides `ai4j-agent`, `ai4j-coding`, `ai4j-cli`, `ai4j-spring-boot-starter`, `ai4j-flowgram-spring-boot-starter`, and `ai4j-bom`. If you only need the basic LLM integration layer, start with `ai4j`. If you need agent runtime, coding agent, CLI / ACP, Spring Boot, or FlowGram integration, add the corresponding modules.
+This repository has evolved into a multi-module SDK. In addition to the core `ai4j` module, it now provides `ai4j-extension-api`, `ai4j-plugin-ask-user`, `ai4j-agent`, `ai4j-coding`, `ai4j-cli`, `ai4j-spring-boot-starter`, `ai4j-flowgram-spring-boot-starter`, and `ai4j-bom`. If you only need the basic LLM integration layer, start with `ai4j`. If you need plugin packages, agent runtime, coding agent, CLI / ACP, Spring Boot, or FlowGram integration, add the corresponding modules.
 
 ## README navigation
 
 - [Quick choice](#quick-choice)
 - [Install snippets](#install-snippets)
 - [Project overview](#positioning-compared-with-common-java-ai-options)
+- [Official docs site](#official-docs-site)
 - [Detailed docs](#detailed-docs)
 - [中文 README](README.md)
 
@@ -73,7 +74,10 @@ For module selection, Spring Boot configuration, and usage examples, see [Quick 
 | `LangChain4j` | `Java 17+` | Plain Java / Spring / Quarkus and more | General Java abstractions for LLM, agent, and RAG integration, plus AI Services |
 
 ## Supported platforms
-+ OpenAi
++ OpenAI / OpenAI-compatible
++ Anthropic / Anthropic-compatible Messages
++ DashScope
++ Doubao / Volcengine Ark
 + Jina (Rerank / Jina-compatible Rerank)
 + Zhipu
 + DeepSeek
@@ -83,15 +87,19 @@ For module selection, Spring Boot configuration, and usage examples, see [Quick 
 + Ollama
 + MiniMax
 + Baichuan
++ Suno
 
 ## Supported services
-+ Chat Completions（streaming and non-streaming）
++ Chat Completions (streaming and non-streaming)
 + Responses
++ Anthropic Messages
 + Embedding
 + Rerank
 + Audio
 + Image
++ Video
 + Realtime
++ Music (Suno task-based generation)
 
 ## Supported AgentFlow / hosted workflow platforms
 + Dify (chat / workflow)
@@ -106,6 +114,7 @@ For module selection, Spring Boot configuration, and usage examples, see [Quick 
 + Built-in Coding Agent CLI / TUI with interactive repository sessions, provider profiles, workspace model override, and session/process management.
 + Provides `ai4j-coding` as the coding agent runtime, with workspace-aware tools, outer loop, checkpoint compaction, subagent, and team collaboration support.
 + Provides `ai4j-flowgram-spring-boot-starter` for integrating FlowGram workflows and trace in Spring Boot applications.
++ Provides `ai4j-extension-api` and the official `ai4j-plugin-ask-user` sample plugin for extending Agent / Coding Agent tools, commands, Skills, and Prompts.
 + Provides `ai4j-bom` for version alignment across multiple ai4j modules.
 + Unified input and output.
 + Unified error handling.
@@ -113,9 +122,25 @@ For module selection, Spring Boot configuration, and usage examples, see [Quick 
 + Easily use Tool Calls.
 + Supports simultaneous calls of multiple functions (Zhipu does not support this).
 + Supports stream_options, and directly obtains statistical token usage through streaming output.
-+ Supports RAG. Built-in vector database support: Pinecone.
++ Built-in `ChatMemory` for basic multi-turn context across Chat / Responses.
++ Supports RAG with a unified `VectorStore` abstraction. Current vector stores include Pinecone, Qdrant, pgvector, and Milvus.
++ Built-in `IngestionPipeline` for `DocumentLoader -> Chunker -> MetadataEnricher -> Embedding -> VectorStore.upsert`.
++ Built-in `DenseRetriever`, `Bm25Retriever`, and `HybridRetriever` for semantic, keyword, and hybrid retrieval.
++ `HybridRetriever` supports RRF / RSF / DBSF fusion, keeping fusion ranking separate from semantic reranking.
++ Unified `IRerankService` with Jina / Jina-compatible, Ollama, and Doubao rerank support; `ModelReranker` plugs directly into RAG.
++ RAG trace exposes rank, retriever source, retrieval/fusion/rerank scores, score details, and evaluator metrics such as Precision@K, Recall@K, MRR, and NDCG.
 + Uses Tika to read files.
-+ Token statistics`TikTokensUtil.java`
++ Provides basic token estimation and usage utilities.
+
+## Official docs site
++ Online docs: `https://lnyo-cly.github.io/ai4j/`
++ Docs source: `docs-site/`
++ Start here: `docs-site/docs/start-here/five-minute-first-chat.md`
++ Java quickstart: `docs-site/docs/start-here/quickstart-java.md`
++ Spring Boot quickstart: `docs-site/docs/start-here/quickstart-spring-boot.md`
++ Feature map: `docs-site/docs/start-here/feature-map.md`
++ Plugin packages: `docs-site/docs/core-sdk/extension/plugin-packages.md`
++ Ask User plugin: `docs-site/docs/core-sdk/extension/ask-user-plugin.md`
 
 ## Detailed docs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 
 - [快速选择](#快速选择)
 - [安装片段](#安装片段)
-- [项目概览](#赞助商)
+- [项目定位与对比](#适用场景与常见方案对比)
+- [赞助商](#赞助商)
 - [官方文档站](#官方文档站)
 - [详细文档](#详细文档)
 - [English README](README-EN.md)
@@ -80,25 +81,32 @@ Maven：
 | `LangChain4j` | `Java 17+` | 普通 Java / Spring / Quarkus 等 | 通用 Java LLM / Agent / RAG 抽象、AI Services、多框架集成 |
 
 ## 支持的平台
-+ OpenAi(包含与OpenAi请求格式相同/兼容的平台)
++ OpenAI / OpenAI-compatible
++ Anthropic / Anthropic-compatible Messages
++ DashScope（阿里云百炼 / 通义）
++ Doubao（火山方舟 / 豆包）
 + Jina（Rerank / Jina-compatible Rerank）
-+ Zhipu(智谱)
-+ DeepSeek(深度求索)
-+ Moonshot(月之暗面)
-+ Hunyuan(腾讯混元)
-+ Lingyi(零一万物)
++ Zhipu（智谱）
++ DeepSeek（深度求索）
++ Moonshot（月之暗面）
++ Hunyuan（腾讯混元）
++ Lingyi（零一万物）
 + Ollama
 + MiniMax
 + Baichuan
++ Suno
 
 ## 支持的服务
 + Chat Completions（流式与非流式）
 + Responses
++ Anthropic Messages
 + Embedding
 + Rerank
 + Audio
 + Image
++ Video
 + Realtime
++ Music（Suno 任务式生成）
 
 ## 已适配的 AgentFlow / 工作流平台
 + Dify（Chat / Workflow）
@@ -133,7 +141,7 @@ Maven：
 + 支持统一 `IRerankService`，当前可接 Jina / Jina-compatible、Ollama、Doubao(方舟知识库重排)；可通过 `ModelReranker` 无缝接入 RAG 精排
 + RAG 运行时可直接拿到 `rank/retrieverSource/retrievalScore/fusionScore/rerankScore/scoreDetails/trace`，并可通过 `RagEvaluator` 计算 `Precision@K/Recall@K/F1@K/MRR/NDCG`
 + 使用Tika读取文件
-+ Token统计`TikTokensUtil.java`
++ 提供基础 token 估算与用量统计工具
 
 ## 官方文档站
 + 在线文档站：`https://lnyo-cly.github.io/ai4j/`


### PR DESCRIPTION
## Summary
- fix the Chinese README navigation anchor for project positioning
- sync Chinese and English platform/service capability lists with current SDK code
- bring the English README module/RAG/docs-site summary closer to the Chinese README

## Verification
- git diff --check
- README local markdown links existence check

Docs-only change; no Maven/POM changes.
