### PR TITLE
feat(agent): add generic Skill runtime integration

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -56,6 +56,7 @@ import io.github.lnyocly.ai4j.agent.trace.TraceConfig;
 import io.github.lnyocly.ai4j.agent.trace.TraceExporter;
 import io.github.lnyocly.ai4j.agent.trace.TracePricingResolver;
 import io.github.lnyocly.ai4j.extension.ExtensionRegistry;
+import io.github.lnyocly.ai4j.extension.guardrail.ExtensionGuardrail;
 import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
 import okhttp3.OkHttpClient;
 
@@ -459,18 +460,27 @@ public class AgentBuilder {
         return this;
     }
 
-    /**
-     * Enables the standard workspace/global Skill discovery for this Agent.
-     */
+    /** Enables workspace-owned .ai4j/skills and .agents/skills discovery for this Agent. */
     public AgentBuilder skills(Path workspaceRoot) {
         return skills(workspaceRoot, null);
     }
 
-    /**
-     * Enables the standard Skill discovery with additional root directories.
-     */
+    /** Enables workspace-owned Skill discovery with additional host-declared root directories. */
     public AgentBuilder skills(Path workspaceRoot, List<String> skillDirectories) {
         return skillResolver(AgentSkillResolver.forWorkspace(workspaceRoot, skillDirectories));
+    }
+
+    /**
+     * Enables local developer Skill discovery including process-user roots. Do not use this
+     * convenience method for tenant services; supply a host-owned {@link AgentSkillResolver}.
+     */
+    public AgentBuilder skillsIncludingUserHome(Path workspaceRoot) {
+        return skillsIncludingUserHome(workspaceRoot, null);
+    }
+
+    /** Enables local developer Skill discovery including explicit roots and process-user roots. */
+    public AgentBuilder skillsIncludingUserHome(Path workspaceRoot, List<String> skillDirectories) {
+        return skillResolver(AgentSkillResolver.forWorkspaceIncludingUserHome(workspaceRoot, skillDirectories));
     }
 
     /**
@@ -582,6 +592,9 @@ public class AgentBuilder {
             mergedHooks.addAll(extensionTools.getLifecycleHooks());
         }
         mergedHooks.addAll(additionalLifecycleHooks);
+        List<ExtensionGuardrail> resolvedExtensionGuardrails = extensionTools == null
+                ? Collections.<ExtensionGuardrail>emptyList()
+                : new ArrayList<ExtensionGuardrail>(extensionTools.getGuardrails());
         AgentLifecycleHookDispatcher lifecycleHooks = mergedHooks.isEmpty()
                 ? AgentLifecycleHookDispatcher.empty()
                 : new AgentLifecycleHookDispatcher(mergedHooks);
@@ -619,6 +632,7 @@ public class AgentBuilder {
                 .extraBody(extraBody)
                 .pricingResolver(resolvedPricingResolver)
                 .skillResolver(skillResolver)
+                .extensionGuardrails(resolvedExtensionGuardrails)
                 .build();
 
         return new Agent(resolvedRuntime, context, resolvedMemorySupplier, sessionStore);

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentBuilder.java
@@ -41,6 +41,7 @@ import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.interceptor.AgentHooks;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillResolver;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
 import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.config.AnthropicConfig;
@@ -59,6 +60,7 @@ import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
 import okhttp3.OkHttpClient;
 
 import java.lang.reflect.Constructor;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -121,6 +123,7 @@ public class AgentBuilder {
     private Boolean store;
     private String user;
     private Map<String, Object> extraBody;
+    private AgentSkillResolver skillResolver;
 
     public AgentBuilder runtime(AgentRuntime runtime) {
         this.runtime = runtime;
@@ -456,6 +459,28 @@ public class AgentBuilder {
         return this;
     }
 
+    /**
+     * Enables the standard workspace/global Skill discovery for this Agent.
+     */
+    public AgentBuilder skills(Path workspaceRoot) {
+        return skills(workspaceRoot, null);
+    }
+
+    /**
+     * Enables the standard Skill discovery with additional root directories.
+     */
+    public AgentBuilder skills(Path workspaceRoot, List<String> skillDirectories) {
+        return skillResolver(AgentSkillResolver.forWorkspace(workspaceRoot, skillDirectories));
+    }
+
+    /**
+     * Supplies Skill roots dynamically for each Agent run, for example from host-owned tenant policy.
+     */
+    public AgentBuilder skillResolver(AgentSkillResolver skillResolver) {
+        this.skillResolver = skillResolver;
+        return this;
+    }
+
     public AgentBuilder temperature(Double temperature) {
         this.temperature = temperature;
         return this;
@@ -593,6 +618,7 @@ public class AgentBuilder {
                 .user(user)
                 .extraBody(extraBody)
                 .pricingResolver(resolvedPricingResolver)
+                .skillResolver(skillResolver)
                 .build();
 
         return new Agent(resolvedRuntime, context, resolvedMemorySupplier, sessionStore);

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -19,9 +19,11 @@ import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.agent.skill.AgentSkillResolver;
 import io.github.lnyocly.ai4j.agent.trace.TracePricingResolver;
+import io.github.lnyocly.ai4j.extension.guardrail.ExtensionGuardrail;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -91,4 +93,7 @@ public class AgentContext {
     private TracePricingResolver pricingResolver;
 
     private AgentSkillResolver skillResolver;
+
+    /** Guardrails contributed by extensions; Skill-owned tools must use the same boundary. */
+    private List<ExtensionGuardrail> extensionGuardrails;
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentContext.java
@@ -17,6 +17,7 @@ import io.github.lnyocly.ai4j.agent.interceptor.PromptInterceptor;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
 import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillResolver;
 import io.github.lnyocly.ai4j.agent.trace.TracePricingResolver;
 import lombok.Builder;
 import lombok.Data;
@@ -88,4 +89,6 @@ public class AgentContext {
     private Map<String, Object> extraBody;
 
     private TracePricingResolver pricingResolver;
+
+    private AgentSkillResolver skillResolver;
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentRequest.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentRequest.java
@@ -28,6 +28,13 @@ public class AgentRequest {
      */
     private List<String> selectedSkills;
 
+    /**
+     * Source-compatible constructor retained for callers compiled before selectedSkills existed.
+     */
+    public AgentRequest(Object input, Map<String, Object> metadata) {
+        this(input, metadata, null);
+    }
+
     public String getMetadataString(String key) {
         if (metadata == null || key == null) {
             return null;

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentRequest.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/AgentRequest.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
+import java.util.List;
 
 @Data
 @Builder(toBuilder = true)
@@ -21,6 +22,11 @@ public class AgentRequest {
     private Object input;
 
     private Map<String, Object> metadata;
+
+    /**
+     * Skills explicitly selected by the host for this run. Manual-only Skills are eligible here.
+     */
+    private List<String> selectedSkills;
 
     public String getMetadataString(String key) {
         if (metadata == null || key == null) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -28,6 +28,7 @@ import io.github.lnyocly.ai4j.agent.interceptor.PromptDecision;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillRuntimeSupport;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
 import io.github.lnyocly.ai4j.agent.compact.CompactResult;
 import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
@@ -97,6 +98,7 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
     }
 
     protected AgentResult runInternal(AgentContext context, AgentRequest request, AgentListener listener) throws Exception {
+        context = AgentSkillRuntimeSupport.apply(context, request);
         AgentOptions options = context.getOptions();
         int maxSteps = options == null ? AgentOptions.DEFAULT_MAX_STEPS : options.getMaxSteps();
         long wallClockTimeoutMs = options == null ? AgentOptions.DEFAULT_WALL_CLOCK_TIMEOUT_MS : options.getWallClockTimeoutMillis();

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/CodeActRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/CodeActRuntime.java
@@ -16,6 +16,7 @@ import io.github.lnyocly.ai4j.agent.event.AgentListener;
 import io.github.lnyocly.ai4j.agent.memory.AgentMemory;
 import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
 import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillRuntimeSupport;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
 import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
@@ -46,6 +47,7 @@ public class CodeActRuntime extends BaseAgentRuntime {
     }
 
     protected AgentResult runInternal(AgentContext context, AgentRequest request, AgentListener listener) throws Exception {
+        context = AgentSkillRuntimeSupport.apply(context, request, false);
         AgentOptions options = context.getOptions();
         int maxSteps = options == null ? 0 : options.getMaxSteps();
         CodeActOptions codeActOptions = context.getCodeActOptions();

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/CodeActRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/CodeActRuntime.java
@@ -47,7 +47,7 @@ public class CodeActRuntime extends BaseAgentRuntime {
     }
 
     protected AgentResult runInternal(AgentContext context, AgentRequest request, AgentListener listener) throws Exception {
-        context = AgentSkillRuntimeSupport.apply(context, request, false);
+        context = AgentSkillRuntimeSupport.apply(context, request, true);
         AgentOptions options = context.getOptions();
         int maxSteps = options == null ? 0 : options.getMaxSteps();
         CodeActOptions codeActOptions = context.getCodeActOptions();

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillResolver.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillResolver.java
@@ -16,6 +16,28 @@ public interface AgentSkillResolver {
     static AgentSkillResolver forWorkspace(final Path workspaceRoot, List<String> skillDirectories) {
         final List<String> copiedDirectories = skillDirectories == null
                 ? new ArrayList<String>() : new ArrayList<String>(skillDirectories);
+        copiedDirectories.add(0, ".agents/skills");
+        copiedDirectories.add(0, ".ai4j/skills");
+        return new AgentSkillResolver() {
+            @Override
+            public AgentSkillScope resolve(AgentRequest request) {
+                return AgentSkillScope.builder()
+                        .workspaceRoot(workspaceRoot)
+                        .skillDirectories(new ArrayList<String>(copiedDirectories))
+                        .includeDefaultSkillRoots(false)
+                        .build();
+            }
+        };
+    }
+
+    /**
+     * Opts into process-user Skill roots for local developer tools. Server applications should use
+     * {@link #forWorkspace(Path, List)} or a host-owned resolver instead.
+     */
+    static AgentSkillResolver forWorkspaceIncludingUserHome(final Path workspaceRoot,
+                                                             List<String> skillDirectories) {
+        final List<String> copiedDirectories = skillDirectories == null
+                ? new ArrayList<String>() : new ArrayList<String>(skillDirectories);
         return new AgentSkillResolver() {
             @Override
             public AgentSkillScope resolve(AgentRequest request) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillResolver.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillResolver.java
@@ -1,0 +1,30 @@
+package io.github.lnyocly.ai4j.agent.skill;
+
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves host-owned Skill discovery scope once at the start of each Agent run.
+ */
+public interface AgentSkillResolver {
+
+    AgentSkillScope resolve(AgentRequest request);
+
+    static AgentSkillResolver forWorkspace(final Path workspaceRoot, List<String> skillDirectories) {
+        final List<String> copiedDirectories = skillDirectories == null
+                ? new ArrayList<String>() : new ArrayList<String>(skillDirectories);
+        return new AgentSkillResolver() {
+            @Override
+            public AgentSkillScope resolve(AgentRequest request) {
+                return AgentSkillScope.builder()
+                        .workspaceRoot(workspaceRoot)
+                        .skillDirectories(new ArrayList<String>(copiedDirectories))
+                        .includeDefaultSkillRoots(true)
+                        .build();
+            }
+        };
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
@@ -2,13 +2,17 @@ package io.github.lnyocly.ai4j.agent.skill;
 
 import io.github.lnyocly.ai4j.agent.AgentContext;
 import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.extension.ExtensionGuardrailToolExecutor;
+import io.github.lnyocly.ai4j.agent.memory.AgentMemory;
+import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
 import io.github.lnyocly.ai4j.agent.permission.AgentPermissionToolExecutor;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
+import io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
-import io.github.lnyocly.ai4j.agent.tool.ToolUtilRegistry;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
 import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
 import io.github.lnyocly.ai4j.skill.SkillDescriptor;
 import io.github.lnyocly.ai4j.skill.Skills;
@@ -34,6 +38,10 @@ import java.util.Set;
  * Resolves a stable Skill snapshot once per Agent run and keeps its read_file capability scoped.
  */
 public final class AgentSkillRuntimeSupport {
+
+    private static final String SKILL_READ_FILE = "read_skill_file";
+    private static final long MAX_SELECTED_SKILL_BYTES = 48_000L;
+    private static final int MAX_SELECTED_SKILL_CHARS = 12_000;
 
     private AgentSkillRuntimeSupport() {
     }
@@ -64,18 +72,25 @@ public final class AgentSkillRuntimeSupport {
             return context;
         }
 
-        String prompt = Skills.appendAvailableSkillsPrompt(context.getSystemPrompt(), automatic);
-        prompt = appendSelectedSkillsPrompt(prompt, selected);
+        String readToolName = supportsSkillReadFile ? resolveReadToolName(context.getToolRegistry()) : BuiltInTools.READ_FILE;
+        String prompt = Skills.appendAvailableSkillsPrompt(context.getSystemPrompt(), automatic, readToolName);
+        String selectedPrompt = buildSelectedSkillsPrompt(selected);
+        AgentContext.AgentContextBuilder contextBuilder = context.toBuilder().systemPrompt(prompt);
+        if (!isBlank(selectedPrompt)) {
+            if (context.getMemory() == null) {
+                throw new IllegalStateException("memory is required to apply explicitly selected Skills");
+            }
+            contextBuilder.memory(new SkillPromptOverlayMemory(context.getMemory(), selectedPrompt));
+        }
         if (!supportsSkillReadFile) {
-            return context.toBuilder().systemPrompt(prompt).build();
+            return contextBuilder.build();
         }
 
         List<String> skillRoots = skillRoots(exposed);
         BuiltInToolContext readContext = Skills.createSkillToolContext(skillRoots);
-        AgentToolRegistry registry = addReadFileTool(context.getToolRegistry());
-        ToolExecutor executor = addReadFileExecutor(context, readContext);
-        return context.toBuilder()
-                .systemPrompt(prompt)
+        AgentToolRegistry registry = addReadFileTool(context.getToolRegistry(), readToolName);
+        ToolExecutor executor = addReadFileExecutor(context, readContext, providedContents(exposed), readToolName);
+        return contextBuilder
                 .toolRegistry(registry)
                 .toolExecutor(executor)
                 .build();
@@ -97,23 +112,78 @@ public final class AgentSkillRuntimeSupport {
     }
 
     private static Skills.DiscoveryResult discover(AgentSkillScope scope) {
+        Skills.DiscoveryResult discovered;
         if (scope.isIncludeDefaultSkillRoots()) {
-            return Skills.discoverDefault(scope.getWorkspaceRoot(), safeList(scope.getSkillDirectories()));
-        }
-        Path workspaceRoot = scope.getWorkspaceRoot() == null
-                ? Paths.get(".").toAbsolutePath().normalize()
-                : scope.getWorkspaceRoot().toAbsolutePath().normalize();
-        List<Path> roots = new ArrayList<Path>();
-        for (String directory : safeList(scope.getSkillDirectories())) {
-            if (!isBlank(directory)) {
-                Path root = Paths.get(directory);
-                if (!root.isAbsolute()) {
-                    root = workspaceRoot.resolve(root);
+            discovered = Skills.discoverDefault(scope.getWorkspaceRoot(), safeList(scope.getSkillDirectories()));
+        } else {
+            Path workspaceRoot = scope.getWorkspaceRoot() == null
+                    ? Paths.get(".").toAbsolutePath().normalize()
+                    : scope.getWorkspaceRoot().toAbsolutePath().normalize();
+            List<Path> roots = new ArrayList<Path>();
+            for (String directory : safeList(scope.getSkillDirectories())) {
+                if (!isBlank(directory)) {
+                    Path root = Paths.get(directory);
+                    if (!root.isAbsolute()) {
+                        root = workspaceRoot.resolve(root);
+                    }
+                    roots.add(root.toAbsolutePath().normalize());
                 }
-                roots.add(root.toAbsolutePath().normalize());
             }
+            discovered = Skills.discover(workspaceRoot, roots);
         }
-        return Skills.discover(workspaceRoot, roots);
+        return mergeProvidedSkills(discovered, scope.getProvidedSkills());
+    }
+
+    private static Skills.DiscoveryResult mergeProvidedSkills(Skills.DiscoveryResult discovered,
+                                                               List<SkillDescriptor> provided) {
+        List<SkillDescriptor> merged = new ArrayList<SkillDescriptor>();
+        Map<String, SkillDescriptor> byName = new LinkedHashMap<String, SkillDescriptor>();
+        for (SkillDescriptor skill : safeList(discovered == null ? null : discovered.getSkills())) {
+            addUniqueSkill(merged, byName, skill);
+        }
+        for (SkillDescriptor skill : safeList(provided)) {
+            validateProvidedSkill(skill);
+            addUniqueSkill(merged, byName, skill);
+        }
+        return new Skills.DiscoveryResult(merged,
+                discovered == null ? Collections.<String>emptyList() : discovered.getAllowedReadRoots());
+    }
+
+    private static void addUniqueSkill(List<SkillDescriptor> target, Map<String, SkillDescriptor> byName,
+                                       SkillDescriptor skill) {
+        if (skill == null) {
+            return;
+        }
+        String key = normalize(skill.getName());
+        SkillDescriptor existing = byName.get(key);
+        if (existing != null && !sameSkill(existing, skill)) {
+            throw new IllegalArgumentException("Duplicate Skill name '" + skill.getName()
+                    + "' resolved from " + existing.getSkillFilePath() + " and " + skill.getSkillFilePath());
+        }
+        if (existing == null) {
+            byName.put(key, skill);
+            target.add(skill);
+        }
+    }
+
+    private static boolean sameSkill(SkillDescriptor first, SkillDescriptor second) {
+        if (first == second) {
+            return true;
+        }
+        if (first == null || second == null || isBlank(first.getSkillFilePath()) || isBlank(second.getSkillFilePath())) {
+            return false;
+        }
+        return first.getSkillFilePath().equals(second.getSkillFilePath())
+                && equalsNullable(first.getContent(), second.getContent());
+    }
+
+    private static void validateProvidedSkill(SkillDescriptor skill) {
+        if (skill == null || isBlank(skill.getName()) || isBlank(skill.getDescription()) || isBlank(skill.getSkillFilePath())) {
+            throw new IllegalArgumentException("Host-provided Skill requires name, description, and skillFilePath");
+        }
+        if (skill.getContent() != null) {
+            validateSelectedSkillContent(skill, skill.getContent());
+        }
     }
 
     private static List<SkillDescriptor> resolveSelected(List<SkillDescriptor> enabled, List<String> selectedNames) {
@@ -170,7 +240,7 @@ public final class AgentSkillRuntimeSupport {
     private static List<String> skillRoots(List<SkillDescriptor> skills) {
         Set<String> roots = new LinkedHashSet<String>();
         for (SkillDescriptor skill : safeList(skills)) {
-            if (skill == null || isBlank(skill.getSkillFilePath())) {
+            if (skill == null || skill.getContent() != null || isBlank(skill.getSkillFilePath())) {
                 continue;
             }
             Path skillFile = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize();
@@ -182,30 +252,63 @@ public final class AgentSkillRuntimeSupport {
                 roots.add(parent.toString());
             }
         }
-        if (roots.isEmpty()) {
-            throw new IllegalArgumentException("Resolved Skills have no readable roots");
-        }
         return new ArrayList<String>(roots);
     }
 
-    private static AgentToolRegistry addReadFileTool(AgentToolRegistry existing) {
-        if (hasToolNamed(existing, BuiltInTools.READ_FILE)) {
-            throw new IllegalStateException("Skill integration reserves read_file; remove the conflicting custom tool before enabling Skills");
+    private static Map<String, String> providedContents(List<SkillDescriptor> skills) {
+        Map<String, String> contents = new LinkedHashMap<String, String>();
+        for (SkillDescriptor skill : safeList(skills)) {
+            if (skill == null || skill.getContent() == null) {
+                continue;
+            }
+            String existing = contents.put(skill.getSkillFilePath(), skill.getContent());
+            if (existing != null && !existing.equals(skill.getContent())) {
+                throw new IllegalArgumentException("Multiple host-provided Skills share virtual location: "
+                        + skill.getSkillFilePath());
+            }
         }
-        AgentToolRegistry skillRegistry = new ToolUtilRegistry(
-                Collections.singletonList(BuiltInTools.READ_FILE), Collections.<String>emptyList());
+        return contents;
+    }
+
+    private static String resolveReadToolName(AgentToolRegistry existing) {
+        if (!hasToolNamed(existing, BuiltInTools.READ_FILE)) {
+            return BuiltInTools.READ_FILE;
+        }
+        if (hasToolNamed(existing, SKILL_READ_FILE)) {
+            throw new IllegalStateException("Skill integration cannot add " + SKILL_READ_FILE
+                    + " because the host already owns both read_file and " + SKILL_READ_FILE);
+        }
+        return SKILL_READ_FILE;
+    }
+
+    private static AgentToolRegistry addReadFileTool(AgentToolRegistry existing, String readToolName) {
+        Tool readTool = BuiltInTools.readFileTool();
+        if (readTool.getFunction() == null) {
+            throw new IllegalStateException("Built-in read_file tool is missing a function definition");
+        }
+        readTool.getFunction().setName(readToolName);
+        AgentToolRegistry skillRegistry = new StaticToolRegistry(Collections.<Object>singletonList(readTool));
         return new CompositeToolRegistry(existing, skillRegistry);
     }
 
-    private static ToolExecutor addReadFileExecutor(AgentContext context, BuiltInToolContext readContext) {
-        ToolExecutor readExecutor = new SkillReadFileToolExecutor(readContext);
+    private static ToolExecutor addReadFileExecutor(AgentContext context,
+                                                     BuiltInToolContext readContext,
+                                                     Map<String, String> providedContents,
+                                                     String readToolName) {
+        ToolExecutor readExecutor = new SkillReadFileToolExecutor(readContext, providedContents);
+        if (context.getExtensionGuardrails() != null && !context.getExtensionGuardrails().isEmpty()) {
+            readExecutor = new ExtensionGuardrailToolExecutor(readExecutor, context.getExtensionGuardrails());
+        }
         if (context.getPermissionPolicy() != null) {
             readExecutor = new AgentPermissionToolExecutor(
                     readExecutor, context.getPermissionPolicy(), context.getExecutionEnvironment());
         }
+        if (!BuiltInTools.READ_FILE.equals(readToolName)) {
+            readExecutor = new SkillToolAliasExecutor(readToolName, readExecutor);
+        }
         return new RoutingToolExecutor(
                 Collections.singletonList(RoutingToolExecutor.route(
-                        Collections.singleton(BuiltInTools.READ_FILE), readExecutor)),
+                        Collections.singleton(readToolName), readExecutor)),
                 context.getToolExecutor());
     }
 
@@ -229,14 +332,11 @@ public final class AgentSkillRuntimeSupport {
         return false;
     }
 
-    private static String appendSelectedSkillsPrompt(String basePrompt, List<SkillDescriptor> selected) {
+    private static String buildSelectedSkillsPrompt(List<SkillDescriptor> selected) {
         if (selected == null || selected.isEmpty()) {
-            return basePrompt;
+            return null;
         }
-        StringBuilder builder = new StringBuilder(isBlank(basePrompt) ? "" : basePrompt.trim());
-        if (builder.length() > 0) {
-            builder.append("\n\n");
-        }
+        StringBuilder builder = new StringBuilder();
         builder.append("The host explicitly activated these skills for this request. Follow their instructions.\n");
         builder.append("<selected_skills>\n");
         for (SkillDescriptor skill : selected) {
@@ -254,12 +354,18 @@ public final class AgentSkillRuntimeSupport {
         if (skill == null || isBlank(skill.getSkillFilePath())) {
             throw new IllegalArgumentException("Selected Skill has no readable SKILL.md");
         }
+        if (skill.getContent() != null) {
+            validateSelectedSkillContent(skill, skill.getContent());
+            return skill.getContent().trim();
+        }
         Path skillFile = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize();
         try {
             if (Files.isSymbolicLink(skillFile) || !Files.isRegularFile(skillFile, LinkOption.NOFOLLOW_LINKS)) {
                 throw new IllegalArgumentException("Selected Skill file must be a regular non-symlink file: " + skill.getSkillFilePath());
             }
-            return new String(Files.readAllBytes(skillFile), StandardCharsets.UTF_8).trim();
+            String content = new String(Files.readAllBytes(skillFile), StandardCharsets.UTF_8).trim();
+            validateSelectedSkillContent(skill, content);
+            return content;
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to read selected Skill: " + valueOrDefault(skill.getName(), skill.getSkillFilePath()), ex);
         }
@@ -269,8 +375,107 @@ public final class AgentSkillRuntimeSupport {
         if (skill == null || isBlank(skill.getSkillFilePath())) {
             return "(missing)";
         }
+        if (skill.getContent() != null) {
+            return "(virtual: " + skill.getSkillFilePath() + ")";
+        }
         Path parent = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize().getParent();
         return parent == null ? "(missing)" : parent.toString();
+    }
+
+    private static void validateSelectedSkillContent(SkillDescriptor skill, String content) {
+        byte[] bytes = content == null ? new byte[0] : content.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_SELECTED_SKILL_BYTES) {
+            throw new IllegalArgumentException("Selected Skill exceeds the " + MAX_SELECTED_SKILL_BYTES
+                    + " byte limit: " + valueOrDefault(skill.getName(), skill.getSkillFilePath()));
+        }
+        if (content != null && content.length() > MAX_SELECTED_SKILL_CHARS) {
+            throw new IllegalArgumentException("Selected Skill exceeds the " + MAX_SELECTED_SKILL_CHARS
+                    + " character limit: " + valueOrDefault(skill.getName(), skill.getSkillFilePath()));
+        }
+    }
+
+    /** Maps the public fallback name back before guardrail and permission evaluation. */
+    private static final class SkillToolAliasExecutor implements ToolExecutor {
+
+        private final String alias;
+        private final ToolExecutor delegate;
+
+        private SkillToolAliasExecutor(String alias, ToolExecutor delegate) {
+            this.alias = alias;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String execute(AgentToolCall call) throws Exception {
+            if (call == null || !alias.equals(call.getName())) {
+                throw new IllegalArgumentException("Unsupported Skill tool: " + (call == null ? null : call.getName()));
+            }
+            AgentToolCall canonicalCall = AgentToolCall.builder()
+                    .name(BuiltInTools.READ_FILE)
+                    .arguments(call.getArguments())
+                    .callId(call.getCallId())
+                    .type(call.getType())
+                    .build();
+            return delegate.execute(canonicalCall);
+        }
+    }
+
+    /**
+     * Keeps explicit Skill contents request-scoped so they do not mutate long-lived Agent memory
+     * or the cacheable system prefix.
+     */
+    private static final class SkillPromptOverlayMemory implements AgentMemory {
+
+        private final AgentMemory delegate;
+        private final Object promptItem;
+
+        private SkillPromptOverlayMemory(AgentMemory delegate, String prompt) {
+            this.delegate = delegate;
+            this.promptItem = AgentInputItem.userMessage(prompt);
+        }
+
+        @Override
+        public void addUserInput(Object input) {
+            delegate.addUserInput(input);
+        }
+
+        @Override
+        public void addOutputItems(List<Object> items) {
+            delegate.addOutputItems(items);
+        }
+
+        @Override
+        public void addToolOutput(String callId, String output) {
+            delegate.addToolOutput(callId, output);
+        }
+
+        @Override
+        public List<Object> getItems() {
+            List<Object> items = new ArrayList<Object>();
+            items.add(promptItem);
+            items.addAll(delegate.getItems());
+            return items;
+        }
+
+        @Override
+        public String getSummary() {
+            return delegate.getSummary();
+        }
+
+        @Override
+        public MemorySnapshot snapshot() {
+            return delegate.snapshot();
+        }
+
+        @Override
+        public void restore(MemorySnapshot snapshot) {
+            delegate.restore(snapshot);
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
     }
 
     private static Set<String> normalizedNames(List<String> values) {
@@ -294,6 +499,10 @@ public final class AgentSkillRuntimeSupport {
 
     private static String valueOrDefault(String value, String fallback) {
         return isBlank(value) ? fallback : value.trim();
+    }
+
+    private static boolean equalsNullable(String first, String second) {
+        return first == null ? second == null : first.equals(second);
     }
 
     private static String escapeXml(String value) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
@@ -3,6 +3,8 @@ package io.github.lnyocly.ai4j.agent.skill;
 import io.github.lnyocly.ai4j.agent.AgentContext;
 import io.github.lnyocly.ai4j.agent.AgentRequest;
 import io.github.lnyocly.ai4j.agent.extension.ExtensionGuardrailToolExecutor;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolInterceptor;
 import io.github.lnyocly.ai4j.agent.memory.AgentMemory;
 import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
 import io.github.lnyocly.ai4j.agent.permission.AgentPermissionToolExecutor;
@@ -76,6 +78,9 @@ public final class AgentSkillRuntimeSupport {
         String prompt = Skills.appendAvailableSkillsPrompt(context.getSystemPrompt(), automatic, readToolName);
         String selectedPrompt = buildSelectedSkillsPrompt(selected);
         AgentContext.AgentContextBuilder contextBuilder = context.toBuilder().systemPrompt(prompt);
+        if (!BuiltInTools.READ_FILE.equals(readToolName)) {
+            contextBuilder.toolInterceptor(aliasSkillReaderInterceptor(context.getToolInterceptor(), readToolName));
+        }
         if (!isBlank(selectedPrompt)) {
             if (context.getMemory() == null) {
                 throw new IllegalStateException("memory is required to apply explicitly selected Skills");
@@ -142,7 +147,8 @@ public final class AgentSkillRuntimeSupport {
             addUniqueSkill(merged, byName, skill);
         }
         for (SkillDescriptor skill : safeList(provided)) {
-            validateProvidedSkill(skill);
+            validateProvidedSkill(skill, discovered == null
+                    ? Collections.<String>emptyList() : discovered.getAllowedReadRoots());
             addUniqueSkill(merged, byName, skill);
         }
         return new Skills.DiscoveryResult(merged,
@@ -177,12 +183,48 @@ public final class AgentSkillRuntimeSupport {
                 && equalsNullable(first.getContent(), second.getContent());
     }
 
-    private static void validateProvidedSkill(SkillDescriptor skill) {
+    private static void validateProvidedSkill(SkillDescriptor skill, List<String> allowedReadRoots) {
         if (skill == null || isBlank(skill.getName()) || isBlank(skill.getDescription()) || isBlank(skill.getSkillFilePath())) {
             throw new IllegalArgumentException("Host-provided Skill requires name, description, and skillFilePath");
         }
         if (skill.getContent() != null) {
             validateSelectedSkillContent(skill, skill.getContent());
+            return;
+        }
+        Path skillFile;
+        try {
+            skillFile = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize();
+        } catch (RuntimeException ex) {
+            throw new IllegalArgumentException("Host-provided Skill path is invalid: " + skill.getSkillFilePath(), ex);
+        }
+        if (Files.isSymbolicLink(skillFile) || !Files.isRegularFile(skillFile, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalArgumentException("Host-provided Skill file must be a regular non-symlink file: "
+                    + skill.getSkillFilePath());
+        }
+        if (!isWithinAllowedReadRoots(skillFile, allowedReadRoots)) {
+            throw new IllegalArgumentException("Host-provided Skill file must be under a declared Skill root: "
+                    + skill.getSkillFilePath());
+        }
+    }
+
+    private static boolean isWithinAllowedReadRoots(Path skillFile, List<String> allowedReadRoots) {
+        for (String configuredRoot : safeList(allowedReadRoots)) {
+            if (isBlank(configuredRoot)) {
+                continue;
+            }
+            Path root = Paths.get(configuredRoot).toAbsolutePath().normalize();
+            if (skillFile.startsWith(root) && resolvesWithin(skillFile, root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean resolvesWithin(Path candidate, Path root) {
+        try {
+            return candidate.toRealPath().startsWith(root.toRealPath());
+        } catch (IOException ex) {
+            return false;
         }
     }
 
@@ -312,6 +354,54 @@ public final class AgentSkillRuntimeSupport {
                 context.getToolExecutor());
     }
 
+    private static ToolInterceptor aliasSkillReaderInterceptor(final ToolInterceptor interceptor,
+                                                                 final String alias) {
+        if (interceptor == null || BuiltInTools.READ_FILE.equals(alias)) {
+            return interceptor;
+        }
+        return new ToolInterceptor() {
+            @Override
+            public ToolCallDecision beforeToolCall(AgentToolCall call, AgentContext context) {
+                ToolCallDecision decision = interceptor.beforeToolCall(canonicalSkillReaderCall(call, alias), context);
+                return restoreAliasDecision(decision, alias);
+            }
+
+            @Override
+            public ToolCallDecision afterToolCall(AgentToolCall call, String output, AgentContext context) {
+                return interceptor.afterToolCall(canonicalSkillReaderCall(call, alias), output, context);
+            }
+        };
+    }
+
+    private static ToolCallDecision restoreAliasDecision(ToolCallDecision decision, String alias) {
+        if (decision == null || decision.getType() != ToolCallDecision.Type.MODIFY
+                || decision.getModifiedCall() == null
+                || !BuiltInTools.READ_FILE.equals(decision.getModifiedCall().getName())) {
+            return decision;
+        }
+        return ToolCallDecision.modify(aliasSkillReadCall(decision.getModifiedCall(), alias));
+    }
+
+    private static AgentToolCall canonicalSkillReaderCall(AgentToolCall call, String alias) {
+        return renameSkillReaderCall(call, alias, BuiltInTools.READ_FILE);
+    }
+
+    private static AgentToolCall aliasSkillReadCall(AgentToolCall call, String alias) {
+        return renameSkillReaderCall(call, BuiltInTools.READ_FILE, alias);
+    }
+
+    private static AgentToolCall renameSkillReaderCall(AgentToolCall call, String expectedName, String replacementName) {
+        if (call == null || !expectedName.equals(call.getName())) {
+            return call;
+        }
+        return AgentToolCall.builder()
+                .name(replacementName)
+                .arguments(call.getArguments())
+                .callId(call.getCallId())
+                .type(call.getType())
+                .build();
+    }
+
     private static boolean hasToolNamed(AgentToolRegistry registry, String name) {
         if (registry == null || registry.getTools() == null) {
             return false;
@@ -410,13 +500,7 @@ public final class AgentSkillRuntimeSupport {
             if (call == null || !alias.equals(call.getName())) {
                 throw new IllegalArgumentException("Unsupported Skill tool: " + (call == null ? null : call.getName()));
             }
-            AgentToolCall canonicalCall = AgentToolCall.builder()
-                    .name(BuiltInTools.READ_FILE)
-                    .arguments(call.getArguments())
-                    .callId(call.getCallId())
-                    .type(call.getType())
-                    .build();
-            return delegate.execute(canonicalCall);
+            return delegate.execute(canonicalSkillReaderCall(call, alias));
         }
     }
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillRuntimeSupport.java
@@ -1,0 +1,311 @@
+package io.github.lnyocly.ai4j.agent.skill;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.permission.AgentPermissionToolExecutor;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.CompositeToolRegistry;
+import io.github.lnyocly.ai4j.agent.tool.RoutingToolExecutor;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.agent.tool.ToolUtilRegistry;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.skill.SkillDescriptor;
+import io.github.lnyocly.ai4j.skill.Skills;
+import io.github.lnyocly.ai4j.tool.BuiltInToolContext;
+import io.github.lnyocly.ai4j.tool.BuiltInTools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resolves a stable Skill snapshot once per Agent run and keeps its read_file capability scoped.
+ */
+public final class AgentSkillRuntimeSupport {
+
+    private AgentSkillRuntimeSupport() {
+    }
+
+    public static AgentContext apply(AgentContext context, AgentRequest request) {
+        return apply(context, request, true);
+    }
+
+    /**
+     * Applies Skills to a runtime. Runtimes without function-tool support can only receive
+     * host-selected Skills, because they cannot perform progressive read_file activation.
+     */
+    public static AgentContext apply(AgentContext context, AgentRequest request, boolean supportsSkillReadFile) {
+        if (context == null || context.getSkillResolver() == null) {
+            return context;
+        }
+        AgentSkillScope scope = context.getSkillResolver().resolve(request);
+        if (scope == null) {
+            return context;
+        }
+        Skills.DiscoveryResult discovery = discover(scope);
+        List<SkillDescriptor> enabled = filterEnabled(discovery.getSkills(), scope.getEnabledSkillNames());
+        List<SkillDescriptor> selected = resolveSelected(enabled, request == null ? null : request.getSelectedSkills());
+        List<SkillDescriptor> automatic = supportsSkillReadFile
+                ? modelInvocable(enabled) : Collections.<SkillDescriptor>emptyList();
+        List<SkillDescriptor> exposed = merge(automatic, selected);
+        if (exposed.isEmpty()) {
+            return context;
+        }
+
+        String prompt = Skills.appendAvailableSkillsPrompt(context.getSystemPrompt(), automatic);
+        prompt = appendSelectedSkillsPrompt(prompt, selected);
+        if (!supportsSkillReadFile) {
+            return context.toBuilder().systemPrompt(prompt).build();
+        }
+
+        List<String> skillRoots = skillRoots(exposed);
+        BuiltInToolContext readContext = Skills.createSkillToolContext(skillRoots);
+        AgentToolRegistry registry = addReadFileTool(context.getToolRegistry());
+        ToolExecutor executor = addReadFileExecutor(context, readContext);
+        return context.toBuilder()
+                .systemPrompt(prompt)
+                .toolRegistry(registry)
+                .toolExecutor(executor)
+                .build();
+    }
+
+    private static List<SkillDescriptor> filterEnabled(List<SkillDescriptor> discovered, List<String> enabledNames) {
+        List<SkillDescriptor> skills = safeList(discovered);
+        Set<String> enabled = normalizedNames(enabledNames);
+        if (enabled.isEmpty()) {
+            return skills;
+        }
+        List<SkillDescriptor> result = new ArrayList<SkillDescriptor>();
+        for (SkillDescriptor skill : skills) {
+            if (skill != null && enabled.contains(normalize(skill.getName()))) {
+                result.add(skill);
+            }
+        }
+        return result;
+    }
+
+    private static Skills.DiscoveryResult discover(AgentSkillScope scope) {
+        if (scope.isIncludeDefaultSkillRoots()) {
+            return Skills.discoverDefault(scope.getWorkspaceRoot(), safeList(scope.getSkillDirectories()));
+        }
+        Path workspaceRoot = scope.getWorkspaceRoot() == null
+                ? Paths.get(".").toAbsolutePath().normalize()
+                : scope.getWorkspaceRoot().toAbsolutePath().normalize();
+        List<Path> roots = new ArrayList<Path>();
+        for (String directory : safeList(scope.getSkillDirectories())) {
+            if (!isBlank(directory)) {
+                Path root = Paths.get(directory);
+                if (!root.isAbsolute()) {
+                    root = workspaceRoot.resolve(root);
+                }
+                roots.add(root.toAbsolutePath().normalize());
+            }
+        }
+        return Skills.discover(workspaceRoot, roots);
+    }
+
+    private static List<SkillDescriptor> resolveSelected(List<SkillDescriptor> enabled, List<String> selectedNames) {
+        if (selectedNames == null || selectedNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Map<String, SkillDescriptor> byName = new LinkedHashMap<String, SkillDescriptor>();
+        for (SkillDescriptor skill : safeList(enabled)) {
+            if (skill != null) {
+                byName.put(normalize(skill.getName()), skill);
+            }
+        }
+        List<SkillDescriptor> result = new ArrayList<SkillDescriptor>();
+        Set<String> seen = new LinkedHashSet<String>();
+        for (String selectedName : selectedNames) {
+            String key = normalize(selectedName);
+            if (key.isEmpty() || !seen.add(key)) {
+                continue;
+            }
+            SkillDescriptor skill = byName.get(key);
+            if (skill == null) {
+                throw new IllegalArgumentException("Selected Skill is not enabled or installed: " + selectedName);
+            }
+            result.add(skill);
+        }
+        return result;
+    }
+
+    private static List<SkillDescriptor> modelInvocable(List<SkillDescriptor> skills) {
+        List<SkillDescriptor> result = new ArrayList<SkillDescriptor>();
+        for (SkillDescriptor skill : safeList(skills)) {
+            if (skill != null && !skill.isDisableModelInvocation()) {
+                result.add(skill);
+            }
+        }
+        return result;
+    }
+
+    private static List<SkillDescriptor> merge(List<SkillDescriptor> automatic, List<SkillDescriptor> selected) {
+        Map<String, SkillDescriptor> result = new LinkedHashMap<String, SkillDescriptor>();
+        append(result, automatic);
+        append(result, selected);
+        return new ArrayList<SkillDescriptor>(result.values());
+    }
+
+    private static void append(Map<String, SkillDescriptor> target, List<SkillDescriptor> skills) {
+        for (SkillDescriptor skill : safeList(skills)) {
+            if (skill != null) {
+                target.put(normalize(skill.getName()) + "\u0000" + skill.getSkillFilePath(), skill);
+            }
+        }
+    }
+
+    private static List<String> skillRoots(List<SkillDescriptor> skills) {
+        Set<String> roots = new LinkedHashSet<String>();
+        for (SkillDescriptor skill : safeList(skills)) {
+            if (skill == null || isBlank(skill.getSkillFilePath())) {
+                continue;
+            }
+            Path skillFile = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize();
+            if (Files.isSymbolicLink(skillFile) || !Files.isRegularFile(skillFile, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalArgumentException("Skill file must be a regular non-symlink file: " + skill.getSkillFilePath());
+            }
+            Path parent = skillFile.getParent();
+            if (parent != null) {
+                roots.add(parent.toString());
+            }
+        }
+        if (roots.isEmpty()) {
+            throw new IllegalArgumentException("Resolved Skills have no readable roots");
+        }
+        return new ArrayList<String>(roots);
+    }
+
+    private static AgentToolRegistry addReadFileTool(AgentToolRegistry existing) {
+        if (hasToolNamed(existing, BuiltInTools.READ_FILE)) {
+            throw new IllegalStateException("Skill integration reserves read_file; remove the conflicting custom tool before enabling Skills");
+        }
+        AgentToolRegistry skillRegistry = new ToolUtilRegistry(
+                Collections.singletonList(BuiltInTools.READ_FILE), Collections.<String>emptyList());
+        return new CompositeToolRegistry(existing, skillRegistry);
+    }
+
+    private static ToolExecutor addReadFileExecutor(AgentContext context, BuiltInToolContext readContext) {
+        ToolExecutor readExecutor = new SkillReadFileToolExecutor(readContext);
+        if (context.getPermissionPolicy() != null) {
+            readExecutor = new AgentPermissionToolExecutor(
+                    readExecutor, context.getPermissionPolicy(), context.getExecutionEnvironment());
+        }
+        return new RoutingToolExecutor(
+                Collections.singletonList(RoutingToolExecutor.route(
+                        Collections.singleton(BuiltInTools.READ_FILE), readExecutor)),
+                context.getToolExecutor());
+    }
+
+    private static boolean hasToolNamed(AgentToolRegistry registry, String name) {
+        if (registry == null || registry.getTools() == null) {
+            return false;
+        }
+        for (Object candidate : registry.getTools()) {
+            if (candidate instanceof Tool) {
+                Tool tool = (Tool) candidate;
+                if (tool.getFunction() != null && name.equals(tool.getFunction().getName())) {
+                    return true;
+                }
+            } else if (candidate instanceof Map) {
+                Object function = ((Map<?, ?>) candidate).get("function");
+                if (function instanceof Map && name.equals(((Map<?, ?>) function).get("name"))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String appendSelectedSkillsPrompt(String basePrompt, List<SkillDescriptor> selected) {
+        if (selected == null || selected.isEmpty()) {
+            return basePrompt;
+        }
+        StringBuilder builder = new StringBuilder(isBlank(basePrompt) ? "" : basePrompt.trim());
+        if (builder.length() > 0) {
+            builder.append("\n\n");
+        }
+        builder.append("The host explicitly activated these skills for this request. Follow their instructions.\n");
+        builder.append("<selected_skills>\n");
+        for (SkillDescriptor skill : selected) {
+            builder.append("<selected_skill name=\"").append(escapeXml(valueOrDefault(skill.getName(), "skill"))).append("\">\n");
+            builder.append(readSelectedSkillContent(skill));
+            builder.append("\nSkill directory: ").append(escapeXml(skillDirectory(skill))).append("\n");
+            builder.append("</selected_skill>\n");
+        }
+        builder.append("</selected_skills>\n");
+        builder.append("Do not treat a Skill as permission to invoke additional tools or access data outside its Skill directory.");
+        return builder.toString();
+    }
+
+    private static String readSelectedSkillContent(SkillDescriptor skill) {
+        if (skill == null || isBlank(skill.getSkillFilePath())) {
+            throw new IllegalArgumentException("Selected Skill has no readable SKILL.md");
+        }
+        Path skillFile = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize();
+        try {
+            if (Files.isSymbolicLink(skillFile) || !Files.isRegularFile(skillFile, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalArgumentException("Selected Skill file must be a regular non-symlink file: " + skill.getSkillFilePath());
+            }
+            return new String(Files.readAllBytes(skillFile), StandardCharsets.UTF_8).trim();
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to read selected Skill: " + valueOrDefault(skill.getName(), skill.getSkillFilePath()), ex);
+        }
+    }
+
+    private static String skillDirectory(SkillDescriptor skill) {
+        if (skill == null || isBlank(skill.getSkillFilePath())) {
+            return "(missing)";
+        }
+        Path parent = Paths.get(skill.getSkillFilePath()).toAbsolutePath().normalize().getParent();
+        return parent == null ? "(missing)" : parent.toString();
+    }
+
+    private static Set<String> normalizedNames(List<String> values) {
+        Set<String> result = new LinkedHashSet<String>();
+        for (String value : safeList(values)) {
+            String normalized = normalize(value);
+            if (!normalized.isEmpty()) {
+                result.add(normalized);
+            }
+        }
+        return result;
+    }
+
+    private static <T> List<T> safeList(List<T> values) {
+        return values == null ? Collections.<T>emptyList() : values;
+    }
+
+    private static String normalize(String value) {
+        return isBlank(value) ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String valueOrDefault(String value, String fallback) {
+        return isBlank(value) ? fallback : value.trim();
+    }
+
+    private static String escapeXml(String value) {
+        return value == null ? "" : value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillScope.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillScope.java
@@ -1,5 +1,6 @@
 package io.github.lnyocly.ai4j.agent.skill;
 
+import io.github.lnyocly.ai4j.skill.SkillDescriptor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,4 +36,20 @@ public class AgentSkillScope {
      */
     @Builder.Default
     private List<String> enabledSkillNames = new ArrayList<String>();
+
+    /**
+     * Host-provided Skills added to the discovered file catalog for this run. A descriptor with
+     * {@link SkillDescriptor#getContent()} uses {@code skillFilePath} as a stable virtual location.
+     */
+    @Builder.Default
+    private List<SkillDescriptor> providedSkills = new ArrayList<SkillDescriptor>();
+
+    /**
+     * Source-compatible constructor retained for callers compiled before host-provided Skills.
+     */
+    public AgentSkillScope(Path workspaceRoot, List<String> skillDirectories,
+                           boolean includeDefaultSkillRoots, List<String> enabledSkillNames) {
+        this(workspaceRoot, skillDirectories, includeDefaultSkillRoots, enabledSkillNames,
+                new ArrayList<SkillDescriptor>());
+    }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillScope.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/AgentSkillScope.java
@@ -1,0 +1,38 @@
+package io.github.lnyocly.ai4j.agent.skill;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Host-owned Skill discovery configuration for one Agent run.
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentSkillScope {
+
+    private Path workspaceRoot;
+
+    @Builder.Default
+    private List<String> skillDirectories = new ArrayList<String>();
+
+    /**
+     * Includes the standard workspace and process-user Skill roots. Custom host resolvers default
+     * to explicit roots so a tenant policy cannot accidentally expose server-global Skills.
+     */
+    @Builder.Default
+    private boolean includeDefaultSkillRoots = false;
+
+    /**
+     * Empty means every discovered Skill is enabled. Manual-only still requires explicit selection.
+     */
+    @Builder.Default
+    private List<String> enabledSkillNames = new ArrayList<String>();
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/SkillReadFileToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/SkillReadFileToolExecutor.java
@@ -1,10 +1,18 @@
 package io.github.lnyocly.ai4j.agent.skill;
 
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
 import io.github.lnyocly.ai4j.tool.BuiltInToolContext;
 import io.github.lnyocly.ai4j.tool.BuiltInTools;
 import io.github.lnyocly.ai4j.tool.ToolUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Executes only the Skill-owned read_file capability under a per-run restricted context.
@@ -12,9 +20,17 @@ import io.github.lnyocly.ai4j.tool.ToolUtil;
 final class SkillReadFileToolExecutor implements ToolExecutor {
 
     private final BuiltInToolContext context;
+    private final Map<String, String> providedContents;
 
     SkillReadFileToolExecutor(BuiltInToolContext context) {
+        this(context, null);
+    }
+
+    SkillReadFileToolExecutor(BuiltInToolContext context, Map<String, String> providedContents) {
         this.context = context;
+        this.providedContents = providedContents == null
+                ? Collections.<String, String>emptyMap()
+                : new LinkedHashMap<String, String>(providedContents);
     }
 
     @Override
@@ -22,11 +38,52 @@ final class SkillReadFileToolExecutor implements ToolExecutor {
         if (call == null || !BuiltInTools.READ_FILE.equals(call.getName())) {
             throw new IllegalArgumentException("Unsupported Skill tool: " + (call == null ? null : call.getName()));
         }
+        JSONObject arguments = JSON.parseObject(call.getArguments());
+        String path = arguments == null ? null : arguments.getString("path");
+        String providedContent = providedContents.get(path);
+        if (providedContent != null) {
+            return JSON.toJSONString(readProvidedSkill(path, providedContent, arguments));
+        }
         ToolUtil.pushBuiltInToolContext(context);
         try {
             return ToolUtil.invoke(call.getName(), call.getArguments());
         } finally {
             ToolUtil.popBuiltInToolContext();
         }
+    }
+
+    private Map<String, Object> readProvidedSkill(String path, String content, JSONObject arguments) {
+        List<String> lines = new ArrayList<String>();
+        Collections.addAll(lines, content.split("\\r?\\n", -1));
+        int startLine = arguments.getInteger("startLine") == null || arguments.getInteger("startLine").intValue() < 1
+                ? 1 : arguments.getInteger("startLine").intValue();
+        int endLine = arguments.getInteger("endLine") == null || arguments.getInteger("endLine").intValue() > lines.size()
+                ? lines.size() : arguments.getInteger("endLine").intValue();
+        if (endLine < startLine) {
+            endLine = startLine - 1;
+        }
+
+        StringBuilder selected = new StringBuilder();
+        for (int index = startLine; index <= endLine && index <= lines.size(); index++) {
+            if (selected.length() > 0) {
+                selected.append('\n');
+            }
+            selected.append(lines.get(index - 1));
+        }
+        int maxChars = arguments.getInteger("maxChars") == null || arguments.getInteger("maxChars").intValue() <= 0
+                ? context.getDefaultReadMaxChars() : arguments.getInteger("maxChars").intValue();
+        String selectedContent = selected.toString();
+        boolean truncated = selectedContent.length() > maxChars;
+        if (truncated) {
+            selectedContent = selectedContent.substring(0, maxChars);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("path", path);
+        result.put("content", selectedContent);
+        result.put("startLine", startLine);
+        result.put("endLine", endLine);
+        result.put("truncated", truncated);
+        return result;
     }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/SkillReadFileToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/skill/SkillReadFileToolExecutor.java
@@ -1,0 +1,32 @@
+package io.github.lnyocly.ai4j.agent.skill;
+
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.tool.BuiltInToolContext;
+import io.github.lnyocly.ai4j.tool.BuiltInTools;
+import io.github.lnyocly.ai4j.tool.ToolUtil;
+
+/**
+ * Executes only the Skill-owned read_file capability under a per-run restricted context.
+ */
+final class SkillReadFileToolExecutor implements ToolExecutor {
+
+    private final BuiltInToolContext context;
+
+    SkillReadFileToolExecutor(BuiltInToolContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public String execute(AgentToolCall call) throws Exception {
+        if (call == null || !BuiltInTools.READ_FILE.equals(call.getName())) {
+            throw new IllegalArgumentException("Unsupported Skill tool: " + (call == null ? null : call.getName()));
+        }
+        ToolUtil.pushBuiltInToolContext(context);
+        try {
+            return ToolUtil.invoke(call.getName(), call.getArguments());
+        } finally {
+            ToolUtil.popBuiltInToolContext();
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
@@ -9,6 +9,7 @@ import io.github.lnyocly.ai4j.agent.codeact.CodeExecutionRequest;
 import io.github.lnyocly.ai4j.agent.codeact.CodeExecutionResult;
 import io.github.lnyocly.ai4j.agent.codeact.CodeExecutor;
 import io.github.lnyocly.ai4j.agent.extension.ExtensionAgentTools;
+import io.github.lnyocly.ai4j.agent.interceptor.ToolCallDecision;
 import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
 import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
 import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
@@ -200,6 +201,37 @@ public class AgentSkillRuntimeSupportTest {
     }
 
     @Test
+    public void shouldApplyToolInterceptorToAliasedSkillReader() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-interceptor-conflict").toPath();
+        Path skillFile = writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Tool hostReadFile = new Tool();
+        Tool.Function hostFunction = new Tool.Function();
+        hostFunction.setName("read_file");
+        hostReadFile.setFunction(hostFunction);
+        final AtomicReference<String> interceptedName = new AtomicReference<String>();
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("alias-read", "read_skill_file", "{\"path\":\"" + escapeJson(skillFile.toString()) + "\"}"),
+                textResult("done"));
+
+        AgentResult result = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .toolRegistry(() -> Collections.<Object>singletonList(hostReadFile))
+                .toolInterceptor((call, context) -> {
+                    interceptedName.set(call.getName());
+                    return ToolCallDecision.block("host blocked skill reads");
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build()
+                .run(AgentRequest.builder().input("read safely").build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals("read_file", interceptedName.get());
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("host blocked skill reads"));
+    }
+
+    @Test
     public void shouldKeepCustomResolverRootsIsolatedFromDefaultSkillRoots() throws Exception {
         Path workspace = temporaryFolder.newFolder("skill-isolation-workspace").toPath();
         writeSkill(workspace, "workspace-only", "Must not be exposed to the tenant resolver.", false);
@@ -308,6 +340,66 @@ public class AgentSkillRuntimeSupportTest {
     }
 
     @Test
+    public void shouldKeepHostProvidedCatalogStableWhenResolverOrderChanges() throws Exception {
+        Path workspace = temporaryFolder.newFolder("memory-skill-order").toPath();
+        final SkillDescriptor alpha = inMemorySkill("alpha", "Alpha workflow.", "# Alpha", "tenant://alpha/SKILL.md", false);
+        final SkillDescriptor beta = inMemorySkill("beta", "Beta workflow.", "# Beta", "tenant://beta/SKILL.md", false);
+        final AtomicInteger resolutionCount = new AtomicInteger();
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("first"), textResult("second"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(new AgentSkillResolver() {
+                    @Override
+                    public AgentSkillScope resolve(AgentRequest request) {
+                        List<SkillDescriptor> ordered = resolutionCount.incrementAndGet() % 2 == 0
+                                ? Arrays.asList(beta, alpha) : Arrays.asList(alpha, beta);
+                        return AgentSkillScope.builder()
+                                .workspaceRoot(workspace)
+                                .providedSkills(ordered)
+                                .build();
+                    }
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("first").build());
+        agent.run(AgentRequest.builder().input("second").build());
+
+        String firstPrompt = modelClient.prompts.get(0).getSystemPrompt();
+        Assert.assertEquals(firstPrompt, modelClient.prompts.get(1).getSystemPrompt());
+        Assert.assertTrue(firstPrompt.indexOf("<name>alpha</name>") < firstPrompt.indexOf("<name>beta</name>"));
+    }
+
+    @Test
+    public void shouldRejectFileBackedProvidedSkillOutsideDeclaredRoots() throws Exception {
+        Path workspace = temporaryFolder.newFolder("provided-skill-workspace").toPath();
+        Path outsideRoot = temporaryFolder.newFolder("provided-skill-outside").toPath();
+        Path outsideSkill = writeSkillUnderRoot(outsideRoot, "outside", "Outside the declared Skill root.", false);
+        SkillDescriptor descriptor = SkillDescriptor.builder()
+                .name("outside")
+                .description("Outside the declared Skill root.")
+                .skillFilePath(outsideSkill.toString())
+                .source("host")
+                .build();
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("unused"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(hostProvidedResolver(workspace, descriptor))
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        try {
+            agent.run(AgentRequest.builder().input("outside").build());
+            Assert.fail("expected outside root rejection");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("declared Skill root"));
+        }
+        Assert.assertTrue(modelClient.prompts.isEmpty());
+    }
+
+    @Test
     public void shouldRejectDuplicateHostProvidedSkillName() throws Exception {
         Path workspace = temporaryFolder.newFolder("memory-skill-duplicate").toPath();
         writeSkill(workspace, "shared", "File-backed shared Skill.", false);
@@ -375,6 +467,29 @@ public class AgentSkillRuntimeSupportTest {
         Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("<available_skills>"));
         Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("read_file"));
         Assert.assertTrue(readOutput.get().contains("Review code changes."));
+    }
+
+    @Test
+    public void shouldApplySelectedManualOnlySkillToCodeActRuntime() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-codeact-selected").toPath();
+        writeSkill(workspace, "release-runbook", "Follow the release procedure.", true);
+        RecordingModelClient modelClient = new RecordingModelClient(
+                textResult("{\"type\":\"final\",\"output\":\"done\"}"));
+        Agent agent = Agents.codeAct()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        AgentResult result = agent.run(AgentRequest.builder()
+                .input("prepare the release")
+                .selectedSkills(Collections.singletonList("release-runbook"))
+                .build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertFalse(modelClient.prompts.get(0).getSystemPrompt().contains("release-runbook"));
+        Assert.assertTrue(promptItemsText(modelClient.prompts.get(0)).contains("# release-runbook"));
     }
 
     @Test

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
@@ -1,0 +1,371 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentOptions;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicies;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillResolver;
+import io.github.lnyocly.ai4j.agent.skill.AgentSkillScope;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+public class AgentSkillRuntimeSupportTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private String originalUserHome;
+
+    @Before
+    public void isolateUserSkillRoots() throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", temporaryFolder.newFolder("isolated-user-home").getAbsolutePath());
+    }
+
+    @After
+    public void restoreUserSkillRoots() {
+        if (originalUserHome == null) {
+            System.clearProperty("user.home");
+            return;
+        }
+        System.setProperty("user.home", originalUserHome);
+    }
+
+    @Test
+    public void shouldLeaveAgentPromptUntouchedWhenNoSkillsAreDiscovered() throws Exception {
+        Path workspace = temporaryFolder.newFolder("empty-skill-root").toPath();
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("done"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .systemPrompt("host-system-boundary")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("no skills").build());
+
+        AgentPrompt prompt = modelClient.prompts.get(0);
+        Assert.assertTrue(prompt.getSystemPrompt().contains("host-system-boundary"));
+        Assert.assertFalse(prompt.getSystemPrompt().contains("<available_skills>"));
+        Assert.assertFalse(hasTool(prompt, "read_file"));
+    }
+
+    @Test
+    public void shouldRefreshSkillCatalogPerRunAndExposeManualOnlyOnlyWhenSelected() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-refresh").toPath();
+        Path reviewer = writeSkill(workspace, "reviewer", "Review source changes.", false);
+        writeSkill(workspace, "manual-runbook", "Run only when explicitly selected.", true);
+
+        RecordingModelClient modelClient = new RecordingModelClient(
+                textResult("first"), textResult("second"), textResult("selected"), textResult("refreshed"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("first").build());
+        agent.run(AgentRequest.builder().input("second").build());
+        agent.run(AgentRequest.builder()
+                .input("selected")
+                .selectedSkills(Collections.singletonList("manual-runbook"))
+                .build());
+
+        Files.delete(reviewer);
+        writeSkill(workspace, "writer", "Write a focused change.", false);
+        agent.run(AgentRequest.builder().input("refreshed").build());
+
+        Assert.assertEquals(4, modelClient.prompts.size());
+        String firstSystem = modelClient.prompts.get(0).getSystemPrompt();
+        Assert.assertTrue(firstSystem.contains("<available_skills>"));
+        Assert.assertTrue(firstSystem.contains("reviewer"));
+        Assert.assertFalse(firstSystem.contains("manual-runbook"));
+        Assert.assertEquals("unchanged catalog should preserve a stable system prompt for prompt cache reuse",
+                firstSystem, modelClient.prompts.get(1).getSystemPrompt());
+        Assert.assertTrue(hasTool(modelClient.prompts.get(0), "read_file"));
+
+        String selectedSystem = modelClient.prompts.get(2).getSystemPrompt();
+        Assert.assertTrue(selectedSystem.contains("<selected_skills>"));
+        Assert.assertTrue(selectedSystem.contains("manual-runbook"));
+        Assert.assertTrue(selectedSystem.contains("# manual-runbook"));
+
+        String refreshedSystem = modelClient.prompts.get(3).getSystemPrompt();
+        Assert.assertTrue(refreshedSystem.contains("writer"));
+        Assert.assertFalse(refreshedSystem.contains("reviewer"));
+        Assert.assertFalse(refreshedSystem.contains("manual-runbook"));
+    }
+
+    @Test
+    public void shouldReadOnlySkillDirectoryAndHonorPermissionPolicy() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-read").toPath();
+        Path skillFile = writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Path secretFile = workspace.resolve("outside.txt");
+        Files.write(secretFile, "outside-secret".getBytes(StandardCharsets.UTF_8));
+
+        AgentResult allowed = runWithToolCall(workspace, skillFile, null);
+        Assert.assertEquals("done", allowed.getOutputText());
+        Assert.assertEquals(1, allowed.getToolResults().size());
+        Assert.assertTrue(allowed.getToolResults().get(0).getOutput().contains("Read the Skill instructions."));
+
+        AgentResult outside = runWithToolCall(workspace, secretFile, null);
+        Assert.assertEquals("done", outside.getOutputText());
+        Assert.assertEquals(1, outside.getToolResults().size());
+        Assert.assertTrue(outside.getToolResults().get(0).getOutput().contains("Path escapes workspace root"));
+
+        AgentResult denied = runWithToolCall(workspace, skillFile,
+                AgentPermissionPolicies.denyTools(Collections.singleton("read_file"), "host denied Skill reads"));
+        Assert.assertEquals("done", denied.getOutputText());
+        Assert.assertEquals(1, denied.getToolResults().size());
+        Assert.assertTrue(denied.getToolResults().get(0).getOutput().contains("host denied Skill reads"));
+    }
+
+    @Test
+    public void shouldRejectAConflictingReadFileTool() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-conflict").toPath();
+        writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Tool conflict = new Tool();
+        Tool.Function function = new Tool.Function();
+        function.setName("read_file");
+        conflict.setFunction(function);
+
+        Agent agent = Agents.react()
+                .modelClient(new RecordingModelClient(textResult("unused")))
+                .model("test-model")
+                .skills(workspace)
+                .toolRegistry(() -> Collections.<Object>singletonList(conflict))
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        try {
+            agent.run(AgentRequest.builder().input("conflict").build());
+            Assert.fail("expected read_file conflict");
+        } catch (IllegalStateException expected) {
+            Assert.assertTrue(expected.getMessage().contains("reserves read_file"));
+        }
+    }
+
+    @Test
+    public void shouldKeepCustomResolverRootsIsolatedFromDefaultSkillRoots() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-isolation-workspace").toPath();
+        writeSkill(workspace, "workspace-only", "Must not be exposed to the tenant resolver.", false);
+        Path tenantRoot = temporaryFolder.newFolder("skill-isolation-tenant").toPath();
+        writeSkillUnderRoot(tenantRoot, "tenant-only", "Available through the host policy.", false);
+
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("done"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(new AgentSkillResolver() {
+                    @Override
+                    public AgentSkillScope resolve(AgentRequest request) {
+                        return AgentSkillScope.builder()
+                                .workspaceRoot(workspace)
+                                .skillDirectories(Collections.singletonList(tenantRoot.toString()))
+                                .build();
+                    }
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("isolation").build());
+
+        String systemPrompt = modelClient.prompts.get(0).getSystemPrompt();
+        Assert.assertTrue(systemPrompt.contains("tenant-only"));
+        Assert.assertFalse(systemPrompt.contains("workspace-only"));
+    }
+
+    @Test
+    public void shouldResolveRelativeCustomResolverRootsAgainstItsWorkspace() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-relative-resolver-workspace").toPath();
+        writeSkillUnderRoot(workspace.resolve("tenant-skills"), "tenant-relative",
+                "Available through a relative tenant policy root.", false);
+
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("done"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(new AgentSkillResolver() {
+                    @Override
+                    public AgentSkillScope resolve(AgentRequest request) {
+                        return AgentSkillScope.builder()
+                                .workspaceRoot(workspace)
+                                .skillDirectories(Collections.singletonList("tenant-skills"))
+                                .build();
+                    }
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("relative root").build());
+
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("tenant-relative"));
+    }
+
+    @Test
+    public void shouldApplySkillsToCodeActRuntime() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-codeact").toPath();
+        writeSkill(workspace, "code-review", "Review code changes.", true);
+
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("{\"type\":\"final\",\"output\":\"done\"}"));
+        Agent agent = Agents.codeAct()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        AgentResult result = agent.run(AgentRequest.builder()
+                .input("review")
+                .selectedSkills(Collections.singletonList("code-review"))
+                .build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals(1, modelClient.prompts.size());
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("code-review"));
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("# code-review"));
+        Assert.assertFalse(modelClient.prompts.get(0).getSystemPrompt().contains("<available_skills>"));
+    }
+
+    @Test
+    public void shouldRejectSymlinkEscapeWhenSupported() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-symlink").toPath();
+        Path skillFile = writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Path secretFile = workspace.resolve("outside.txt");
+        Files.write(secretFile, "outside-secret".getBytes(StandardCharsets.UTF_8));
+        Path escape = skillFile.getParent().resolve("escape.txt");
+        try {
+            Files.createSymbolicLink(escape, secretFile);
+        } catch (UnsupportedOperationException ex) {
+            Assume.assumeNoException(ex);
+        } catch (SecurityException ex) {
+            Assume.assumeNoException(ex);
+        } catch (java.io.IOException ex) {
+            Assume.assumeNoException(ex);
+        }
+
+        AgentResult result = runWithToolCall(workspace, escape, null);
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals(1, result.getToolResults().size());
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("Path escapes workspace root"));
+    }
+
+    private AgentResult runWithToolCall(Path workspace,
+                                        Path target,
+                                        io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicy permissionPolicy) throws Exception {
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("read-1", "read_file", "{\"path\":\"" + escapeJson(target.toString()) + "\"}"),
+                textResult("done"));
+        io.github.lnyocly.ai4j.agent.AgentBuilder builder = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(3).build());
+        if (permissionPolicy != null) {
+            builder.permissionPolicy(permissionPolicy);
+        }
+        return builder.build().run(AgentRequest.builder().input("read").build());
+    }
+
+    private Path writeSkill(Path workspace, String name, String description, boolean manualOnly) throws Exception {
+        return writeSkillUnderRoot(workspace.resolve(".ai4j").resolve("skills"), name, description, manualOnly);
+    }
+
+    private Path writeSkillUnderRoot(Path root, String name, String description, boolean manualOnly) throws Exception {
+        Path skillFile = root.resolve(name).resolve("SKILL.md");
+        Files.createDirectories(skillFile.getParent());
+        String content = "---\n"
+                + "name: " + name + "\n"
+                + "description: " + description + "\n"
+                + "disable-model-invocation: " + manualOnly + "\n"
+                + "---\n\n"
+                + "# " + name + "\n\n"
+                + description + "\n";
+        Files.write(skillFile, content.getBytes(StandardCharsets.UTF_8));
+        return skillFile;
+    }
+
+    private static boolean hasTool(AgentPrompt prompt, String name) {
+        if (prompt == null || prompt.getTools() == null) {
+            return false;
+        }
+        for (Object candidate : prompt.getTools()) {
+            if (candidate instanceof Tool) {
+                Tool tool = (Tool) candidate;
+                if (tool.getFunction() != null && name.equals(tool.getFunction().getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static AgentModelResult textResult(String text) {
+        return AgentModelResult.builder()
+                .outputText(text)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<AgentToolCall>())
+                .build();
+    }
+
+    private static AgentModelResult toolCallResult(String callId, String name, String arguments) {
+        return AgentModelResult.builder()
+                .toolCalls(Arrays.asList(AgentToolCall.builder()
+                        .callId(callId)
+                        .name(name)
+                        .arguments(arguments)
+                        .type("function_call")
+                        .build()))
+                .memoryItems(new ArrayList<Object>())
+                .build();
+    }
+
+    private static String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static class RecordingModelClient implements AgentModelClient {
+        private final Deque<AgentModelResult> results = new ArrayDeque<AgentModelResult>();
+        private final List<AgentPrompt> prompts = new ArrayList<AgentPrompt>();
+
+        private RecordingModelClient(AgentModelResult... responses) {
+            results.addAll(Arrays.asList(responses));
+        }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            prompts.add(prompt);
+            return results.isEmpty() ? textResult("") : results.removeFirst();
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return create(prompt);
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentSkillRuntimeSupportTest.java
@@ -5,6 +5,10 @@ import io.github.lnyocly.ai4j.agent.AgentOptions;
 import io.github.lnyocly.ai4j.agent.AgentRequest;
 import io.github.lnyocly.ai4j.agent.AgentResult;
 import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.codeact.CodeExecutionRequest;
+import io.github.lnyocly.ai4j.agent.codeact.CodeExecutionResult;
+import io.github.lnyocly.ai4j.agent.codeact.CodeExecutor;
+import io.github.lnyocly.ai4j.agent.extension.ExtensionAgentTools;
 import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
 import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
 import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
@@ -13,7 +17,13 @@ import io.github.lnyocly.ai4j.agent.permission.AgentPermissionPolicies;
 import io.github.lnyocly.ai4j.agent.skill.AgentSkillResolver;
 import io.github.lnyocly.ai4j.agent.skill.AgentSkillScope;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import io.github.lnyocly.ai4j.extension.ExtensionRuntimeSnapshot;
+import io.github.lnyocly.ai4j.extension.guardrail.ExtensionGuardrail;
+import io.github.lnyocly.ai4j.extension.guardrail.GuardrailDecision;
+import io.github.lnyocly.ai4j.extension.guardrail.GuardrailRequest;
 import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.skill.SkillDescriptor;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -25,12 +35,15 @@ import org.junit.rules.TemporaryFolder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AgentSkillRuntimeSupportTest {
 
@@ -110,14 +123,18 @@ public class AgentSkillRuntimeSupportTest {
         Assert.assertTrue(hasTool(modelClient.prompts.get(0), "read_file"));
 
         String selectedSystem = modelClient.prompts.get(2).getSystemPrompt();
-        Assert.assertTrue(selectedSystem.contains("<selected_skills>"));
-        Assert.assertTrue(selectedSystem.contains("manual-runbook"));
-        Assert.assertTrue(selectedSystem.contains("# manual-runbook"));
+        Assert.assertEquals("explicit Skill content must not invalidate the stable system prefix",
+                firstSystem, selectedSystem);
+        Assert.assertFalse(selectedSystem.contains("manual-runbook"));
+        Assert.assertTrue(promptItemsText(modelClient.prompts.get(2)).contains("<selected_skills>"));
+        Assert.assertTrue(promptItemsText(modelClient.prompts.get(2)).contains("# manual-runbook"));
 
         String refreshedSystem = modelClient.prompts.get(3).getSystemPrompt();
         Assert.assertTrue(refreshedSystem.contains("writer"));
         Assert.assertFalse(refreshedSystem.contains("reviewer"));
         Assert.assertFalse(refreshedSystem.contains("manual-runbook"));
+        Assert.assertFalse("request-scoped Skill content must not persist into later Agent runs",
+                promptItemsText(modelClient.prompts.get(3)).contains("# manual-runbook"));
     }
 
     @Test
@@ -145,28 +162,41 @@ public class AgentSkillRuntimeSupportTest {
     }
 
     @Test
-    public void shouldRejectAConflictingReadFileTool() throws Exception {
+    public void shouldExposeReadSkillFileWhenHostOwnsReadFile() throws Exception {
         Path workspace = temporaryFolder.newFolder("skill-conflict").toPath();
-        writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Path skillFile = writeSkill(workspace, "reader", "Read the Skill instructions.", false);
         Tool conflict = new Tool();
         Tool.Function function = new Tool.Function();
         function.setName("read_file");
         conflict.setFunction(function);
+        final AtomicInteger hostCalls = new AtomicInteger();
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("skill-read", "read_skill_file", "{\"path\":\"" + escapeJson(skillFile.toString()) + "\"}"),
+                textResult("done"));
 
         Agent agent = Agents.react()
-                .modelClient(new RecordingModelClient(textResult("unused")))
+                .modelClient(modelClient)
                 .model("test-model")
                 .skills(workspace)
                 .toolRegistry(() -> Collections.<Object>singletonList(conflict))
+                .toolExecutor(new ToolExecutor() {
+                    @Override
+                    public String execute(AgentToolCall call) {
+                        hostCalls.incrementAndGet();
+                        return "host-owned read_file";
+                    }
+                })
                 .options(AgentOptions.builder().maxSteps(2).build())
                 .build();
 
-        try {
-            agent.run(AgentRequest.builder().input("conflict").build());
-            Assert.fail("expected read_file conflict");
-        } catch (IllegalStateException expected) {
-            Assert.assertTrue(expected.getMessage().contains("reserves read_file"));
-        }
+        AgentResult result = agent.run(AgentRequest.builder().input("conflict").build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals(0, hostCalls.get());
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("Read the Skill instructions."));
+        Assert.assertTrue(hasTool(modelClient.prompts.get(0), "read_file"));
+        Assert.assertTrue(hasTool(modelClient.prompts.get(0), "read_skill_file"));
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("read_skill_file"));
     }
 
     @Test
@@ -227,28 +257,294 @@ public class AgentSkillRuntimeSupportTest {
     }
 
     @Test
-    public void shouldApplySkillsToCodeActRuntime() throws Exception {
-        Path workspace = temporaryFolder.newFolder("skill-codeact").toPath();
-        writeSkill(workspace, "code-review", "Review code changes.", true);
+    public void shouldLoadHostProvidedMemorySkillOnDemand() throws Exception {
+        Path workspace = temporaryFolder.newFolder("memory-skill-workspace").toPath();
+        String virtualPath = "tenant://acme/runbooks/reconcile/SKILL.md";
+        SkillDescriptor skill = inMemorySkill("tenant-reconcile", "Reconcile a tenant invoice safely.",
+                "# Tenant reconcile\n\nReturn the tenant reconciliation checklist.", virtualPath, false);
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("read-memory-skill", "read_file", "{\"path\":\"" + escapeJson(virtualPath) + "\"}"),
+                textResult("done"));
 
-        RecordingModelClient modelClient = new RecordingModelClient(textResult("{\"type\":\"final\",\"output\":\"done\"}"));
+        AgentResult result = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(hostProvidedResolver(workspace, skill))
+                .options(AgentOptions.builder().maxSteps(3).build())
+                .build()
+                .run(AgentRequest.builder().input("reconcile this tenant invoice").build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        String systemPrompt = modelClient.prompts.get(0).getSystemPrompt();
+        Assert.assertTrue(systemPrompt.contains("tenant-reconcile"));
+        Assert.assertTrue(systemPrompt.contains(virtualPath));
+        Assert.assertFalse("full in-memory Skill content must remain progressive", systemPrompt.contains("Tenant reconcile"));
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("tenant reconciliation checklist"));
+    }
+
+    @Test
+    public void shouldApplySelectedHostProvidedMemorySkillAsRequestOverlay() throws Exception {
+        Path workspace = temporaryFolder.newFolder("memory-skill-selected").toPath();
+        String virtualPath = "tenant://acme/runbooks/manual/SKILL.md";
+        SkillDescriptor skill = inMemorySkill("tenant-manual", "Host-selected tenant procedure.",
+                "# Tenant manual\n\nAlways produce MANUAL_SKILL_APPLIED.", virtualPath, true);
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("first"), textResult("second"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(hostProvidedResolver(workspace, skill))
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("use manual runbook")
+                .selectedSkills(Collections.singletonList("tenant-manual"))
+                .build());
+        agent.run(AgentRequest.builder().input("ordinary follow-up").build());
+
+        Assert.assertFalse(modelClient.prompts.get(0).getSystemPrompt().contains("tenant-manual"));
+        Assert.assertTrue(promptItemsText(modelClient.prompts.get(0)).contains("MANUAL_SKILL_APPLIED"));
+        Assert.assertFalse("selected in-memory content must not persist into the next run",
+                promptItemsText(modelClient.prompts.get(1)).contains("MANUAL_SKILL_APPLIED"));
+    }
+
+    @Test
+    public void shouldRejectDuplicateHostProvidedSkillName() throws Exception {
+        Path workspace = temporaryFolder.newFolder("memory-skill-duplicate").toPath();
+        writeSkill(workspace, "shared", "File-backed shared Skill.", false);
+        SkillDescriptor duplicate = inMemorySkill("shared", "Memory-backed shared Skill.",
+                "# Shared\n\nThis must not shadow a file Skill.", "tenant://acme/shared/SKILL.md", false);
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("unused"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skillResolver(new AgentSkillResolver() {
+                    @Override
+                    public AgentSkillScope resolve(AgentRequest request) {
+                        return AgentSkillScope.builder()
+                                .workspaceRoot(workspace)
+                                .skillDirectories(Collections.singletonList(".ai4j/skills"))
+                                .providedSkills(Collections.singletonList(duplicate))
+                                .build();
+                    }
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        try {
+            agent.run(AgentRequest.builder().input("shared").build());
+            Assert.fail("expected duplicate Skill name rejection");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Duplicate Skill name"));
+        }
+        Assert.assertTrue(modelClient.prompts.isEmpty());
+    }
+
+    @Test
+    public void shouldApplyAutomaticSkillsAndScopedReaderToCodeActRuntime() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-codeact").toPath();
+        final Path skillFile = writeSkill(workspace, "code-review", "Review code changes.", false);
+        final AtomicReference<String> readOutput = new AtomicReference<String>();
+
+        RecordingModelClient modelClient = new RecordingModelClient(
+                textResult("{\"type\":\"code\",\"language\":\"js\",\"code\":\"load skill\"}"));
         Agent agent = Agents.codeAct()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .codeExecutor(new CodeExecutor() {
+                    @Override
+                    public CodeExecutionResult execute(CodeExecutionRequest request) throws Exception {
+                        Assert.assertTrue(request.getToolNames().contains("read_file"));
+                        readOutput.set(request.getToolExecutor().execute(AgentToolCall.builder()
+                                .name("read_file")
+                                .arguments("{\"path\":\"" + escapeJson(skillFile.toString()) + "\"}")
+                                .callId("code-read")
+                                .type("function_call")
+                                .build()));
+                        return CodeExecutionResult.builder().result("done").build();
+                    }
+                })
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build();
+
+        AgentResult result = agent.run(AgentRequest.builder().input("review").build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals(1, modelClient.prompts.size());
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("code-review"));
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("<available_skills>"));
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("read_file"));
+        Assert.assertTrue(readOutput.get().contains("Review code changes."));
+    }
+
+    @Test
+    public void shouldKeepUserHomeSkillsOptInOnly() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-workspace-defaults").toPath();
+        Path userHomeSkills = Paths.get(System.getProperty("user.home"))
+                .resolve(".ai4j").resolve("skills");
+        writeSkillUnderRoot(userHomeSkills, "user-home-only", "Available only to local developer mode.", false);
+
+        RecordingModelClient workspaceOnlyClient = new RecordingModelClient(textResult("done"));
+        Agents.react()
+                .modelClient(workspaceOnlyClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build()
+                .run(AgentRequest.builder().input("workspace only").build());
+
+        RecordingModelClient localClient = new RecordingModelClient(textResult("done"));
+        Agents.react()
+                .modelClient(localClient)
+                .model("test-model")
+                .skillsIncludingUserHome(workspace)
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build()
+                .run(AgentRequest.builder().input("local roots").build());
+
+        Assert.assertFalse(workspaceOnlyClient.prompts.get(0).getSystemPrompt().contains("user-home-only"));
+        Assert.assertTrue(localClient.prompts.get(0).getSystemPrompt().contains("user-home-only"));
+    }
+
+    @Test
+    public void shouldKeepCatalogStableDuringToolLoopAndRefreshOnNextRun() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-loop-cache").toPath();
+        Path reviewer = writeSkill(workspace, "reviewer", "Review source changes.", false);
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("read-reviewer", "read_file", "{\"path\":\"" + escapeJson(reviewer.toString()) + "\"}"),
+                textResult("first run done"),
+                textResult("second run done"));
+        Agent agent = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(3).build())
+                .build();
+
+        agent.run(AgentRequest.builder().input("first run").build());
+        Files.delete(reviewer);
+        writeSkill(workspace, "writer", "Write a focused change.", false);
+        agent.run(AgentRequest.builder().input("second run").build());
+
+        Assert.assertEquals(3, modelClient.prompts.size());
+        Assert.assertEquals("one run must reuse exactly one cacheable catalog across model turns",
+                modelClient.prompts.get(0).getSystemPrompt(), modelClient.prompts.get(1).getSystemPrompt());
+        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("reviewer"));
+        Assert.assertTrue(modelClient.prompts.get(2).getSystemPrompt().contains("writer"));
+        Assert.assertFalse(modelClient.prompts.get(2).getSystemPrompt().contains("reviewer"));
+    }
+
+    @Test
+    public void shouldApplyExtensionGuardrailToAliasedSkillReader() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-guardrail").toPath();
+        Path skillFile = writeSkill(workspace, "reader", "Read the Skill instructions.", false);
+        Tool hostReadFile = new Tool();
+        Tool.Function hostFunction = new Tool.Function();
+        hostFunction.setName("read_file");
+        hostReadFile.setFunction(hostFunction);
+        final AtomicReference<String> guardedTool = new AtomicReference<String>();
+        ExtensionGuardrail guardrail = new ExtensionGuardrail() {
+            @Override
+            public String name() {
+                return "deny-skill-reads";
+            }
+
+            @Override
+            public GuardrailDecision evaluate(GuardrailRequest request) {
+                guardedTool.set(request.getTarget());
+                return GuardrailDecision.deny("extension policy");
+            }
+        };
+        ExtensionAgentTools extensionTools = ExtensionAgentTools.from(new ExtensionRuntimeSnapshot(
+                Collections.emptyList(), Collections.emptyMap(),
+                Collections.emptyList(), Collections.emptyMap(),
+                Collections.emptyList(), Collections.emptyList(),
+                Collections.singletonList(guardrail), Collections.emptyList()));
+        RecordingModelClient modelClient = new RecordingModelClient(
+                toolCallResult("alias-read", "read_skill_file", "{\"path\":\"" + escapeJson(skillFile.toString()) + "\"}"),
+                textResult("done"));
+
+        AgentResult result = Agents.react()
+                .modelClient(modelClient)
+                .model("test-model")
+                .extensions(extensionTools)
+                .skills(workspace)
+                .toolRegistry(() -> Collections.<Object>singletonList(hostReadFile))
+                .options(AgentOptions.builder().maxSteps(2).build())
+                .build()
+                .run(AgentRequest.builder().input("read guarded skill").build());
+
+        Assert.assertEquals("done", result.getOutputText());
+        Assert.assertEquals("read_file", guardedTool.get());
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("extension policy"));
+    }
+
+    @Test
+    public void shouldRejectOversizedSelectedSkillBeforeModelInvocation() throws Exception {
+        Path workspace = temporaryFolder.newFolder("skill-size-limit").toPath();
+        Path skillFile = workspace.resolve(".ai4j").resolve("skills").resolve("oversized").resolve("SKILL.md");
+        Files.createDirectories(skillFile.getParent());
+        StringBuilder content = new StringBuilder("---\nname: oversized\ndescription: Test size limits.\ndisable-model-invocation: true\n---\n");
+        for (int index = 0; index <= 12_000; index++) {
+            content.append('x');
+        }
+        Files.write(skillFile, content.toString().getBytes(StandardCharsets.UTF_8));
+        RecordingModelClient modelClient = new RecordingModelClient(textResult("unused"));
+        Agent agent = Agents.react()
                 .modelClient(modelClient)
                 .model("test-model")
                 .skills(workspace)
                 .options(AgentOptions.builder().maxSteps(2).build())
                 .build();
 
-        AgentResult result = agent.run(AgentRequest.builder()
-                .input("review")
-                .selectedSkills(Collections.singletonList("code-review"))
-                .build());
+        try {
+            agent.run(AgentRequest.builder()
+                    .input("activate oversized")
+                    .selectedSkills(Collections.singletonList("oversized"))
+                    .build());
+            Assert.fail("expected selected Skill size validation");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("12000 character"));
+        }
+        Assert.assertTrue(modelClient.prompts.isEmpty());
+    }
 
-        Assert.assertEquals("done", result.getOutputText());
-        Assert.assertEquals(1, modelClient.prompts.size());
-        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("code-review"));
-        Assert.assertTrue(modelClient.prompts.get(0).getSystemPrompt().contains("# code-review"));
-        Assert.assertFalse(modelClient.prompts.get(0).getSystemPrompt().contains("<available_skills>"));
+    @Test
+    public void shouldKeepLegacyAgentRequestConstructor() {
+        AgentRequest request = new AgentRequest("legacy input", Collections.<String, Object>singletonMap("key", "value"));
+
+        Assert.assertEquals("legacy input", request.getInput());
+        Assert.assertEquals("value", request.getMetadataString("key"));
+        Assert.assertNull(request.getSelectedSkills());
+    }
+
+    @Test
+    public void shouldLoadSkillWithNativeAnthropicProviderWhenExplicitlyEnabled() throws Exception {
+        String apiKey = System.getenv("ANTHROPIC_API_KEY");
+        Assume.assumeTrue("skip: set AI4J_LIVE_SKILLS_TEST=true and ANTHROPIC_API_KEY to run live Skill smoke",
+                "true".equalsIgnoreCase(System.getenv("AI4J_LIVE_SKILLS_TEST"))
+                        && apiKey != null && !apiKey.trim().isEmpty());
+        String baseUrl = valueOrDefault(System.getenv("ANTHROPIC_BASE_URL"),
+                "https://open.bigmodel.cn/api/anthropic/");
+        String model = valueOrDefault(System.getenv("ANTHROPIC_MODEL"), "glm-5.1");
+        Path workspace = temporaryFolder.newFolder("skill-live-provider").toPath();
+        writeSkill(workspace, "live-skill", "After reading this Skill, answer with SKILL_LOADED.", false);
+
+        AgentResult result = Agents.react()
+                .anthropicMessages(apiKey, baseUrl)
+                .model(model)
+                .skills(workspace)
+                .options(AgentOptions.builder().maxSteps(4).build())
+                .build()
+                .run(AgentRequest.builder()
+                        .input("Use the available live-skill before answering. You must call read_file to load its SKILL.md, then follow its instruction.")
+                        .build());
+
+        Assert.assertFalse("live model must return a response", result.getOutputText().trim().isEmpty());
+        Assert.assertFalse("live model must load the announced Skill", result.getToolCalls().isEmpty());
+        Assert.assertEquals("read_file", result.getToolCalls().get(0).getName());
+        Assert.assertTrue("live model must apply the loaded Skill instruction",
+                result.getOutputText().contains("SKILL_LOADED"));
     }
 
     @Test
@@ -292,6 +588,30 @@ public class AgentSkillRuntimeSupportTest {
         return builder.build().run(AgentRequest.builder().input("read").build());
     }
 
+    private AgentSkillResolver hostProvidedResolver(final Path workspace, final SkillDescriptor... skills) {
+        return new AgentSkillResolver() {
+            @Override
+            public AgentSkillScope resolve(AgentRequest request) {
+                return AgentSkillScope.builder()
+                        .workspaceRoot(workspace)
+                        .providedSkills(Arrays.asList(skills))
+                        .build();
+            }
+        };
+    }
+
+    private SkillDescriptor inMemorySkill(String name, String description, String content,
+                                          String virtualPath, boolean manualOnly) {
+        return SkillDescriptor.builder()
+                .name(name)
+                .description(description)
+                .content(content)
+                .skillFilePath(virtualPath)
+                .source("tenant")
+                .disableModelInvocation(manualOnly)
+                .build();
+    }
+
     private Path writeSkill(Path workspace, String name, String description, boolean manualOnly) throws Exception {
         return writeSkillUnderRoot(workspace.resolve(".ai4j").resolve("skills"), name, description, manualOnly);
     }
@@ -308,6 +628,14 @@ public class AgentSkillRuntimeSupportTest {
                 + description + "\n";
         Files.write(skillFile, content.getBytes(StandardCharsets.UTF_8));
         return skillFile;
+    }
+
+    private static String promptItemsText(AgentPrompt prompt) {
+        return prompt == null || prompt.getItems() == null ? "" : String.valueOf(prompt.getItems());
+    }
+
+    private static String valueOrDefault(String value, String fallback) {
+        return value == null || value.trim().isEmpty() ? fallback : value.trim();
     }
 
     private static boolean hasTool(AgentPrompt prompt, String name) {

--- a/ai4j-coding/src/test/java/io/github/lnyocly/ai4j/coding/CodingSkillSupportTest.java
+++ b/ai4j-coding/src/test/java/io/github/lnyocly/ai4j/coding/CodingSkillSupportTest.java
@@ -87,9 +87,9 @@ public class CodingSkillSupportTest {
             AgentPrompt prompt = modelClient.getLastPrompt();
             assertNotNull(prompt);
             assertTrue(prompt.getSystemPrompt().contains("<available_skills>"));
-            assertTrue(prompt.getSystemPrompt().contains("name: reviewer"));
+            assertTrue(prompt.getSystemPrompt().contains("<name>reviewer</name>"));
             assertTrue(prompt.getSystemPrompt().contains(workspaceSkillFile.toAbsolutePath().normalize().toString()));
-            assertTrue(prompt.getSystemPrompt().contains("name: refactorer"));
+            assertTrue(prompt.getSystemPrompt().contains("<name>refactorer</name>"));
             assertTrue(prompt.getSystemPrompt().contains(globalSkillFile.toAbsolutePath().normalize().toString()));
         } finally {
             restoreProperty("user.home", originalUserHome);
@@ -178,63 +178,70 @@ public class CodingSkillSupportTest {
     @Test
     public void shouldInjectEnabledExtensionSkillAndPromptResources() throws Exception {
         Path workspaceRoot = temporaryFolder.newFolder("workspace-extension-resources").toPath();
-        WorkspaceContext workspaceContext = WorkspaceContext.builder()
-                .rootPath(workspaceRoot.toString())
-                .description("Extension resource workspace")
-                .build();
-        ExtensionRegistry registry = ExtensionRegistry.of(new CodingResourceExtension())
-                .enable("coding-resource-pack");
-        CapturingModelClient modelClient = new CapturingModelClient();
-
-        CodingAgent agent = CodingAgents.builder()
-                .modelClient(modelClient)
-                .model("glm-4.5-flash")
-                .workspaceContext(workspaceContext)
-                .extensions(registry)
-                .systemPrompt("Base prompt.")
-                .build();
-
-        WorkspaceContext enriched = agent.getWorkspaceContext();
-        assertEquals(1, enriched.getAvailableSkills().size());
-        assertEquals("coding-extension-skill", enriched.getAvailableSkills().get(0).getName());
-        assertEquals("extension:coding-resource-pack", enriched.getAvailableSkills().get(0).getSource());
-        assertEquals(1, enriched.getAvailablePrompts().size());
-        assertEquals("coding-extension-prompt", enriched.getAvailablePrompts().get(0).getName());
-        assertEquals("extension:coding-resource-pack", enriched.getAvailablePrompts().get(0).getSource());
-
-        LocalWorkspaceFileService fileService = new LocalWorkspaceFileService(enriched);
-        WorkspaceFileReadResult skillRead = fileService.readFile(
-                enriched.getAvailableSkills().get(0).getSkillFilePath(),
-                1,
-                10,
-                4000
-        );
-        assertTrue(skillRead.getContent().contains("name: coding-extension-skill"));
-        assertTrue(skillRead.getContent().contains("Verify coding agent extension skill projection."));
-        WorkspaceFileReadResult promptRead = fileService.readFile(
-                enriched.getAvailablePrompts().get(0).getPromptFilePath(),
-                1,
-                10,
-                4000
-        );
-        assertTrue(promptRead.getContent().contains("Coding extension prompt fixture"));
-
+        Path fakeHome = temporaryFolder.newFolder("fake-extension-home").toPath();
+        String originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", fakeHome.toString());
         try {
-            fileService.writeFile(enriched.getAvailableSkills().get(0).getSkillFilePath(), "mutated", false);
-            fail("extension resources should be read-only outside the workspace root");
-        } catch (IllegalArgumentException expected) {
-            assertTrue(expected.getMessage().contains("escapes workspace root"));
-        }
+            WorkspaceContext workspaceContext = WorkspaceContext.builder()
+                    .rootPath(workspaceRoot.toString())
+                    .description("Extension resource workspace")
+                    .build();
+            ExtensionRegistry registry = ExtensionRegistry.of(new CodingResourceExtension())
+                    .enable("coding-resource-pack");
+            CapturingModelClient modelClient = new CapturingModelClient();
 
-        try (CodingSession session = agent.newSession()) {
-            session.run("Use extension resources.");
+            CodingAgent agent = CodingAgents.builder()
+                    .modelClient(modelClient)
+                    .model("glm-4.5-flash")
+                    .workspaceContext(workspaceContext)
+                    .extensions(registry)
+                    .systemPrompt("Base prompt.")
+                    .build();
+
+            WorkspaceContext enriched = agent.getWorkspaceContext();
+            assertEquals(1, enriched.getAvailableSkills().size());
+            assertEquals("coding-extension-skill", enriched.getAvailableSkills().get(0).getName());
+            assertEquals("extension:coding-resource-pack", enriched.getAvailableSkills().get(0).getSource());
+            assertEquals(1, enriched.getAvailablePrompts().size());
+            assertEquals("coding-extension-prompt", enriched.getAvailablePrompts().get(0).getName());
+            assertEquals("extension:coding-resource-pack", enriched.getAvailablePrompts().get(0).getSource());
+
+            LocalWorkspaceFileService fileService = new LocalWorkspaceFileService(enriched);
+            WorkspaceFileReadResult skillRead = fileService.readFile(
+                    enriched.getAvailableSkills().get(0).getSkillFilePath(),
+                    1,
+                    10,
+                    4000
+            );
+            assertTrue(skillRead.getContent().contains("name: coding-extension-skill"));
+            assertTrue(skillRead.getContent().contains("Verify coding agent extension skill projection."));
+            WorkspaceFileReadResult promptRead = fileService.readFile(
+                    enriched.getAvailablePrompts().get(0).getPromptFilePath(),
+                    1,
+                    10,
+                    4000
+            );
+            assertTrue(promptRead.getContent().contains("Coding extension prompt fixture"));
+
+            try {
+                fileService.writeFile(enriched.getAvailableSkills().get(0).getSkillFilePath(), "mutated", false);
+                fail("extension resources should be read-only outside the workspace root");
+            } catch (IllegalArgumentException expected) {
+                assertTrue(expected.getMessage().contains("escapes workspace root"));
+            }
+
+            try (CodingSession session = agent.newSession()) {
+                session.run("Use extension resources.");
+            }
+            AgentPrompt prompt = modelClient.getLastPrompt();
+            assertNotNull(prompt);
+            assertTrue(prompt.getSystemPrompt().contains("<available_skills>"));
+            assertTrue(prompt.getSystemPrompt().contains("<name>coding-extension-skill</name>"));
+            assertTrue(prompt.getSystemPrompt().contains("<available_prompts>"));
+            assertTrue(prompt.getSystemPrompt().contains("name: coding-extension-prompt"));
+        } finally {
+            restoreProperty("user.home", originalUserHome);
         }
-        AgentPrompt prompt = modelClient.getLastPrompt();
-        assertNotNull(prompt);
-        assertTrue(prompt.getSystemPrompt().contains("<available_skills>"));
-        assertTrue(prompt.getSystemPrompt().contains("name: coding-extension-skill"));
-        assertTrue(prompt.getSystemPrompt().contains("<available_prompts>"));
-        assertTrue(prompt.getSystemPrompt().contains("name: coding-extension-prompt"));
     }
 
     private static Path writeSkill(Path skillFile, String content) throws Exception {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/SkillDescriptor.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/SkillDescriptor.java
@@ -17,6 +17,20 @@ public class SkillDescriptor {
     private String source;
     private boolean disableModelInvocation;
 
+    /**
+     * Optional host-provided SKILL.md body. When present, {@code skillFilePath} is a stable
+     * virtual location resolved by the host's scoped Skill reader rather than the local filesystem.
+     */
+    private String content;
+
+    /**
+     * Source-compatible constructor retained for callers compiled before in-memory Skills existed.
+     */
+    public SkillDescriptor(String name, String description, String skillFilePath, String source,
+                           boolean disableModelInvocation) {
+        this(name, description, skillFilePath, source, disableModelInvocation, null);
+    }
+
     public SkillDescriptor(String name, String description, String skillFilePath, String source) {
         this(name, description, skillFilePath, source, false);
     }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
@@ -82,6 +82,28 @@ public final class Skills {
                 .build();
     }
 
+    /**
+     * Creates a read_file context that exposes only the supplied Skill roots, never the workspace.
+     */
+    public static BuiltInToolContext createSkillToolContext(List<String> skillRoots) {
+        List<String> allowedReadRoots = new ArrayList<String>();
+        if (skillRoots != null) {
+            for (String skillRoot : skillRoots) {
+                if (!isBlank(skillRoot)) {
+                    allowedReadRoots.add(Paths.get(skillRoot).toAbsolutePath().normalize().toString());
+                }
+            }
+        }
+        Path restrictedRoot = allowedReadRoots.isEmpty()
+                ? Paths.get(".").toAbsolutePath().normalize().resolve(".ai4j-skill-read-denied")
+                : Paths.get(allowedReadRoots.get(0)).toAbsolutePath().normalize();
+        return BuiltInToolContext.builder()
+                .workspaceRoot(restrictedRoot.toString())
+                .allowedReadRoots(allowedReadRoots)
+                .restrictReadToAllowedRoots(true)
+                .build();
+    }
+
     public static String appendAvailableSkillsPrompt(String basePrompt,
                                                      List<? extends SkillDescriptor> availableSkills) {
         String skillPrompt = buildAvailableSkillsPrompt(availableSkills);
@@ -118,16 +140,19 @@ public final class Skills {
             if (skill == null || skill.isDisableModelInvocation()) {
                 continue;
             }
-            entries.append("- name: ").append(firstNonBlank(skill.getName(), "skill")).append("\n");
-            entries.append("  path: ").append(firstNonBlank(skill.getSkillFilePath(), "(missing)")).append("\n");
-            entries.append("  description: ").append(firstNonBlank(skill.getDescription(), "No description available.")).append("\n");
+            entries.append("  <skill>\n");
+            entries.append("    <name>").append(escapeXml(firstNonBlank(skill.getName(), "skill"))).append("</name>\n");
+            entries.append("    <description>").append(escapeXml(firstNonBlank(skill.getDescription(), "No description available."))).append("</description>\n");
+            entries.append("    <location>").append(escapeXml(firstNonBlank(skill.getSkillFilePath(), "(missing)"))).append("</location>\n");
+            entries.append("  </skill>\n");
         }
         if (entries.length() == 0) {
             return null;
         }
         StringBuilder builder = new StringBuilder();
-        builder.append("Some reusable skills are installed. Do not read every skill file up front. ")
-                .append("When the task clearly matches a skill, read that SKILL.md with read_file first and then follow it.\n");
+        builder.append("The following skills provide specialized instructions for specific tasks. ")
+                .append("Do not read every skill file up front. When a task matches a skill's description, ")
+                .append("read its SKILL.md with read_file before proceeding. Resolve relative paths against the Skill directory.\n");
         builder.append("<available_skills>\n");
         builder.append(entries);
         builder.append("</available_skills>\n");
@@ -138,9 +163,11 @@ public final class Skills {
     private static List<Path> resolveSkillRoots(Path workspaceRoot, List<String> skillDirectories) {
         Set<Path> roots = new LinkedHashSet<Path>();
         roots.add(workspaceRoot.resolve(".ai4j").resolve("skills").toAbsolutePath().normalize());
+        roots.add(workspaceRoot.resolve(".agents").resolve("skills").toAbsolutePath().normalize());
         String userHome = System.getProperty("user.home");
         if (!isBlank(userHome)) {
             roots.add(Paths.get(userHome).resolve(".ai4j").resolve("skills").toAbsolutePath().normalize());
+            roots.add(Paths.get(userHome).resolve(".agents").resolve("skills").toAbsolutePath().normalize());
         }
         if (skillDirectories != null) {
             for (String configuredRoot : skillDirectories) {
@@ -369,6 +396,15 @@ public final class Skills {
 
     private static boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private static String escapeXml(String value) {
+        return value == null ? "" : value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     public static final class DiscoveryResult {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
@@ -1,6 +1,7 @@
 package io.github.lnyocly.ai4j.skill;
 
 import io.github.lnyocly.ai4j.tool.BuiltInToolContext;
+import io.github.lnyocly.ai4j.tool.BuiltInTools;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,8 +55,13 @@ public final class Skills {
                 allowedReadRoots.add(root.toAbsolutePath().normalize().toString());
                 for (SkillDescriptor descriptor : discoverFromRoot(root, resolvedWorkspaceRoot)) {
                     String normalizedName = normalizeKey(descriptor.getName());
-                    if (!byName.containsKey(normalizedName)) {
+                    SkillDescriptor existing = byName.get(normalizedName);
+                    if (existing == null) {
                         byName.put(normalizedName, descriptor);
+                    } else if (!sameSkillFile(existing, descriptor)) {
+                        throw new IllegalArgumentException("Duplicate Skill name '" + descriptor.getName()
+                                + "' discovered at " + existing.getSkillFilePath()
+                                + " and " + descriptor.getSkillFilePath());
                     }
                 }
             }
@@ -106,7 +112,16 @@ public final class Skills {
 
     public static String appendAvailableSkillsPrompt(String basePrompt,
                                                      List<? extends SkillDescriptor> availableSkills) {
-        String skillPrompt = buildAvailableSkillsPrompt(availableSkills);
+        return appendAvailableSkillsPrompt(basePrompt, availableSkills, BuiltInTools.READ_FILE);
+    }
+
+    /**
+     * Appends the Skill catalog using the actual reader exposed to the model.
+     */
+    public static String appendAvailableSkillsPrompt(String basePrompt,
+                                                     List<? extends SkillDescriptor> availableSkills,
+                                                     String readToolName) {
+        String skillPrompt = buildAvailableSkillsPrompt(availableSkills, readToolName);
         if (isBlank(basePrompt)) {
             return skillPrompt;
         }
@@ -118,10 +133,19 @@ public final class Skills {
 
     public static void appendAvailableSkillsPrompt(StringBuilder builder,
                                                    List<? extends SkillDescriptor> availableSkills) {
+        appendAvailableSkillsPrompt(builder, availableSkills, BuiltInTools.READ_FILE);
+    }
+
+    /**
+     * Appends the Skill catalog using the actual reader exposed to the model.
+     */
+    public static void appendAvailableSkillsPrompt(StringBuilder builder,
+                                                   List<? extends SkillDescriptor> availableSkills,
+                                                   String readToolName) {
         if (builder == null) {
             return;
         }
-        String skillPrompt = buildAvailableSkillsPrompt(availableSkills);
+        String skillPrompt = buildAvailableSkillsPrompt(availableSkills, readToolName);
         if (isBlank(skillPrompt)) {
             return;
         }
@@ -132,9 +156,18 @@ public final class Skills {
     }
 
     public static String buildAvailableSkillsPrompt(List<? extends SkillDescriptor> availableSkills) {
+        return buildAvailableSkillsPrompt(availableSkills, BuiltInTools.READ_FILE);
+    }
+
+    /**
+     * Builds a cache-stable Skill catalog and names the reader available for progressive loading.
+     */
+    public static String buildAvailableSkillsPrompt(List<? extends SkillDescriptor> availableSkills,
+                                                    String readToolName) {
         if (availableSkills == null || availableSkills.isEmpty()) {
             return null;
         }
+        String resolvedReadToolName = firstNonBlank(readToolName, BuiltInTools.READ_FILE);
         StringBuilder entries = new StringBuilder();
         for (SkillDescriptor skill : availableSkills) {
             if (skill == null || skill.isDisableModelInvocation()) {
@@ -152,12 +185,31 @@ public final class Skills {
         StringBuilder builder = new StringBuilder();
         builder.append("The following skills provide specialized instructions for specific tasks. ")
                 .append("Do not read every skill file up front. When a task matches a skill's description, ")
-                .append("read its SKILL.md with read_file before proceeding. Resolve relative paths against the Skill directory.\n");
+                .append("read its SKILL.md with ").append(resolvedReadToolName)
+                .append(" before proceeding. Resolve relative paths against the Skill directory.\n");
         builder.append("<available_skills>\n");
         builder.append(entries);
         builder.append("</available_skills>\n");
-        builder.append("Only use a skill after reading its SKILL.md. Prefer the smallest relevant skill set and reuse read_file instead of asking for a dedicated skill tool.");
+        builder.append("Only use a skill after reading its SKILL.md. Prefer the smallest relevant skill set and reuse ")
+                .append(resolvedReadToolName)
+                .append(" instead of asking for a dedicated skill tool.");
         return builder.toString().trim();
+    }
+
+    private static boolean sameSkillFile(SkillDescriptor first, SkillDescriptor second) {
+        if (first == null || second == null || isBlank(first.getSkillFilePath()) || isBlank(second.getSkillFilePath())) {
+            return false;
+        }
+        Path firstPath = Paths.get(first.getSkillFilePath()).toAbsolutePath().normalize();
+        Path secondPath = Paths.get(second.getSkillFilePath()).toAbsolutePath().normalize();
+        if (firstPath.equals(secondPath)) {
+            return true;
+        }
+        try {
+            return Files.isSameFile(firstPath, secondPath);
+        } catch (IOException ex) {
+            return false;
+        }
     }
 
     private static List<Path> resolveSkillRoots(Path workspaceRoot, List<String> skillDirectories) {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/skill/Skills.java
@@ -168,11 +168,31 @@ public final class Skills {
             return null;
         }
         String resolvedReadToolName = firstNonBlank(readToolName, BuiltInTools.READ_FILE);
-        StringBuilder entries = new StringBuilder();
+        List<SkillDescriptor> sortedSkills = new ArrayList<SkillDescriptor>();
         for (SkillDescriptor skill : availableSkills) {
-            if (skill == null || skill.isDisableModelInvocation()) {
-                continue;
+            if (skill != null && !skill.isDisableModelInvocation()) {
+                sortedSkills.add(skill);
             }
+        }
+        Collections.sort(sortedSkills, new Comparator<SkillDescriptor>() {
+            @Override
+            public int compare(SkillDescriptor first, SkillDescriptor second) {
+                int comparison = firstNonBlank(first.getName(), "skill")
+                        .compareTo(firstNonBlank(second.getName(), "skill"));
+                if (comparison != 0) {
+                    return comparison;
+                }
+                comparison = firstNonBlank(first.getDescription(), "No description available.")
+                        .compareTo(firstNonBlank(second.getDescription(), "No description available."));
+                if (comparison != 0) {
+                    return comparison;
+                }
+                return firstNonBlank(first.getSkillFilePath(), "(missing)")
+                        .compareTo(firstNonBlank(second.getSkillFilePath(), "(missing)"));
+            }
+        });
+        StringBuilder entries = new StringBuilder();
+        for (SkillDescriptor skill : sortedSkills) {
             entries.append("  <skill>\n");
             entries.append("    <name>").append(escapeXml(firstNonBlank(skill.getName(), "skill"))).append("</name>\n");
             entries.append("    <description>").append(escapeXml(firstNonBlank(skill.getDescription(), "No description available."))).append("</description>\n");

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/BuiltInToolContext.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/BuiltInToolContext.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -25,6 +26,12 @@ public class BuiltInToolContext {
 
     @Builder.Default
     private List<String> allowedReadRoots = new ArrayList<String>();
+
+    /**
+     * Restrict read_file to {@link #allowedReadRoots}; useful for prompt-owned assets such as Skills.
+     */
+    @Builder.Default
+    private boolean restrictReadToAllowedRoots = false;
 
     @Builder.Default
     private int defaultReadMaxChars = 12000;
@@ -76,11 +83,15 @@ public class BuiltInToolContext {
             candidate = root.resolve(path);
         }
         candidate = candidate.toAbsolutePath().normalize();
-        if (allowOutsideWorkspace || candidate.startsWith(root)) {
+        if (allowOutsideWorkspace) {
+            return candidate;
+        }
+        if (!restrictReadToAllowedRoots && candidate.startsWith(root)) {
             return candidate;
         }
         for (Path allowedRoot : getAllowedReadRootPaths()) {
-            if (candidate.startsWith(allowedRoot)) {
+            if (candidate.startsWith(allowedRoot)
+                    && (!restrictReadToAllowedRoots || resolvesWithin(candidate, allowedRoot))) {
                 return candidate;
             }
         }
@@ -115,5 +126,13 @@ public class BuiltInToolContext {
 
     private boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private boolean resolvesWithin(Path candidate, Path allowedRoot) {
+        try {
+            return candidate.toRealPath().startsWith(allowedRoot.toRealPath());
+        } catch (IOException ex) {
+            return false;
+        }
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/BuiltInToolContext.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/BuiltInToolContext.java
@@ -50,6 +50,30 @@ public class BuiltInToolContext {
 
     private transient BuiltInProcessRegistry processRegistry;
 
+    /**
+     * Source-compatible constructor retained for callers compiled before restricted Skill reads.
+     */
+    public BuiltInToolContext(String workspaceRoot,
+                              boolean allowOutsideWorkspace,
+                              List<String> allowedReadRoots,
+                              int defaultReadMaxChars,
+                              long defaultCommandTimeoutMs,
+                              int defaultBashLogChars,
+                              int maxProcessOutputChars,
+                              long processStopGraceMs,
+                              BuiltInProcessRegistry processRegistry) {
+        this(workspaceRoot,
+                allowOutsideWorkspace,
+                allowedReadRoots,
+                false,
+                defaultReadMaxChars,
+                defaultCommandTimeoutMs,
+                defaultBashLogChars,
+                maxProcessOutputChars,
+                processStopGraceMs,
+                processRegistry);
+    }
+
     public Path getWorkspaceRootPath() {
         if (isBlank(workspaceRoot)) {
             return Paths.get(".").toAbsolutePath().normalize();

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/skill/SkillsIChatServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/skill/SkillsIChatServiceTest.java
@@ -117,9 +117,46 @@ public class SkillsIChatServiceTest {
             String prompt = Skills.buildAvailableSkillsPrompt(discovery.getSkills());
             Assert.assertTrue(prompt.contains("<skill>"));
             Assert.assertTrue(prompt.contains("Review &lt;API&gt; changes &amp; report risks."));
+            Assert.assertTrue(Skills.buildAvailableSkillsPrompt(discovery.getSkills(), "read_skill_file")
+                    .contains("read its SKILL.md with read_skill_file"));
         } finally {
             restoreProperty("user.home", originalUserHome);
         }
+    }
+
+    @Test
+    public void shouldRejectDuplicateNormalizedSkillNamesFromDifferentFiles() throws Exception {
+        Path workspaceRoot = temporaryFolder.newFolder("skills-duplicate-workspace").toPath();
+        Path firstRoot = temporaryFolder.newFolder("skills-duplicate-first").toPath();
+        Path secondRoot = temporaryFolder.newFolder("skills-duplicate-second").toPath();
+        Path first = writeSkill(firstRoot.resolve("first").resolve("SKILL.md"),
+                "---\nname: review\ndescription: First review skill.\n---\n");
+        Path second = writeSkill(secondRoot.resolve("second").resolve("SKILL.md"),
+                "---\nname: REVIEW\ndescription: Second review skill.\n---\n");
+
+        try {
+            Skills.discover(workspaceRoot, Arrays.asList(firstRoot, secondRoot));
+            Assert.fail("expected duplicate normalized Skill name rejection");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("Duplicate Skill name"));
+            Assert.assertTrue(expected.getMessage().contains(first.toString()));
+            Assert.assertTrue(expected.getMessage().contains(second.toString()));
+        }
+    }
+
+    @Test
+    public void shouldAllowSameSkillFileWhenRootsOverlap() throws Exception {
+        Path workspaceRoot = temporaryFolder.newFolder("skills-overlap-workspace").toPath();
+        Path root = temporaryFolder.newFolder("skills-overlap-root").toPath();
+        Path skillFile = writeSkill(root.resolve("shared").resolve("SKILL.md"),
+                "---\nname: shared\ndescription: Shared Skill.\n---\n");
+
+        Skills.DiscoveryResult discovery = Skills.discover(workspaceRoot,
+                Arrays.asList(root, skillFile.getParent()));
+
+        Assert.assertEquals(1, discovery.getSkills().size());
+        Assert.assertEquals(skillFile.toAbsolutePath().normalize().toString(),
+                discovery.getSkills().get(0).getSkillFilePath());
     }
 
     @Test

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/skill/SkillsIChatServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/skill/SkillsIChatServiceTest.java
@@ -16,6 +16,8 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -32,6 +34,19 @@ public class SkillsIChatServiceTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private String originalUserHome;
+
+    @Before
+    public void isolateUserSkillRoots() throws Exception {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", temporaryFolder.newFolder("isolated-user-home").getAbsolutePath());
+    }
+
+    @After
+    public void restoreUserSkillRoots() {
+        restoreProperty("user.home", originalUserHome);
+    }
 
     @Test
     public void shouldDiscoverSkillsAndAssemblePromptForBasicChatUsage() throws Exception {
@@ -81,6 +96,27 @@ public class SkillsIChatServiceTest {
             Assert.assertEquals("api-review", first.getSkills().get(1).getName());
             Assert.assertEquals("java-review", first.getSkills().get(2).getName());
             Assert.assertEquals(first.getSkills(), second.getSkills());
+        } finally {
+            restoreProperty("user.home", originalUserHome);
+        }
+    }
+
+    @Test
+    public void shouldDiscoverCrossClientAgentsSkillsAndEscapePromptCatalog() throws Exception {
+        Path workspaceRoot = temporaryFolder.newFolder("skills-cross-client").toPath();
+        writeSkill(
+                workspaceRoot.resolve(".agents").resolve("skills").resolve("reviewer").resolve("SKILL.md"),
+                "---\nname: reviewer\ndescription: Review <API> changes & report risks.\n---\n"
+        );
+
+        String originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", temporaryFolder.newFolder("skills-cross-client-home").getAbsolutePath());
+        try {
+            Skills.DiscoveryResult discovery = Skills.discoverDefault(workspaceRoot);
+            Assert.assertEquals(1, discovery.getSkills().size());
+            String prompt = Skills.buildAvailableSkillsPrompt(discovery.getSkills());
+            Assert.assertTrue(prompt.contains("<skill>"));
+            Assert.assertTrue(prompt.contains("Review &lt;API&gt; changes &amp; report risks."));
         } finally {
             restoreProperty("user.home", originalUserHome);
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/tool/BuiltInToolExecutorTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/tool/BuiltInToolExecutorTest.java
@@ -10,6 +10,7 @@ import org.junit.rules.TemporaryFolder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 public class BuiltInToolExecutorTest {
 
@@ -104,6 +105,27 @@ public class BuiltInToolExecutorTest {
         ));
         Assert.assertEquals(processId, stopResult.getString("processId"));
         Assert.assertEquals("STOPPED", stopResult.getString("status"));
+    }
+
+    @Test
+    public void shouldKeepLegacyBuiltInToolContextConstructor() throws Exception {
+        Path workspaceRoot = temporaryFolder.newFolder("legacy-built-in-context").toPath();
+
+        BuiltInToolContext context = new BuiltInToolContext(
+                workspaceRoot.toString(),
+                false,
+                Collections.<String>emptyList(),
+                100,
+                200L,
+                300,
+                400,
+                500L,
+                null);
+
+        Assert.assertEquals(workspaceRoot.toAbsolutePath().normalize(), context.getWorkspaceRootPath());
+        Assert.assertFalse(context.isRestrictReadToAllowedRoots());
+        Assert.assertEquals(100, context.getDefaultReadMaxChars());
+        Assert.assertEquals(200L, context.getDefaultCommandTimeoutMs());
     }
 
     private static boolean isWindows() {


### PR DESCRIPTION
## Summary
- add per-run generic Skill resolution to AgentBuilder and AgentContext
- support workspace scopes, host-provided in-memory Skills, explicit manual-only overlays, and ReAct/CodeAct parity
- scope progressive Skill reads to declared Skill directories while preserving permission and guardrail enforcement

## Verification
- mvn -pl ai4j-agent -am clean test
- mvn -DskipTests package
- independent source review: no findings

## Boundaries
Tenant storage, RBAC, slash-command UI, and business tool activation remain host responsibilities.