### PR TITLE
chore(release): bump main to 2.4.3-SNAPSHOT

### DIFF
--- a/ai4j-agent/pom.xml
+++ b/ai4j-agent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-agent</artifactId>

--- a/ai4j-bom/pom.xml
+++ b/ai4j-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-bom</artifactId>

--- a/ai4j-cli/pom.xml
+++ b/ai4j-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-cli</artifactId>

--- a/ai4j-coding/pom.xml
+++ b/ai4j-coding/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-coding</artifactId>

--- a/ai4j-extension-api/pom.xml
+++ b/ai4j-extension-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-extension-api</artifactId>

--- a/ai4j-flowgram-demo/pom.xml
+++ b/ai4j-flowgram-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-flowgram-demo</artifactId>

--- a/ai4j-flowgram-spring-boot-starter/pom.xml
+++ b/ai4j-flowgram-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-flowgram-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2</version>
+    <version>2.4.3-SNAPSHOT</version>
 
     <name>ai4j-flowgram-spring-boot-starter</name>
     <description>ai4j FlowGram 的 Spring Boot Starter，支持流程应用与 trace 集成。 Spring Boot starter for ai4j FlowGram workflow applications and trace integration.</description>

--- a/ai4j-plugin-ask-user/pom.xml
+++ b/ai4j-plugin-ask-user/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.lnyo-cly</groupId>
         <artifactId>ai4j-sdk</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai4j-plugin-ask-user</artifactId>

--- a/ai4j-spring-boot-starter/pom.xml
+++ b/ai4j-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2</version>
+    <version>2.4.3-SNAPSHOT</version>
 
     <name>ai4j-spring-boot-starter</name>
     <description>ai4j 核心 SDK 的 Spring Boot Starter，简化自动配置与集成。 Spring Boot starter for configuring and integrating the ai4j core SDK.</description>

--- a/ai4j/pom.xml
+++ b/ai4j/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.2</version>
+    <version>2.4.3-SNAPSHOT</version>
 
     <name>ai4j</name>
     <description>ai4j 核心 Java SDK，提供统一大模型接入、Tool Call、RAG 与 MCP 能力。 Core Java SDK for unified LLM access, tool calling, RAG, and MCP integration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.lnyo-cly</groupId>
     <artifactId>ai4j-sdk</artifactId>
 
-    <version>2.4.2</version>
+    <version>2.4.3-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
- Bump all Maven POM release-train versions from 2.4.2 to 2.4.3-SNAPSHOT after publishing 2.4.2.
- Keep README/docs stable user-facing examples at 2.4.2.

## Verification
- git diff --check
- mvn -DskipTests package