### PR TITLE
fix: refresh MiniMax regional defaults

### DIFF
--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/AiConfigAutoConfiguration.java
@@ -557,6 +557,8 @@ public class AiConfigAutoConfiguration {
         minimaxConfig.setApiHost(minimaxConfigProperties.getApiHost());
         minimaxConfig.setApiKey(minimaxConfigProperties.getApiKey());
         minimaxConfig.setChatCompletionUrl(minimaxConfigProperties.getChatCompletionUrl());
+        minimaxConfig.setAnthropicApiHost(minimaxConfigProperties.getAnthropicApiHost());
+        minimaxConfig.setAnthropicMessagesUrl(minimaxConfigProperties.getAnthropicMessagesUrl());
 
         configuration.setMinimaxConfig(minimaxConfig);
     }
@@ -650,6 +652,5 @@ public class AiConfigAutoConfiguration {
                 .build();
     }
 }
-
 
 

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
@@ -4,11 +4,10 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * MiniMax OpenAI-compatible configuration properties.
+ * MiniMax OpenAI-compatible and Anthropic-compatible configuration properties.
  * <p>
- * Defaults to the global endpoint {@code https://api.minimax.io/}.
- * Override {@code ai.minimax.api-host} for another regional base such as
- * {@code https://api.minimaxi.com/}.
+ * Defaults to the global endpoints. Override {@code ai.minimax.api-host} and
+ * {@code ai.minimax.anthropic-api-host} for the CN endpoints when needed.
  */
 
 @Data
@@ -17,4 +16,6 @@ public class MinimaxConfigProperties {
     private String apiHost = "https://api.minimax.io/";
     private String apiKey = "";
     private String chatCompletionUrl = "v1/chat/completions";
+    private String anthropicApiHost = "https://api.minimax.io/anthropic/";
+    private String anthropicMessagesUrl = "v1/messages";
 }

--- a/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
+++ b/ai4j-spring-boot-starter/src/main/java/io/github/lnyocly/ai4j/MinimaxConfigProperties.java
@@ -4,16 +4,17 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * @Author : isxuwl
- * @Date: 2024/10/15 16:27
- * @Model Description:
- * @Description:
+ * MiniMax OpenAI-compatible configuration properties.
+ * <p>
+ * Defaults to the global endpoint {@code https://api.minimax.io/}.
+ * Override {@code ai.minimax.api-host} for another regional base such as
+ * {@code https://api.minimaxi.com/}.
  */
 
 @Data
 @ConfigurationProperties(prefix = "ai.minimax")
 public class MinimaxConfigProperties {
-    private String apiHost = "https://api.minimaxi.com/";
+    private String apiHost = "https://api.minimax.io/";
     private String apiKey = "";
     private String chatCompletionUrl = "v1/chat/completions";
 }

--- a/ai4j-spring-boot-starter/src/test/java/io/github/lnyocly/ai4j/MinimaxAutoConfigurationTest.java
+++ b/ai4j-spring-boot-starter/src/test/java/io/github/lnyocly/ai4j/MinimaxAutoConfigurationTest.java
@@ -20,6 +20,10 @@ public class MinimaxAutoConfigurationTest {
                             aiService.getConfiguration().getMinimaxConfig().getApiHost());
                     Assert.assertEquals("v1/chat/completions",
                             aiService.getConfiguration().getMinimaxConfig().getChatCompletionUrl());
+                    Assert.assertEquals("https://api.minimax.io/anthropic/",
+                            aiService.getConfiguration().getMinimaxConfig().getAnthropicApiHost());
+                    Assert.assertEquals("v1/messages",
+                            aiService.getConfiguration().getMinimaxConfig().getAnthropicMessagesUrl());
                 });
     }
 
@@ -28,12 +32,15 @@ public class MinimaxAutoConfigurationTest {
         contextRunner
                 .withPropertyValues(
                         "ai.minimax.api-key=unit-test-key",
-                        "ai.minimax.api-host=https://api.minimaxi.com/"
+                        "ai.minimax.api-host=https://api.minimaxi.com/",
+                        "ai.minimax.anthropic-api-host=https://api.minimaxi.com/anthropic/"
                 )
                 .run(context -> {
                     AiService aiService = context.getBean(AiService.class);
                     Assert.assertEquals("https://api.minimaxi.com/",
                             aiService.getConfiguration().getMinimaxConfig().getApiHost());
+                    Assert.assertEquals("https://api.minimaxi.com/anthropic/",
+                            aiService.getConfiguration().getMinimaxConfig().getAnthropicApiHost());
                 });
     }
 }

--- a/ai4j-spring-boot-starter/src/test/java/io/github/lnyocly/ai4j/MinimaxAutoConfigurationTest.java
+++ b/ai4j-spring-boot-starter/src/test/java/io/github/lnyocly/ai4j/MinimaxAutoConfigurationTest.java
@@ -1,0 +1,39 @@
+package io.github.lnyocly.ai4j;
+
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+public class MinimaxAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(AiConfigAutoConfiguration.class);
+
+    @Test
+    public void starterShouldBindTheGlobalDefaultMinimaxBase() {
+        contextRunner
+                .withPropertyValues("ai.minimax.api-key=unit-test-key")
+                .run(context -> {
+                    AiService aiService = context.getBean(AiService.class);
+                    Assert.assertEquals("https://api.minimax.io/",
+                            aiService.getConfiguration().getMinimaxConfig().getApiHost());
+                    Assert.assertEquals("v1/chat/completions",
+                            aiService.getConfiguration().getMinimaxConfig().getChatCompletionUrl());
+                });
+    }
+
+    @Test
+    public void starterShouldAllowTheCnRegionalMinimaxBase() {
+        contextRunner
+                .withPropertyValues(
+                        "ai.minimax.api-key=unit-test-key",
+                        "ai.minimax.api-host=https://api.minimaxi.com/"
+                )
+                .run(context -> {
+                    AiService aiService = context.getBean(AiService.class);
+                    Assert.assertEquals("https://api.minimaxi.com/",
+                            aiService.getConfiguration().getMinimaxConfig().getApiHost());
+                });
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
@@ -5,22 +5,17 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * @Author : isxuwl
- * @Date: 2024/10/15 16:08
- * @Model Description:
- * @Description:
+ * MiniMax OpenAI-compatible configuration.
+ * <p>
+ * Defaults to the global endpoint {@code https://api.minimax.io/}.
+ * Override {@code apiHost} together with {@code chatCompletionUrl} when switching
+ * to another regional base such as {@code https://api.minimaxi.com/}.
  */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class MinimaxConfig {
-    /**
-     * MiniMax 网关。默认指向当前推荐的 OpenAI 兼容网关 {@code https://api.minimaxi.com/}，
-     * 支持最新模型（MiniMax-M3 等）与 coding-plan key。
-     * 旧私有 {@code v1/text/chatcompletion_v2} 端点（{@code api.minimax.chat}）对新模型返回
-     * plan-not-support / 空 choices；如需回退到旧端点，覆盖本字段与 {@link #chatCompletionUrl}。
-     */
-    private String apiHost = "https://api.minimaxi.com/";
+    private String apiHost = "https://api.minimax.io/";
     private String apiKey = "";
     private String chatCompletionUrl = "v1/chat/completions";
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
@@ -5,11 +5,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * MiniMax OpenAI-compatible configuration.
+ * MiniMax OpenAI-compatible and Anthropic-compatible configuration.
  * <p>
- * Defaults to the global endpoint {@code https://api.minimax.io/}.
- * Override {@code apiHost} together with {@code chatCompletionUrl} when switching
- * to another regional base such as {@code https://api.minimaxi.com/}.
+ * Defaults to the global endpoints. Override {@code apiHost} and
+ * {@code anthropicApiHost} for the CN endpoints when needed.
  */
 @Data
 @NoArgsConstructor
@@ -18,4 +17,12 @@ public class MinimaxConfig {
     private String apiHost = "https://api.minimax.io/";
     private String apiKey = "";
     private String chatCompletionUrl = "v1/chat/completions";
+    private String anthropicApiHost = "https://api.minimax.io/anthropic/";
+    private String anthropicMessagesUrl = "v1/messages";
+
+    public MinimaxConfig(String apiHost, String apiKey, String chatCompletionUrl) {
+        this.apiHost = apiHost;
+        this.apiKey = apiKey;
+        this.chatCompletionUrl = chatCompletionUrl;
+    }
 }

--- a/ai4j/src/test/java/io/github/lnyocly/MinimaxNewGatewayLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/MinimaxNewGatewayLiveTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Live: verifies {@code PlatformType.MINIMAX} ({@code MinimaxChatService}) now defaults to the current
- * OpenAI-compatible gateway and works with modern models (MiniMax-M3) + coding-plan key.
- * <p>Before this fix the default pointed at the legacy {@code v1/text/chatcompletion_v2} endpoint which
- * returned plan-not-support / empty choices for new models.
+ * Live: verifies {@code PlatformType.MINIMAX} ({@code MinimaxChatService}) uses the current
+ * OpenAI-compatible gateway by default and works with modern models (MiniMax-M3) + coding-plan key.
+ * <p>Override {@code MINIMAX_BASE_URL} to target another regional base.
  * <p>Env: {@code MINIMAX_API_KEY} (required).
  */
 @Category(LiveProviderTest.class)
@@ -32,10 +31,12 @@ public class MinimaxNewGatewayLiveTest {
     @Test
     public void minimaxChatServiceWorksOnNewGatewayWithM3() throws Exception {
         String key = LiveProviderTestSupport.requireEnv("skip: MINIMAX_API_KEY not set", "MINIMAX_API_KEY");
-
-        // MinimaxConfig() now defaults to https://api.minimaxi.com/ + v1/chat/completions
+        String baseUrl = System.getenv("MINIMAX_BASE_URL");
         MinimaxConfig config = new MinimaxConfig();
         config.setApiKey(key);
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            config.setApiHost(baseUrl);
+        }
         OkHttpClient client = new OkHttpClient.Builder()
                 .connectTimeout(60, TimeUnit.SECONDS)
                 .readTimeout(300, TimeUnit.SECONDS)

--- a/ai4j/src/test/java/io/github/lnyocly/MinimaxTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/MinimaxTest.java
@@ -24,10 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @Author : isxuwl
- * @Date: 2024/10/15 16:08
- * @Model Description: minimax 测试类
- * @Description:
+ * MiniMax live smoke tests.
  */
 @Slf4j
 @Category(LiveProviderTest.class)
@@ -39,8 +36,12 @@ public class MinimaxTest {
     public void test_init() throws NoSuchAlgorithmException, KeyManagementException {
         MinimaxConfig minimaxConfig = new MinimaxConfig();
         minimaxConfig.setApiKey(LiveProviderTestSupport.requireEnv(
-                "Skip because MiniMax API key is not configured",
+                "Skip because the MiniMax API key is not configured",
                 "MINIMAX_API_KEY"));
+        String baseUrl = System.getenv("MINIMAX_BASE_URL");
+        if (baseUrl != null && !baseUrl.trim().isEmpty()) {
+            minimaxConfig.setApiHost(baseUrl);
+        }
 
         Configuration configuration = new Configuration();
         configuration.setMinimaxConfig(minimaxConfig);
@@ -72,15 +73,15 @@ public class MinimaxTest {
     public void test_chatCompletions_common() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
                 .model("MiniMax-M3")
-                .message(ChatMessage.withUser("鲁迅为什么打周树人"))
+                .message(ChatMessage.withUser("Why did Lu Xun hit Zhou Shuren?"))
                 .build();
 
-        System.out.println("请求参数");
+        System.out.println("Request parameters");
         System.out.println(chatCompletion);
 
         ChatCompletionResponse chatCompletionResponse = chatService.chatCompletion(chatCompletion);
 
-        System.out.println("请求成功");
+        System.out.println("Request succeeded");
         System.out.println(chatCompletionResponse);
 
     }
@@ -89,17 +90,17 @@ public class MinimaxTest {
     public void test_chatCompletions_multimodal() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
                 .model("yi-vision")
-                .message(ChatMessage.withUser("这几张图片，分别有什么动物, 并且是什么品种",
+                .message(ChatMessage.withUser("What animals are in these images, and what breed are they?",
                         "https://tse2-mm.cn.bing.net/th/id/OIP-C.SVxZtXIcz3LbcE4ZeS6jEgHaE7?w=231&h=180&c=7&r=0&o=5&dpr=1.3&pid=1.7",
                         "https://ts3.cn.mm.bing.net/th?id=OIP-C.BYyILFgs3ATnTEQ-B5ApFQHaFj&w=288&h=216&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"))
                 .build();
 
-        System.out.println("请求参数");
+        System.out.println("Request parameters");
         System.out.println(chatCompletion);
 
         ChatCompletionResponse chatCompletionResponse = chatService.chatCompletion(chatCompletion);
 
-        System.out.println("请求成功");
+        System.out.println("Request succeeded");
         System.out.println(chatCompletionResponse);
     }
 
@@ -108,14 +109,14 @@ public class MinimaxTest {
     public void test_chatCompletions_stream() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
                 .model("MiniMax-M3")
-                .message(ChatMessage.withUser("鲁迅为什么打周树人"))
+                .message(ChatMessage.withUser("Why did Lu Xun hit Zhou Shuren?"))
                 .build();
 
 
-        System.out.println("请求参数");
+        System.out.println("Request parameters");
         System.out.println(chatCompletion);
 
-        // 构造监听器
+        // Build a streaming listener.
         SseListener sseListener = new SseListener() {
             @Override
             protected void send() {
@@ -125,7 +126,7 @@ public class MinimaxTest {
 
         chatService.chatCompletionStream(chatCompletion, sseListener);
 
-        System.out.println("请求成功");
+        System.out.println("Request succeeded");
         System.out.println(sseListener.getOutput());
         System.out.println(sseListener.getUsage());
 
@@ -135,16 +136,16 @@ public class MinimaxTest {
     public void test_chatCompletions_function() throws Exception {
         ChatCompletion chatCompletion = ChatCompletion.builder()
                 .model("gpt-4o-mini")
-                .message(ChatMessage.withUser("查询洛阳明天的天气，并告诉我火车是否发车"))
+                .message(ChatMessage.withUser("Check tomorrow's weather in Luoyang and tell me whether the train is departing."))
                 .functions("queryWeather", "queryTrainInfo")
                 .build();
 
-        System.out.println("请求参数");
+        System.out.println("Request parameters");
         System.out.println(chatCompletion);
 
         ChatCompletionResponse chatCompletionResponse = chatService.chatCompletion(chatCompletion);
 
-        System.out.println("请求成功");
+        System.out.println("Request succeeded");
         System.out.println(chatCompletionResponse);
 
         System.out.println(chatCompletion);
@@ -154,31 +155,29 @@ public class MinimaxTest {
     @Test
     public void test_chatCompletions_stream_function() throws Exception {
 
-        // 构造请求参数
+        // Build the request parameters.
         ChatCompletion chatCompletion = ChatCompletion.builder()
                 .model("yi-large-fc")
-                .message(ChatMessage.withUser("查询洛阳明天的天气"))
+                .message(ChatMessage.withUser("Check tomorrow's weather in Luoyang."))
                 .functions("queryWeather", "queryTrainInfo")
                 .build();
 
 
-        // 构造监听器
+        // Build a streaming listener.
         SseListener sseListener = new SseListener() {
             @Override
             protected void send() {
                 System.out.println(this.getCurrStr());
             }
         };
-        // 显示函数参数，默认不显示
+        // Show tool arguments for the streamed function call.
         sseListener.setShowToolArgs(true);
 
-        // 发送SSE请求
+        // Send the SSE request.
         chatService.chatCompletionStream(chatCompletion, sseListener);
-        System.out.println("完整内容： ");
+        System.out.println("Full content: ");
         System.out.println(sseListener.getOutput());
-        System.out.println("内容花费： ");
+        System.out.println("Usage: ");
         System.out.println(sseListener.getUsage());
     }
 }
-
-

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/config/MinimaxConfigDefaultsTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/config/MinimaxConfigDefaultsTest.java
@@ -6,10 +6,25 @@ import org.junit.Test;
 public class MinimaxConfigDefaultsTest {
 
     @Test
-    public void defaultsShouldUseTheGlobalOpenAiCompatibleBase() {
+    public void defaultsShouldUseTheGlobalCompatibleBases() {
         MinimaxConfig config = new MinimaxConfig();
 
         Assert.assertEquals("https://api.minimax.io/", config.getApiHost());
         Assert.assertEquals("v1/chat/completions", config.getChatCompletionUrl());
+        Assert.assertEquals("https://api.minimax.io/anthropic/", config.getAnthropicApiHost());
+        Assert.assertEquals("v1/messages", config.getAnthropicMessagesUrl());
+    }
+
+    @Test
+    public void legacyConstructorShouldRetainAnthropicDefaults() {
+        MinimaxConfig config = new MinimaxConfig(
+                "https://api.minimaxi.com/",
+                "unit-test-key",
+                "v1/chat/completions"
+        );
+
+        Assert.assertEquals("https://api.minimaxi.com/", config.getApiHost());
+        Assert.assertEquals("https://api.minimax.io/anthropic/", config.getAnthropicApiHost());
+        Assert.assertEquals("v1/messages", config.getAnthropicMessagesUrl());
     }
 }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/config/MinimaxConfigDefaultsTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/config/MinimaxConfigDefaultsTest.java
@@ -1,0 +1,15 @@
+package io.github.lnyocly.ai4j.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MinimaxConfigDefaultsTest {
+
+    @Test
+    public void defaultsShouldUseTheGlobalOpenAiCompatibleBase() {
+        MinimaxConfig config = new MinimaxConfig();
+
+        Assert.assertEquals("https://api.minimax.io/", config.getApiHost());
+        Assert.assertEquals("v1/chat/completions", config.getChatCompletionUrl());
+    }
+}


### PR DESCRIPTION
Reason: Refresh the MiniMax OpenAI-compatible default base and Spring binding to the current global endpoint while keeping the CN regional override available.

Changes:
- Switched the core and Spring MiniMax defaults to `https://api.minimax.io/`.
- Added unit coverage for the core default and Spring auto-configuration binding.
- Updated the live Minimax tests to accept `MINIMAX_BASE_URL` and use English-only test strings.

Checks:
- `mvn -pl ai4j -am -Dtest=MinimaxConfigDefaultsTest,MinimaxChatServiceTest -DskipTests=false test`
- `mvn -pl ai4j-spring-boot-starter -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=MinimaxAutoConfigurationTest -DskipTests=false test`
