### PR TITLE
chore(release): prepare 2.4.2

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -49,7 +49,7 @@ This repository has evolved into a multi-module SDK. In addition to the core `ai
 Gradle:
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.1'
+implementation 'io.github.lnyo-cly:ai4j:2.4.2'
 ```
 
 Maven:
@@ -58,7 +58,7 @@ Maven:
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 Gradle：
 
 ```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.1'
+implementation 'io.github.lnyo-cly:ai4j:2.4.2'
 ```
 
 Maven：
@@ -61,7 +61,7 @@ Maven：
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.2</version>
 </dependency>
 ```
 

--- a/ai4j-agent/pom.xml
+++ b/ai4j-agent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-agent</artifactId>

--- a/ai4j-bom/pom.xml
+++ b/ai4j-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-bom</artifactId>

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-cli</artifactId>

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/CliExtensionCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class CliExtensionCommand {
 
-    private static final String EXTENSION_API_VERSION = "2.4.1";
+    private static final String EXTENSION_API_VERSION = "2.4.2";
 
     private final Path currentDirectory;
 

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/ExtensionScaffoldGenerator.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/command/ExtensionScaffoldGenerator.java
@@ -478,7 +478,7 @@ final class ExtensionScaffoldGenerator {
             this.version = defaultIfBlank(builder.version, "1.0.0");
             this.className = requireClassName(defaultIfBlank(builder.className, classNameFromId(this.extensionId)));
             this.vendor = defaultIfBlank(builder.vendor, "example");
-            this.extensionApiVersion = defaultIfBlank(builder.extensionApiVersion, "2.4.1");
+            this.extensionApiVersion = defaultIfBlank(builder.extensionApiVersion, "2.4.2");
             this.namespace = namespaceFromId(this.extensionId);
             this.resourceSegment = resourceSegmentFromId(this.extensionId);
             this.toolName = this.namespace + ".echo";

--- a/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/Ai4jCliTest.java
+++ b/ai4j-cli/src/test/java/io/github/lnyocly/ai4j/cli/Ai4jCliTest.java
@@ -775,7 +775,7 @@ public class Ai4jCliTest {
         String testSource = read(plugin.resolve("src/test/java/com/example/ai4j/weather/WeatherPackExtensionTest.java"));
         String readme = read(plugin.resolve("README.md"));
         String service = read(plugin.resolve("src/main/resources/META-INF/services/io.github.lnyocly.ai4j.extension.Ai4jExtension"));
-        Assert.assertTrue(pom.contains("<version>2.4.1</version>"));
+        Assert.assertTrue(pom.contains("<version>2.4.2</version>"));
         Assert.assertTrue(extensionSource.contains("implements Ai4jExtension"));
         Assert.assertTrue(extensionSource.contains(".id(\"weather-pack\")"));
         Assert.assertTrue(extensionSource.contains(".capability(ExtensionCapability.TOOL)"));

--- a/ai4j-coding/pom.xml
+++ b/ai4j-coding/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-coding</artifactId>

--- a/ai4j-extension-api/pom.xml
+++ b/ai4j-extension-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-extension-api</artifactId>

--- a/ai4j-flowgram-demo/pom.xml
+++ b/ai4j-flowgram-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-flowgram-demo</artifactId>

--- a/ai4j-flowgram-spring-boot-starter/pom.xml
+++ b/ai4j-flowgram-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-flowgram-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.4.2</version>
 
     <name>ai4j-flowgram-spring-boot-starter</name>
     <description>ai4j FlowGram 的 Spring Boot Starter，支持流程应用与 trace 集成。 Spring Boot starter for ai4j FlowGram workflow applications and trace integration.</description>

--- a/ai4j-plugin-ask-user/pom.xml
+++ b/ai4j-plugin-ask-user/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2-SNAPSHOT</version>
+        <version>2.4.2</version>
     </parent>
 
     <artifactId>ai4j-plugin-ask-user</artifactId>

--- a/ai4j-plugin-ask-user/src/main/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtension.java
+++ b/ai4j-plugin-ask-user/src/main/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtension.java
@@ -23,7 +23,7 @@ public final class AskUserExtension implements Ai4jExtension {
     public static final String SKILL_NAME = "ask-user-collaboration";
     public static final String PROMPT_NAME = "ask-user-question";
 
-    private static final String VERSION = "2.4.1";
+    private static final String VERSION = "2.4.2";
 
     public ExtensionManifest manifest() {
         return ExtensionManifest.builder()

--- a/ai4j-plugin-ask-user/src/test/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtensionTest.java
+++ b/ai4j-plugin-ask-user/src/test/java/io/github/lnyocly/ai4j/plugin/askuser/AskUserExtensionTest.java
@@ -25,7 +25,7 @@ public class AskUserExtensionTest {
 
         Assert.assertEquals("ask-user", manifest.getId());
         Assert.assertEquals("Ask User", manifest.getName());
-        Assert.assertEquals("2.4.1", manifest.getVersion());
+        Assert.assertEquals("2.4.2", manifest.getVersion());
         Assert.assertEquals("ai4j", manifest.getVendor());
         Assert.assertTrue(manifest.hasCapability(ExtensionCapability.TOOL));
         Assert.assertTrue(manifest.hasCapability(ExtensionCapability.COMMAND));

--- a/ai4j-spring-boot-starter/pom.xml
+++ b/ai4j-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.4.2</version>
 
     <name>ai4j-spring-boot-starter</name>
     <description>ai4j 核心 SDK 的 Spring Boot Starter，简化自动配置与集成。 Spring Boot starter for configuring and integrating the ai4j core SDK.</description>

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.4.2</version>
 
     <name>ai4j</name>
     <description>ai4j 核心 Java SDK，提供统一大模型接入、Tool Call、RAG 与 MCP 能力。 Core Java SDK for unified LLM access, tool calling, RAG, and MCP integration.</description>

--- a/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
+++ b/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
@@ -41,7 +41,7 @@ https://github.com/LnYo-Cly/ai4j-plugin-dynamic-workflow
 <dependency>
   <groupId>io.github.lnyo-cly</groupId>
   <artifactId>ai4j-extension-api</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.2</version>
 </dependency>
 ```
 

--- a/docs-site/docs/reference/release-and-artifacts.md
+++ b/docs-site/docs/reference/release-and-artifacts.md
@@ -17,7 +17,7 @@ AI4J 当前发布坐标使用：
 当前仓库版本为：
 
 ```xml
-<version>2.4.1</version>
+<version>2.4.2</version>
 ```
 
 ## 推荐依赖方式
@@ -28,7 +28,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
 </dependency>
 ```
 
@@ -40,7 +40,7 @@ AI4J 当前发布坐标使用：
         <dependency>
             <groupId>io.github.lnyo-cly</groupId>
             <artifactId>ai4j-bom</artifactId>
-            <version>2.4.1</version>
+            <version>2.4.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -91,7 +91,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
 </dependency>
 ```
 
@@ -111,7 +111,7 @@ AI4J 当前发布坐标使用：
 <dependency>
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-agent</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
 </dependency>
 ```
 

--- a/docs-site/docs/reference/release-checklist.md
+++ b/docs-site/docs/reference/release-checklist.md
@@ -10,8 +10,8 @@ sidebar_position: 3
 
 AI4J 当前采用 **全模块同号发布**：
 
-- 发布版：所有发布模块使用同一个稳定版本，例如 `2.4.1`
-- 开发分支：所有 Maven POM 使用下一个 `SNAPSHOT`，例如 `2.4.2-SNAPSHOT`
+- 发布版：所有发布模块使用同一个稳定版本，例如 `2.4.2`
+- 开发分支：所有 Maven POM 使用下一个 `SNAPSHOT`，例如 `2.4.3-SNAPSHOT`
 - README / docs 示例：写最新已发布稳定版，不写 `SNAPSHOT`
 
 只改 README、docs-site 或 demo 时，不需要发布新的 Maven 版本。

--- a/docs-site/docs/reference/version-compatibility.md
+++ b/docs-site/docs/reference/version-compatibility.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 | 项 | 当前边界 |
 | --- | --- |
-| AI4J 版本 | `2.4.1` |
+| AI4J 版本 | `2.4.2` |
 | Maven groupId | `io.github.lnyo-cly` |
 | Java baseline | Java 8 source / target |
 | 构建工具 | Maven |

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-sdk</artifactId>
 
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.4.2</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
- Move the release train from `2.4.2-SNAPSHOT` to stable `2.4.2`.
- Update README, docs-site release references, extension scaffold defaults, and official ask-user plugin manifest version to `2.4.2`.
- Keep package-lock third-party `2.4.1` dependency versions untouched.

## Verification
- `mvn -DskipTests package`
- `npm --prefix docs-site ci`
- `npm --prefix docs-site run build`
- `mvn -P release -DskipTests clean verify`
- `git diff --check`

## Notes
- First release-profile verify attempt stopped before upload due GPG timeout; a local GPG smoke sign succeeded and the re-run passed. No Central deployment was created by the failed attempt.