### PR TITLE
docs: close P0-F annotation and README gaps

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -1,55 +1,20 @@
-<p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:6A5ACD,100:2E86C1&height=180&section=header&text=ai4j&fontSize=46&fontColor=ffffff&animation=fadeIn&desc=Java%20AI%20Agentic%20SDK%20for%20JDK%208%2B&descAlignY=68" alt="ai4j banner" />
-</p>
-
-<p align="center">
-  <a href="https://search.maven.org/artifact/io.github.lnyo-cly/ai4j">
-    <img src="https://img.shields.io/maven-central/v/io.github.lnyo-cly/ai4j?color=2E86C1&label=Maven%20Central" alt="Maven Central" />
-  </a>
-  <a href="https://lnyo-cly.github.io/ai4j/">
-    <img src="https://img.shields.io/badge/Docs-GitHub%20Pages-0A7EA4" alt="Docs" />
-  </a>
-  <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">
-    <img src="https://img.shields.io/badge/License-Apache%202.0-1F6FEB" alt="License" />
-  </a>
-  <img src="https://img.shields.io/badge/JDK-8%2B-2EA043" alt="JDK 8+" />
-  <img src="https://img.shields.io/badge/Agentic-Enabled-6F42C1" alt="Agentic Enabled" />
-  <img src="https://img.shields.io/badge/MCP-Supported-0F766E" alt="MCP Supported" />
-  <img src="https://img.shields.io/badge/RAG-Built--in-B45309" alt="RAG Built-in" />
-  <img src="https://img.shields.io/badge/CLI%20%2F%20TUI%20%2F%20ACP-Built--in-475569" alt="CLI TUI ACP Built-in" />
-</p>
+<p align="center"><img src="https://capsule-render.vercel.app/api?type=waving&color=0:6A5ACD,100:2E86C1&height=180&section=header&text=ai4j&fontSize=46&fontColor=ffffff&animation=fadeIn&desc=Java%20AI%20Agentic%20SDK%20for%20JDK%208%2B&descAlignY=68" alt="ai4j banner" /></p>
+<p align="center"><a href="https://search.maven.org/artifact/io.github.lnyo-cly/ai4j"><img src="https://img.shields.io/maven-central/v/io.github.lnyo-cly/ai4j?color=2E86C1&label=Maven%20Central" alt="Maven Central" /></a> <a href="https://lnyo-cly.github.io/ai4j/"><img src="https://img.shields.io/badge/Docs-GitHub%20Pages-0A7EA4" alt="Docs" /></a> <a href="https://www.apache.org/licenses/LICENSE-2.0.txt"><img src="https://img.shields.io/badge/License-Apache%202.0-1F6FEB" alt="License" /></a> <img src="https://img.shields.io/badge/JDK-8%2B-2EA043" alt="JDK 8+" /> <img src="https://img.shields.io/badge/Agentic-Enabled-6F42C1" alt="Agentic Enabled" /> <img src="https://img.shields.io/badge/MCP-Supported-0F766E" alt="MCP Supported" /> <img src="https://img.shields.io/badge/RAG-Built--in-B45309" alt="RAG Built-in" /> <img src="https://img.shields.io/badge/CLI%20%2F%20TUI%20%2F%20ACP-Built--in-475569" alt="CLI TUI ACP Built-in" /></p>
 
 # ai4j
 
-A **JDK 8+** Java AI Agentic SDK: unified LLM access, Tool Calling, MCP, RAG, an Agent Runtime, and a built-in Coding Agent CLI / TUI / ACP. One SDK covering the full path from basic model calls to complete agentic applications.
+A **JDK 8+** Java AI Agentic SDK: unified LLM access, Tool Calling, MCP, RAG, an Agent Runtime, and a built-in Coding Agent CLI / TUI / ACP.
 
 [中文 README](README.md)
 
 ## Install
 
-Gradle:
-
-```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.2'
-```
-
-Maven:
-
-```xml
-<dependency>
-  <groupId>io.github.lnyo-cly</groupId>
-  <artifactId>ai4j</artifactId>
-  <version>2.4.2</version>
-</dependency>
-```
+- Gradle: `implementation 'io.github.lnyo-cly:ai4j:2.4.2'`
+- Maven: `<dependency><groupId>io.github.lnyo-cly</groupId><artifactId>ai4j</artifactId><version>2.4.2</version></dependency>`
 
 ## Run your first request in 30 seconds
 
-Set the environment variable, then run this code:
-
-```bash
-export OPENAI_API_KEY=sk-...
-```
+Set `OPENAI_API_KEY`, then run this code:
 
 ```java
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
@@ -60,23 +25,18 @@ import io.github.lnyocly.ai4j.service.Configuration;
 import io.github.lnyocly.ai4j.service.IChatService;
 import io.github.lnyocly.ai4j.service.PlatformType;
 import io.github.lnyocly.ai4j.service.factory.AiService;
-
 public class Ai4jFirstChat {
     public static void main(String[] args) {
         OpenAiConfig openAiConfig = new OpenAiConfig();
         openAiConfig.setApiKey(System.getenv("OPENAI_API_KEY"));
-
         Configuration configuration = new Configuration();
         configuration.setOpenAiConfig(openAiConfig);
-
         AiService aiService = new AiService(configuration);
         IChatService chatService = aiService.getChatService(PlatformType.OPENAI);
-
         ChatCompletion request = ChatCompletion.builder()
                 .model("gpt-4o-mini")
                 .message(ChatMessage.withUser("Describe ai4j in one sentence"))
                 .build();
-
         ChatCompletionResponse response = chatService.chatCompletion(request);
         System.out.println(response.getChoices().get(0).getMessage().getContent().getText());
     }
@@ -84,21 +44,18 @@ public class Ai4jFirstChat {
 ```
 
 Sample output:
-
 ```
 ai4j is a JDK 8+ Java AI Agentic SDK covering unified model access, Tool Calling, MCP, and RAG.
 ```
 
-> Want DashScope / DeepSeek / Ollama instead? Just swap the `PlatformType` and its Config — the rest of the code stays the same.
+> Want DashScope / DeepSeek / Ollama instead? Just swap the `PlatformType` and its Config; the rest of the code stays the same.
 
 ## Links
 
-- Docs site: https://lnyo-cly.github.io/ai4j/
-- First request in five minutes: [five-minute-first-chat](docs-site/docs/start-here/five-minute-first-chat.md)
-- Feature map (full 28 capabilities): [feature-map](docs-site/docs/start-here/feature-map.md)
-- Coding Agent CLI / TUI / ACP: [coding-agent-cli](docs/readme/en/coding-agent-cli.md)
-- Changelog: [CHANGELOG](CHANGELOG.md)
-- Contributing: [CONTRIBUTING](CONTRIBUTING.md)
+- Docs: https://lnyo-cly.github.io/ai4j/
+- [First request in five minutes](docs-site/docs/start-here/five-minute-first-chat.md) / [feature map](docs-site/docs/start-here/feature-map.md)
+- [Coding Agent CLI / TUI / ACP](docs/readme/en/coding-agent-cli.md)
+- [CHANGELOG](CHANGELOG.md) / [CONTRIBUTING](CONTRIBUTING.md)
 
 ## Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,20 @@
-<p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:6A5ACD,100:2E86C1&height=180&section=header&text=ai4j&fontSize=46&fontColor=ffffff&animation=fadeIn&desc=Java%20AI%20Agentic%20SDK%20for%20JDK%208%2B&descAlignY=68" alt="ai4j banner" />
-</p>
-
-<p align="center">
-  <a href="https://search.maven.org/artifact/io.github.lnyo-cly/ai4j">
-    <img src="https://img.shields.io/maven-central/v/io.github.lnyo-cly/ai4j?color=2E86C1&label=Maven%20Central" alt="Maven Central" />
-  </a>
-  <a href="https://lnyo-cly.github.io/ai4j/">
-    <img src="https://img.shields.io/badge/Docs-GitHub%20Pages-0A7EA4" alt="Docs" />
-  </a>
-  <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">
-    <img src="https://img.shields.io/badge/License-Apache%202.0-1F6FEB" alt="License" />
-  </a>
-  <img src="https://img.shields.io/badge/JDK-8%2B-2EA043" alt="JDK 8+" />
-  <img src="https://img.shields.io/badge/Agentic-Enabled-6F42C1" alt="Agentic Enabled" />
-  <img src="https://img.shields.io/badge/MCP-Supported-0F766E" alt="MCP Supported" />
-  <img src="https://img.shields.io/badge/A2A-Supported-DC2626" alt="A2A Supported" />
-  <img src="https://img.shields.io/badge/RAG-Built--in-B45309" alt="RAG Built-in" />
-  <img src="https://img.shields.io/badge/CLI%20%2F%20TUI%20%2F%20ACP-Built--in-475569" alt="CLI TUI ACP Built-in" />
-</p>
+<p align="center"><img src="https://capsule-render.vercel.app/api?type=waving&color=0:6A5ACD,100:2E86C1&height=180&section=header&text=ai4j&fontSize=46&fontColor=ffffff&animation=fadeIn&desc=Java%20AI%20Agentic%20SDK%20for%20JDK%208%2B&descAlignY=68" alt="ai4j banner" /></p>
+<p align="center"><a href="https://search.maven.org/artifact/io.github.lnyo-cly/ai4j"><img src="https://img.shields.io/maven-central/v/io.github.lnyo-cly/ai4j?color=2E86C1&label=Maven%20Central" alt="Maven Central" /></a> <a href="https://lnyo-cly.github.io/ai4j/"><img src="https://img.shields.io/badge/Docs-GitHub%20Pages-0A7EA4" alt="Docs" /></a> <a href="https://www.apache.org/licenses/LICENSE-2.0.txt"><img src="https://img.shields.io/badge/License-Apache%202.0-1F6FEB" alt="License" /></a> <img src="https://img.shields.io/badge/JDK-8%2B-2EA043" alt="JDK 8+" /> <img src="https://img.shields.io/badge/Agentic-Enabled-6F42C1" alt="Agentic Enabled" /> <img src="https://img.shields.io/badge/MCP-Supported-0F766E" alt="MCP Supported" /> <img src="https://img.shields.io/badge/A2A-Supported-DC2626" alt="A2A Supported" /> <img src="https://img.shields.io/badge/RAG-Built--in-B45309" alt="RAG Built-in" /> <img src="https://img.shields.io/badge/CLI%20%2F%20TUI%20%2F%20ACP-Built--in-475569" alt="CLI TUI ACP Built-in" /></p>
 
 # ai4j
 
-一款面向 **JDK 8+** 的 Java AI Agentic 开发套件：统一的大模型接入、Tool Calling、MCP、A2A、RAG、Agent Runtime，以及内置的 Coding Agent CLI / TUI / ACP。从基础模型调用到完整的 agentic 应用，一套 SDK 覆盖全链路。
+一款面向 **JDK 8+** 的 Java AI Agentic 开发套件：统一的大模型接入、Tool Calling、MCP、A2A、RAG、Agent Runtime，以及内置的 Coding Agent CLI / TUI / ACP。
 
 [English README](README-EN.md)
 
 ## 安装
 
-Gradle：
-
-```gradle
-implementation 'io.github.lnyo-cly:ai4j:2.4.2'
-```
-
-Maven：
-
-```xml
-<dependency>
-  <groupId>io.github.lnyo-cly</groupId>
-  <artifactId>ai4j</artifactId>
-  <version>2.4.2</version>
-</dependency>
-```
+- Gradle：`implementation 'io.github.lnyo-cly:ai4j:2.4.2'`
+- Maven：`<dependency><groupId>io.github.lnyo-cly</groupId><artifactId>ai4j</artifactId><version>2.4.2</version></dependency>`
 
 ## 30 秒跑通
 
-设置环境变量后，下面这段代码即可发出第一条请求：
-
-```bash
-export OPENAI_API_KEY=sk-...
-```
+设置 `OPENAI_API_KEY` 后，下面代码即可发出第一条请求：
 
 ```java
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
@@ -61,23 +25,18 @@ import io.github.lnyocly.ai4j.service.Configuration;
 import io.github.lnyocly.ai4j.service.IChatService;
 import io.github.lnyocly.ai4j.service.PlatformType;
 import io.github.lnyocly.ai4j.service.factory.AiService;
-
 public class Ai4jFirstChat {
     public static void main(String[] args) {
         OpenAiConfig openAiConfig = new OpenAiConfig();
         openAiConfig.setApiKey(System.getenv("OPENAI_API_KEY"));
-
         Configuration configuration = new Configuration();
         configuration.setOpenAiConfig(openAiConfig);
-
         AiService aiService = new AiService(configuration);
         IChatService chatService = aiService.getChatService(PlatformType.OPENAI);
-
         ChatCompletion request = ChatCompletion.builder()
                 .model("gpt-4o-mini")
                 .message(ChatMessage.withUser("用一句话介绍 ai4j"))
                 .build();
-
         ChatCompletionResponse response = chatService.chatCompletion(request);
         System.out.println(response.getChoices().get(0).getMessage().getContent().getText());
     }
@@ -85,7 +44,6 @@ public class Ai4jFirstChat {
 ```
 
 输出示例：
-
 ```
 ai4j 是一款面向 JDK 8+ 的 Java AI Agentic 开发套件，覆盖统一模型接入、Tool Calling、MCP 与 RAG。
 ```
@@ -95,12 +53,9 @@ ai4j 是一款面向 JDK 8+ 的 Java AI Agentic 开发套件，覆盖统一模�
 ## 链接
 
 - 文档站：https://lnyo-cly.github.io/ai4j/
-- 5 分钟跑通第一条请求：[five-minute-first-chat](docs-site/docs/start-here/five-minute-first-chat.md)
-- 能力地图（28 项特性详解）：[feature-map](docs-site/docs/start-here/feature-map.md)
-- Coding Agent CLI / TUI / ACP：[coding-agent-cli](docs/readme/zh/coding-agent-cli.md)
-- A2A 协议（Agent 互操作）：[A2A Protocol](docs-site/docs/agent/a2a.md)
-- 更新日志：[CHANGELOG](CHANGELOG.md)
-- 贡献指南：[CONTRIBUTING](CONTRIBUTING.md)
+- [5 分钟跑通](docs-site/docs/start-here/five-minute-first-chat.md) / [能力地图](docs-site/docs/start-here/feature-map.md)
+- [Coding Agent CLI / TUI / ACP](docs/readme/zh/coding-agent-cli.md) / [A2A Protocol](docs-site/docs/agent/a2a.md)
+- [CHANGELOG](CHANGELOG.md) / [CONTRIBUTING](CONTRIBUTING.md)
 
 ## 支持的平台
 

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/ServiceLoaderExtensionLoader.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/ServiceLoaderExtensionLoader.java
@@ -1,9 +1,12 @@
 package io.github.lnyocly.ai4j.extension;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Internal;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
+@Internal("Default implementation; depend on ExtensionLoader.")
 public class ServiceLoaderExtensionLoader implements ExtensionLoader {
 
     private final ClassLoader classLoader;

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/guardrail/ExtensionGuardrail.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/guardrail/ExtensionGuardrail.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.guardrail;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface ExtensionGuardrail {
 
     String name();

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/guardrail/GuardrailRegistry.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/guardrail/GuardrailRegistry.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.guardrail;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface GuardrailRegistry {
 
     void register(ExtensionGuardrail guardrail);

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/lifecycle/AgentLifecycleHook.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/lifecycle/AgentLifecycleHook.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.lifecycle;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface AgentLifecycleHook {
 
     String name();

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/lifecycle/LifecycleHookRegistry.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/lifecycle/LifecycleHookRegistry.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.lifecycle;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface LifecycleHookRegistry {
 
     void register(AgentLifecycleHook hook);

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/prompt/PromptRegistry.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/prompt/PromptRegistry.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.prompt;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface PromptRegistry {
 
     void register(ExtensionPromptResource resource);

--- a/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/skill/SkillRegistry.java
+++ b/ai4j-extension-api/src/main/java/io/github/lnyocly/ai4j/extension/skill/SkillRegistry.java
@@ -1,5 +1,8 @@
 package io.github.lnyocly.ai4j.extension.skill;
 
+import io.github.lnyocly.ai4j.extension.api.annotation.Experimental;
+
+@Experimental(since = "2.4.3")
 public interface SkillRegistry {
 
     void register(ExtensionSkillResource resource);


### PR DESCRIPTION
## Summary
- mark six evolving extension SPI contracts as `@Experimental`
- mark the built-in ServiceLoader implementation as `@Internal`
- keep Chinese and English README entrypoints under the 80-line target

## Verification
- `mvn -pl ai4j-extension-api -DskipTests=false test` (26 passed)
- `git diff --check`

## Residual
- Maven Central exposes `ai4j:2.4.2`; mvnrepository has not indexed that release yet.