### PR TITLE
feat(agent): add server-side filter to RagTool

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/rag/RagTool.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/rag/RagTool.java
@@ -36,8 +36,9 @@ import java.util.Map;
  *           .build();
  * }</pre>
  *
- * <p>filter（多租户权限过滤）可在 RagService 构造时通过 Retriever 注入，
- * 也可由调用方在 executor 里包一层（从 AgentContext 取租户）。
+ * <p>filter（多租户/权限过滤）应由服务端固定注入，而不是暴露成模型可写的
+ * tool 入参。可通过 {@link Builder#filter(Map)} 绑定到此 tool；模型侧 schema
+ * 仍只包含 {@code query}，避免由 LLM 决定租户或权限边界。
  */
 public class RagTool {
 
@@ -45,6 +46,7 @@ public class RagTool {
     private final String dataset;
     private final String embeddingModel;
     private final int topK;
+    private final Map<String, Object> filter;
     private final String name;
     private final String description;
 
@@ -56,7 +58,21 @@ public class RagTool {
     }
 
     public RagTool(RagService ragService, String dataset, String embeddingModel, int topK,
+                   Map<String, Object> filter) {
+        this(ragService, dataset, embeddingModel, topK,
+                "knowledge_search",
+                "Search the knowledge base for relevant context to answer the user's question. "
+                        + "Input: {\"query\": \"the question\"}. Returns assembled context with citations.",
+                filter);
+    }
+
+    public RagTool(RagService ragService, String dataset, String embeddingModel, int topK,
                    String name, String description) {
+        this(ragService, dataset, embeddingModel, topK, name, description, null);
+    }
+
+    public RagTool(RagService ragService, String dataset, String embeddingModel, int topK,
+                   String name, String description, Map<String, Object> filter) {
         if (ragService == null) {
             throw new IllegalArgumentException("ragService is required");
         }
@@ -70,11 +86,14 @@ public class RagTool {
         this.dataset = dataset;
         this.embeddingModel = embeddingModel;
         this.topK = topK <= 0 ? 5 : topK;
+        this.filter = filter == null || filter.isEmpty()
+                ? null
+                : Collections.unmodifiableMap(new HashMap<String, Object>(filter));
         this.name = name;
         this.description = description;
     }
 
-    /** OpenAI function schema（agent 调用契约）。 */
+    /** OpenAI function schema（agent 调用契约）。只暴露 query，不暴露服务端固定 filter。 */
     public Tool tool() {
         Tool.Function fn = new Tool.Function();
         fn.setName(name);
@@ -124,6 +143,7 @@ public class RagTool {
                     .dataset(dataset)
                     .embeddingModel(embeddingModel)
                     .topK(topK)
+                    .filter(filter == null ? null : new HashMap<String, Object>(filter))
                     .build());
             lastResult.set(result);
             return result == null || result.getContext() == null ? "" : result.getContext();
@@ -144,6 +164,7 @@ public class RagTool {
         private String dataset;
         private String embeddingModel;
         private int topK = 5;
+        private Map<String, Object> filter;
         private String name = "knowledge_search";
         private String description = "Search the knowledge base for relevant context.";
 
@@ -166,6 +187,15 @@ public class RagTool {
             return this;
         }
 
+        /**
+         * Bind a fixed server-side retrieval filter. This filter is not exposed in
+         * the tool input schema and cannot be changed by model-provided arguments.
+         */
+        public Builder filter(Map<String, Object> filter) {
+            this.filter = filter;
+            return this;
+        }
+
         public Builder name(String name) {
             this.name = name;
             return this;
@@ -177,7 +207,7 @@ public class RagTool {
         }
 
         public RagTool build() {
-            return new RagTool(ragService, dataset, embeddingModel, topK, name, description);
+            return new RagTool(ragService, dataset, embeddingModel, topK, name, description, filter);
         }
     }
 }

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/rag/RagToolTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/rag/RagToolTest.java
@@ -1,0 +1,60 @@
+package io.github.lnyocly.ai4j.agent.rag;
+
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.rag.RagQuery;
+import io.github.lnyocly.ai4j.rag.RagResult;
+import io.github.lnyocly.ai4j.rag.RagService;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RagToolTest {
+
+    @Test
+    public void builderBindsServerSideFilterWithoutExposingItToModelSchema() throws Exception {
+        CapturingRagService ragService = new CapturingRagService();
+        Map<String, Object> filter = new HashMap<String, Object>();
+        filter.put("tenant", "tenant_a");
+
+        RagTool ragTool = RagTool.builder(ragService)
+                .dataset("shared-kb")
+                .embeddingModel("embed")
+                .topK(3)
+                .filter(filter)
+                .build();
+
+        filter.put("tenant", "tenant_b");
+
+        Tool tool = ragTool.tool();
+        Map<String, Tool.Function.Property> properties = tool.getFunction()
+                .getParameters()
+                .getProperties();
+        Assert.assertTrue(properties.containsKey("query"));
+        Assert.assertFalse(properties.containsKey("filter"));
+
+        String output = ragTool.executor().execute(AgentToolCall.builder()
+                .name("knowledge_search")
+                .arguments("{\"query\":\"policy\",\"filter\":{\"tenant\":\"attacker\"}}")
+                .build());
+
+        Assert.assertEquals("ctx", output);
+        Assert.assertEquals("policy", ragService.lastQuery.getQuery());
+        Assert.assertEquals("shared-kb", ragService.lastQuery.getDataset());
+        Assert.assertEquals("embed", ragService.lastQuery.getEmbeddingModel());
+        Assert.assertEquals(Integer.valueOf(3), ragService.lastQuery.getTopK());
+        Assert.assertEquals("tenant_a", ragService.lastQuery.getFilter().get("tenant"));
+    }
+
+    private static class CapturingRagService implements RagService {
+        private RagQuery lastQuery;
+
+        @Override
+        public RagResult search(RagQuery query) {
+            this.lastQuery = query;
+            return RagResult.builder().context("ctx").build();
+        }
+    }
+}

--- a/docs-site/docs/agent/tools-and-registry.md
+++ b/docs-site/docs/agent/tools-and-registry.md
@@ -96,6 +96,37 @@ public interface ToolExecutor {
 - 不是 `AgentToolCallSanitizer`
 - 也不是某个通用 hook
 
+### 3.1 RAG-as-tool 的多租户 filter 必须固定在服务端
+
+如果把知识库检索暴露成 `RagTool`，模型可见的 tool schema 应只包含用户查询，例如：
+
+```json
+{"query": "用户问题"}
+```
+
+租户、部门、项目、权限范围这类 filter 不应该放进 tool input schema，让模型自己传：
+
+```json
+{"query": "用户问题", "filter": {"tenant": "tenant_a"}}
+```
+
+正确做法是在宿主侧构造 tool 时固定绑定：
+
+```java
+Map<String, Object> tenantFilter = new HashMap<String, Object>();
+tenantFilter.put("tenant", tenantIdFromSession);
+
+RagTool ragTool = RagTool.builder(ragService)
+        .dataset("shared-kb")
+        .embeddingModel("text-embedding")
+        .topK(5)
+        .filter(tenantFilter)
+        .build();
+```
+
+这样 LLM 只负责提出检索 query，真正的租户边界由服务端执行器写入 `RagQuery.filter`。
+这和普通工具权限一样，属于执行边界，不属于模型可协商的参数。
+
 ## 4. 默认 Builder 装配路径比看起来更具体
 
 `AgentBuilder.build()` 的默认逻辑不是“自动帮你把工具接好”，而是一条明确的决策链。


### PR DESCRIPTION
## Summary
- Add a server-side fixed `filter` option to `RagTool` via constructors and builder.
- Keep the model-visible tool schema limited to `query`; LLM-provided arguments cannot set or override tenant/permission filters.
- Document the RAG-as-tool multi-tenant boundary in agent tool docs.

## Verification
- `mvn -pl ai4j-agent -Dtest=RagToolTest -DskipTests=false -DfailIfNoTests=false -DfailIfNoSpecifiedTests=false clean test`
- `git diff --check`

## Known gap
- `npm --prefix docs-site run build` was attempted but this worktree is missing `docs-site/node_modules/@docusaurus/core`, so docs-site build is environment-blocked until dependencies are installed.