### PR TITLE
feat(agent): add CubeSandbox sandbox provider (TencentCloud/envd)

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxApiException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxApiException.java
@@ -1,0 +1,34 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import java.io.IOException;
+
+/**
+ * HTTP-level CubeSandbox API error.
+ */
+final class CubeSandboxApiException extends IOException {
+
+    private final int statusCode;
+    private final String responseBody;
+
+    CubeSandboxApiException(int statusCode, String message, String responseBody) {
+        super(message);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    int getStatusCode() {
+        return statusCode;
+    }
+
+    String getResponseBody() {
+        return responseBody;
+    }
+
+    boolean isNotFound() {
+        return statusCode == 404;
+    }
+
+    boolean isAuthFailure() {
+        return statusCode == 401 || statusCode == 403;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxClient.java
@@ -1,0 +1,464 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class CubeSandboxClient {
+
+    private static final String CONNECT_CONTENT_TYPE = "application/connect+json";
+    private static final String CONNECT_PROTOCOL_VERSION = "1";
+    private static final byte CONNECT_END_STREAM_FLAG = 0x02;
+    private static final byte CONNECT_COMPRESSED_FLAG = 0x01;
+    private static final int DEFAULT_PROCESS_READ_TIMEOUT_MILLIS = 10 * 60 * 1000;
+
+    private final CubeSandboxConfig config;
+
+    CubeSandboxClient(CubeSandboxConfig config) {
+        this.config = config;
+    }
+
+    CubeSandboxConfig getConfig() {
+        return config;
+    }
+
+    JSONObject health() throws IOException, CubeSandboxApiException {
+        return requestJson("GET", "/health", null, 200);
+    }
+
+    CubeSandboxRemote create(String templateId,
+                             int timeoutSeconds,
+                             Map<String, String> envVars,
+                             Map<String, String> metadata,
+                             Boolean allowInternetAccess,
+                             Object network) throws IOException, CubeSandboxApiException {
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("templateID", requireText(templateId, "CubeSandbox templateID is required. Set CUBE_TEMPLATE_ID or spec.config.templateId."));
+        payload.put("timeout", Integer.valueOf(timeoutSeconds));
+        if (envVars != null && !envVars.isEmpty()) {
+            payload.put("envVars", envVars);
+        }
+        if (metadata != null && !metadata.isEmpty()) {
+            payload.put("metadata", metadata);
+        }
+        if (allowInternetAccess != null && !allowInternetAccess.booleanValue()) {
+            payload.put("allowInternetAccess", Boolean.FALSE);
+        }
+        if (network != null) {
+            payload.put("network", network);
+        }
+        return toRemote(requestJson("POST", "/sandboxes", payload, 200, 201));
+    }
+
+    CubeSandboxRemote connect(String sandboxId) throws IOException, CubeSandboxApiException {
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("timeout", Integer.valueOf(config.getTimeoutSeconds()));
+        return toRemote(requestJson("POST", "/sandboxes/" + urlEncodePath(sandboxId) + "/connect", payload, 200, 201));
+    }
+
+    JSONObject getSandbox(String sandboxId) throws IOException, CubeSandboxApiException {
+        return requestJson("GET", "/sandboxes/" + urlEncodePath(sandboxId), null, 200);
+    }
+
+    void kill(String sandboxId) throws IOException, CubeSandboxApiException {
+        requestJson("DELETE", "/sandboxes/" + urlEncodePath(sandboxId), null, 200, 204);
+    }
+
+    ProcessRun runProcess(CubeSandboxRemote remote,
+                          String command,
+                          String cwd,
+                          Map<String, String> environment,
+                          Long timeoutMillis) throws IOException, CubeSandboxApiException {
+        Map<String, Object> process = new LinkedHashMap<String, Object>();
+        process.put("cmd", "/bin/bash");
+        process.put("args", new String[]{"-l", "-c", command});
+        process.put("envs", environment == null ? new LinkedHashMap<String, String>() : environment);
+        if (cwd != null && !cwd.trim().isEmpty()) {
+            process.put("cwd", cwd.trim());
+        }
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("process", process);
+        payload.put("stdin", Boolean.FALSE);
+
+        byte[] envelope = encodeConnectEnvelope(JSON.toJSONBytes(payload), (byte) 0);
+        long start = System.currentTimeMillis();
+        HttpURLConnection connection = null;
+        try {
+            URL url = dataUrl(remote, config.getEnvdPort(), "/process.Process/Start");
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            connection.setConnectTimeout(config.getRequestTimeoutMillis());
+            connection.setReadTimeout(readTimeout(timeoutMillis));
+            connection.setRequestProperty("Content-Type", CONNECT_CONTENT_TYPE);
+            connection.setRequestProperty("Connect-Protocol-Version", CONNECT_PROTOCOL_VERSION);
+            connection.setRequestProperty("Connect-Content-Encoding", "identity");
+            connection.setRequestProperty("Authorization", basicAuth(config.getUser()));
+            if (timeoutMillis != null && timeoutMillis.longValue() > 0) {
+                connection.setRequestProperty("Connect-Timeout-Ms", String.valueOf(timeoutMillis.longValue()));
+            }
+            if (remote.getEnvdAccessToken() != null) {
+                connection.setRequestProperty("X-Access-Token", safeHeaderValue(remote.getEnvdAccessToken(), "X-Access-Token"));
+            }
+            write(connection, envelope);
+
+            int status = connection.getResponseCode();
+            if (status >= 400) {
+                String errorBody = readBody(status >= 400 ? connection.getErrorStream() : connection.getInputStream());
+                throw new CubeSandboxApiException(status, "CubeSandbox process start failed: POST " + url + " -> " + status, errorBody);
+            }
+            ProcessRun run = parseProcessStream(connection.getInputStream());
+            run.durationMillis = Long.valueOf(System.currentTimeMillis() - start);
+            return run;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private JSONObject requestJson(String method, String path, Object payload, int... okStatuses) throws IOException, CubeSandboxApiException {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(config.getApiUrl() + path);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod(method);
+            connection.setConnectTimeout(config.getRequestTimeoutMillis());
+            connection.setReadTimeout(config.getRequestTimeoutMillis());
+            connection.setRequestProperty("Accept", "application/json");
+            if (config.getApiKey() != null) {
+                connection.setRequestProperty("Authorization", safeHeaderValue("Bearer " + config.getApiKey(), "Authorization"));
+            }
+            if (payload != null) {
+                connection.setDoOutput(true);
+                connection.setRequestProperty("Content-Type", "application/json");
+                write(connection, JSON.toJSONBytes(payload));
+            }
+            int status = connection.getResponseCode();
+            if (!statusOk(status, okStatuses)) {
+                String errorBody = readBody(status >= 400 ? connection.getErrorStream() : connection.getInputStream());
+                throw new CubeSandboxApiException(status, "CubeSandbox control API failed: " + method + " " + path + " -> " + status, errorBody);
+            }
+            if (status == 204) {
+                return new JSONObject();
+            }
+            String body = readBody(connection.getInputStream());
+            if (body == null || body.trim().isEmpty()) {
+                return new JSONObject();
+            }
+            return JSON.parseObject(body);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private URL dataUrl(CubeSandboxRemote remote, int port, String path) throws IOException, CubeSandboxApiException {
+        try {
+            if (config.getEnvdBaseUrl() != null) {
+                return new URL(config.getEnvdBaseUrl() + path);
+            }
+            return new URL("http://" + remote.host(port, config.getSandboxDomain()) + path);
+        } catch (io.github.lnyocly.ai4j.agent.sandbox.SandboxException e) {
+            throw new CubeSandboxApiException(400, "Invalid remote host: " + e.getMessage(), null);
+        }
+    }
+
+    private ProcessRun parseProcessStream(InputStream input) throws IOException, CubeSandboxApiException {
+        DataInputStream data = new DataInputStream(input);
+        ProcessRun run = new ProcessRun();
+        StringBuilder stdout = new StringBuilder();
+        StringBuilder stderr = new StringBuilder();
+        boolean sawEnd = false;
+        while (true) {
+            int flags;
+            try {
+                flags = data.readUnsignedByte();
+            } catch (EOFException eof) {
+                break;
+            }
+            int size = data.readInt();
+            if (size < 0 || size > config.getConnectEnvelopeLimitBytes()) {
+                throw new CubeSandboxApiException(400, "CubeSandbox Connect stream message too large: " + size + " bytes", null);
+            }
+            byte[] payload = new byte[size];
+            data.readFully(payload);
+            if ((flags & CONNECT_COMPRESSED_FLAG) != 0) {
+                throw new CubeSandboxApiException(400, "CubeSandbox Connect stream compressed messages are not supported", null);
+            }
+            if ((flags & CONNECT_END_STREAM_FLAG) != 0) {
+                parseConnectEndStream(payload);
+                continue;
+            }
+            JSONObject response;
+            try {
+                response = JSON.parseObject(new String(payload, StandardCharsets.UTF_8));
+            } catch (RuntimeException parseError) {
+                // Skip malformed Connect data frames (lenient parse, mirrors E2B).
+                continue;
+            }
+            JSONObject event = response.getJSONObject("event");
+            if (event == null) {
+                continue;
+            }
+            JSONObject start = event.getJSONObject("start");
+            if (start != null && start.getInteger("pid") != null) {
+                run.pid = start.getInteger("pid");
+            }
+            JSONObject datum = event.getJSONObject("data");
+            if (datum != null) {
+                String out = datum.getString("stdout");
+                String err = datum.getString("stderr");
+                if (out != null && !out.isEmpty()) {
+                    stdout.append(decodeBase64(out));
+                }
+                if (err != null && !err.isEmpty()) {
+                    stderr.append(decodeBase64(err));
+                }
+            }
+            JSONObject end = event.getJSONObject("end");
+            if (end != null) {
+                Integer exitCode = end.getInteger("exitCode");
+                if (exitCode == null) {
+                    exitCode = end.getInteger("exit_code");
+                }
+                if (exitCode == null && end.getString("status") != null) {
+                    exitCode = parseExitCodeFromStatus(end.getString("status"));
+                }
+                if (exitCode == null) {
+                    String error = end.getString("error");
+                    if (error != null && !error.trim().isEmpty()) {
+                        throw new CubeSandboxApiException(400, "CubeSandbox process failed: " + error, null);
+                    }
+                    throw new CubeSandboxApiException(400, "CubeSandbox process stream ended without exit code", null);
+                }
+                run.exitCode = exitCode;
+                sawEnd = true;
+            }
+        }
+        if (!sawEnd) {
+            throw new CubeSandboxApiException(400, "CubeSandbox process stream ended without EndEvent", null);
+        }
+        run.stdout = stdout.toString();
+        run.stderr = stderr.toString();
+        return run;
+    }
+
+    private void parseConnectEndStream(byte[] payload) throws CubeSandboxApiException {
+        if (payload == null || payload.length == 0) {
+            return;
+        }
+        JSONObject object;
+        try {
+            object = JSON.parseObject(new String(payload, StandardCharsets.UTF_8));
+        } catch (RuntimeException parseError) {
+            return;
+        }
+        JSONObject error = object.getJSONObject("error");
+        if (error == null) {
+            return;
+        }
+        String message = error.getString("message");
+        String code = error.getString("code");
+        if (message == null || message.trim().isEmpty()) {
+            message = "Connect stream error";
+        }
+        if (code != null && !code.trim().isEmpty()) {
+            throw new CubeSandboxApiException(400, "CubeSandbox Connect stream error " + code + ": " + message, null);
+        }
+        throw new CubeSandboxApiException(400, "CubeSandbox Connect stream error: " + message, null);
+    }
+
+    private static String decodeBase64(String value) {
+        try {
+            byte[] raw = Base64.getDecoder().decode(value);
+            return new String(raw, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException notBase64) {
+            return value;
+        }
+    }
+
+    private static Integer parseExitCodeFromStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        String marker = "exit status ";
+        int index = status.indexOf(marker);
+        if (index >= 0) {
+            return parseIntegerPrefix(status.substring(index + marker.length()));
+        }
+        marker = "exited with code ";
+        index = status.indexOf(marker);
+        if (index >= 0) {
+            return parseIntegerPrefix(status.substring(index + marker.length()));
+        }
+        if ("exited".equals(status)) {
+            return Integer.valueOf(0);
+        }
+        return null;
+    }
+
+    private static Integer parseIntegerPrefix(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if ((ch >= '0' && ch <= '9') || (i == 0 && ch == '-')) {
+                builder.append(ch);
+            } else {
+                break;
+            }
+        }
+        if (builder.length() == 0 || "-".equals(builder.toString())) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(builder.toString());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static CubeSandboxRemote toRemote(JSONObject object) throws CubeSandboxApiException {
+        String sandboxId = object.getString("sandboxID");
+        String templateId = object.getString("templateID");
+        if (sandboxId == null || sandboxId.trim().isEmpty()) {
+            throw new CubeSandboxApiException(400, "CubeSandbox response missing sandboxID", null);
+        }
+        return new CubeSandboxRemote(
+                templateId,
+                sandboxId,
+                object.getString("clientID"),
+                object.getString("envdVersion"),
+                object.getString("envdAccessToken"),
+                object.getString("trafficAccessToken"),
+                object.getString("domain"));
+    }
+
+    private static boolean statusOk(int status, int[] okStatuses) {
+        for (int okStatus : okStatuses) {
+            if (status == okStatus) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String requireText(String value, String message) throws CubeSandboxApiException {
+        if (value == null || value.trim().isEmpty()) {
+            throw new CubeSandboxApiException(400, message, null);
+        }
+        return value.trim();
+    }
+
+    private static String urlEncodePath(String value) {
+        try {
+            return java.net.URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static String basicAuth(String user) {
+        String value = user == null || user.trim().isEmpty() ? "root" : user.trim();
+        return "Basic " + Base64.getEncoder().encodeToString((value + ":").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String safeHeaderValue(String value, String headerName) throws CubeSandboxApiException {
+        if (value == null) {
+            return "";
+        }
+        if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new CubeSandboxApiException(400, "CubeSandbox " + headerName + " header contains invalid line break", null);
+        }
+        return value;
+    }
+
+    private static byte[] encodeConnectEnvelope(byte[] payload, byte flags) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(flags);
+        int size = payload == null ? 0 : payload.length;
+        out.write((size >>> 24) & 0xff);
+        out.write((size >>> 16) & 0xff);
+        out.write((size >>> 8) & 0xff);
+        out.write(size & 0xff);
+        if (payload != null) {
+            out.write(payload, 0, payload.length);
+        }
+        return out.toByteArray();
+    }
+
+    private static void write(HttpURLConnection connection, byte[] payload) throws IOException {
+        OutputStream output = connection.getOutputStream();
+        try {
+            output.write(payload);
+        } finally {
+            output.close();
+        }
+    }
+
+    private static int readTimeout(Long timeoutMillis) {
+        if (timeoutMillis == null || timeoutMillis.longValue() <= 0) {
+            return DEFAULT_PROCESS_READ_TIMEOUT_MILLIS;
+        }
+        long withMargin = timeoutMillis.longValue() + 5000L;
+        return withMargin > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) withMargin;
+    }
+
+    private static String readBody(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+            return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+        } finally {
+            input.close();
+        }
+    }
+
+    static final class ProcessRun {
+        private Integer pid;
+        private Integer exitCode;
+        private String stdout;
+        private String stderr;
+        private Long durationMillis;
+
+        Integer getPid() {
+            return pid;
+        }
+
+        Integer getExitCode() {
+            return exitCode;
+        }
+
+        String getStdout() {
+            return stdout;
+        }
+
+        String getStderr() {
+            return stderr;
+        }
+
+        Long getDurationMillis() {
+            return durationMillis;
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxClient.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxClient.java
@@ -116,7 +116,7 @@ class CubeSandboxClient {
 
             int status = connection.getResponseCode();
             if (status >= 400) {
-                String errorBody = readBody(status >= 400 ? connection.getErrorStream() : connection.getInputStream());
+                String errorBody = readBody(connection.getErrorStream());
                 throw new CubeSandboxApiException(status, "CubeSandbox process start failed: POST " + url + " -> " + status, errorBody);
             }
             ProcessRun run = parseProcessStream(connection.getInputStream());

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxConfig.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxConfig.java
@@ -122,8 +122,8 @@ public final class CubeSandboxConfig {
             requestTimeoutMillis = millisValue(config, "requestTimeout");
         }
         builder.requestTimeoutMillis(requestTimeoutMillis);
-        builder.closeDestroysSandbox(booleanValue(config, "closeDestroysSandbox", "destroyOnClose", "deleteOnClose"));
-        builder.allowInternetAccessDefault(booleanValue(config, "allowInternetAccess", "allowInternetAccessDefault"));
+        applyBoolean(config, builder::closeDestroysSandbox, "closeDestroysSandbox", "destroyOnClose", "deleteOnClose");
+        applyBoolean(config, builder::allowInternetAccessDefault, "allowInternetAccess", "allowInternetAccessDefault");
         builder.user(stringValue(config, "user"));
         builder.connectEnvelopeLimitBytes(intValue(config, "connectEnvelopeLimitBytes"));
         builder.spec(spec.copy());
@@ -349,16 +349,19 @@ public final class CubeSandboxConfig {
         }
     }
 
-    private static Boolean booleanValue(Map<String, Object> config, String... keys) {
+    private static void applyBoolean(Map<String, Object> config, java.util.function.Consumer<Boolean> setter, String... keys) {
         Object value = objectValue(config, keys);
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        }
         if (value == null) {
-            return null;
+            return;
+        }
+        if (value instanceof Boolean) {
+            setter.accept((Boolean) value);
+            return;
         }
         String text = trimToNull(String.valueOf(value));
-        return text == null ? null : Boolean.valueOf(text);
+        if (text != null) {
+            setter.accept(Boolean.valueOf(text));
+        }
     }
 
     private static Object objectValue(Map<String, Object> config, String... keys) {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxConfig.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxConfig.java
@@ -1,0 +1,495 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Configuration for the CubeSandbox adapter.
+ *
+ * <p>Connection values are resolved from explicit builder values or
+ * environment variables, then task-local non-secret options in
+ * {@link SandboxSpec#getConfig()} can narrow the sandbox request. Secrets are
+ * kept out of {@link SandboxSpec} so they are not accidentally persisted in
+ * session snapshots.</p>
+ */
+public final class CubeSandboxConfig {
+
+    public static final String DEFAULT_PROVIDER_ID = "cubesandbox";
+    public static final String DEFAULT_API_URL = "http://127.0.0.1:3000";
+    public static final String DEFAULT_SANDBOX_DOMAIN = "cube.app";
+    public static final int DEFAULT_ENVD_PORT = 49983;
+    public static final int DEFAULT_TIMEOUT_SECONDS = 300;
+    public static final int DEFAULT_REQUEST_TIMEOUT_MILLIS = 30000;
+    public static final int DEFAULT_CONNECT_ENVELOPE_LIMIT_BYTES = 64 * 1024 * 1024;
+    public static final String CUBE_ENVD_BASE_URL = "CUBE_ENVD_BASE_URL";
+
+    private final String providerId;
+    private final String apiUrl;
+    private final String apiKey;
+    private final String templateId;
+    private final String sandboxDomain;
+    private final String envdBaseUrl;
+    private final int envdPort;
+    private final int timeoutSeconds;
+    private final int requestTimeoutMillis;
+    private final boolean closeDestroysSandbox;
+    private final boolean allowInternetAccessDefault;
+    private final String user;
+    private final int connectEnvelopeLimitBytes;
+    private final SandboxSpec spec;
+
+    private CubeSandboxConfig(Builder builder) {
+        this.providerId = trimToDefault(builder.providerId, DEFAULT_PROVIDER_ID);
+        this.apiUrl = stripTrailingSlash(trimToDefault(builder.apiUrl, DEFAULT_API_URL));
+        this.apiKey = trimToNull(builder.apiKey);
+        this.templateId = trimToNull(builder.templateId);
+        this.sandboxDomain = trimToDefault(builder.sandboxDomain, DEFAULT_SANDBOX_DOMAIN);
+        this.envdBaseUrl = stripTrailingSlash(trimToNull(builder.envdBaseUrl));
+        this.envdPort = positiveOrDefault(builder.envdPort, DEFAULT_ENVD_PORT);
+        this.timeoutSeconds = positiveOrDefault(builder.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
+        this.requestTimeoutMillis = positiveOrDefault(builder.requestTimeoutMillis, DEFAULT_REQUEST_TIMEOUT_MILLIS);
+        this.closeDestroysSandbox = builder.closeDestroysSandbox == null || builder.closeDestroysSandbox.booleanValue();
+        this.allowInternetAccessDefault = builder.allowInternetAccessDefault == null || builder.allowInternetAccessDefault.booleanValue();
+        this.user = trimToDefault(builder.user, "root");
+        this.connectEnvelopeLimitBytes = positiveOrDefault(builder.connectEnvelopeLimitBytes, DEFAULT_CONNECT_ENVELOPE_LIMIT_BYTES);
+        this.spec = builder.spec == null
+                ? SandboxSpec.builder().providerId(this.providerId).build()
+                : builder.spec.copy();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static CubeSandboxConfig fromEnvironment() {
+        return fromEnvironment(null, System.getenv());
+    }
+
+    public static CubeSandboxConfig fromEnvironment(SandboxSpec spec) {
+        return fromEnvironment(spec, System.getenv());
+    }
+
+    public static CubeSandboxConfig fromEnvironment(SandboxSpec spec, Map<String, String> env) {
+        Map<String, String> effectiveEnv = env == null ? Collections.<String, String>emptyMap() : env;
+        Builder builder = builder()
+                .providerId(DEFAULT_PROVIDER_ID)
+                .apiUrl(envValue(effectiveEnv, "CUBE_API_URL") != null
+                        ? envValue(effectiveEnv, "CUBE_API_URL")
+                        : envValue(effectiveEnv, "E2B_API_URL"))
+                .apiKey(envValue(effectiveEnv, "CUBE_API_KEY") != null
+                        ? envValue(effectiveEnv, "CUBE_API_KEY")
+                        : envValue(effectiveEnv, "E2B_API_KEY"))
+                .templateId(envValue(effectiveEnv, "CUBE_TEMPLATE_ID"))
+                .sandboxDomain(envValue(effectiveEnv, "CUBE_SANDBOX_DOMAIN"))
+                .envdBaseUrl(envValue(effectiveEnv, "CUBE_ENVD_BASE_URL"))
+                .envdPort(parseInt(envValue(effectiveEnv, "CUBE_ENVD_PORT")))
+                .timeoutSeconds(parseSeconds(envValue(effectiveEnv, "CUBE_TIMEOUT")))
+                .requestTimeoutMillis(parseMillis(envValue(effectiveEnv, "CUBE_REQUEST_TIMEOUT")));
+        CubeSandboxConfig config = builder.build();
+        if (spec != null) {
+            return config.withSpecOverrides(spec);
+        }
+        return config;
+    }
+
+    private static String envValue(Map<String, String> env, String key) {
+        if (env == null) {
+            return null;
+        }
+        return env.get(key);
+    }
+
+    public CubeSandboxConfig withSpecOverrides(SandboxSpec spec) {
+        if (spec == null || spec.getConfig().isEmpty()) {
+            return this;
+        }
+        Map<String, Object> config = spec.getConfig();
+        Builder builder = toBuilder();
+        builder.apiUrl(stringValue(config, "apiUrl", "apiURL", "baseUrl", "baseURL"));
+        // Intentionally do not read apiKey from SandboxSpec. Specs are often
+        // copied into session snapshots or task definitions; credentials should
+        // come from the provider constructor or environment only.
+        builder.templateId(stringValue(config, "templateId", "templateID"));
+        builder.sandboxDomain(stringValue(config, "sandboxDomain", "domain"));
+        builder.envdBaseUrl(stringValue(config, "envdBaseUrl"));
+        builder.envdPort(intValue(config, "envdPort", "envdHTTPPort", "dataPort"));
+        builder.timeoutSeconds(intValue(config, "timeoutSeconds", "timeout"));
+        Integer requestTimeoutMillis = explicitMillisValue(config, "requestTimeoutMillis");
+        if (requestTimeoutMillis == null) {
+            requestTimeoutMillis = millisValue(config, "requestTimeout");
+        }
+        builder.requestTimeoutMillis(requestTimeoutMillis);
+        builder.closeDestroysSandbox(booleanValue(config, "closeDestroysSandbox", "destroyOnClose", "deleteOnClose"));
+        builder.allowInternetAccessDefault(booleanValue(config, "allowInternetAccess", "allowInternetAccessDefault"));
+        builder.user(stringValue(config, "user"));
+        builder.connectEnvelopeLimitBytes(intValue(config, "connectEnvelopeLimitBytes"));
+        builder.spec(spec.copy());
+        return builder.build();
+    }
+
+    public Builder toBuilder() {
+        return builder()
+                .providerId(providerId)
+                .apiUrl(apiUrl)
+                .apiKey(apiKey)
+                .templateId(templateId)
+                .sandboxDomain(sandboxDomain)
+                .envdBaseUrl(envdBaseUrl)
+                .envdPort(envdPort)
+                .timeoutSeconds(timeoutSeconds)
+                .requestTimeoutMillis(requestTimeoutMillis)
+                .closeDestroysSandbox(closeDestroysSandbox)
+                .allowInternetAccessDefault(allowInternetAccessDefault)
+                .user(user)
+                .connectEnvelopeLimitBytes(connectEnvelopeLimitBytes)
+                .spec(spec);
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public String getSandboxDomain() {
+        return sandboxDomain;
+    }
+
+    public String getEnvdBaseUrl() {
+        return envdBaseUrl;
+    }
+
+    public int getEnvdPort() {
+        return envdPort;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public int getRequestTimeoutMillis() {
+        return requestTimeoutMillis;
+    }
+
+    public boolean isCloseDestroysSandbox() {
+        return closeDestroysSandbox;
+    }
+
+    public boolean isAllowInternetAccessDefault() {
+        return allowInternetAccessDefault;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public int getConnectEnvelopeLimitBytes() {
+        return connectEnvelopeLimitBytes;
+    }
+
+    public SandboxSpec getSpec() {
+        return spec.copy();
+    }
+
+    public Map<String, String> getLabels() {
+        return safeConfigLabels();
+    }
+
+    public Map<String, String> getEnvironment() {
+        return Collections.<String, String>emptyMap();
+    }
+
+    Map<String, String> safeConfigLabels() {
+        Map<String, String> labels = new LinkedHashMap<String, String>();
+        labels.put("sandboxDomain", sandboxDomain);
+        labels.put("envdPort", String.valueOf(envdPort));
+        labels.put("closeDestroysSandbox", String.valueOf(closeDestroysSandbox));
+        return labels;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static String trimToDefault(String value, String fallback) {
+        String trimmed = trimToNull(value);
+        return trimmed == null ? fallback : trimmed;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        if (value == null) {
+            return null;
+        }
+        String result = value;
+        while (result.endsWith("/") && result.length() > 1) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private static int positiveOrDefault(Integer value, int fallback) {
+        return value == null || value.intValue() <= 0 ? fallback : value.intValue();
+    }
+
+    private static Integer parseInt(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(value.trim());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Integer parseSeconds(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim().toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            if (trimmed.endsWith("ms")) {
+                return Integer.valueOf(Math.max(1, (int) Math.ceil(Double.parseDouble(trimmed.substring(0, trimmed.length() - 2)) / 1000.0d)));
+            }
+            if (trimmed.endsWith("s")) {
+                return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed.substring(0, trimmed.length() - 1))));
+            }
+            if (trimmed.endsWith("m")) {
+                return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed.substring(0, trimmed.length() - 1)) * 60.0d));
+            }
+            return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed)));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Integer parseMillis(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim().toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            if (trimmed.endsWith("ms")) {
+                return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed.substring(0, trimmed.length() - 2))));
+            }
+            if (trimmed.endsWith("s")) {
+                return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed.substring(0, trimmed.length() - 1)) * 1000.0d));
+            }
+            return Integer.valueOf((int) Math.ceil(Double.parseDouble(trimmed) * 1000.0d));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static String stringValue(Map<String, Object> config, String... keys) {
+        Object value = objectValue(config, keys);
+        return value == null ? null : trimToNull(String.valueOf(value));
+    }
+
+    private static Integer intValue(Map<String, Object> config, String... keys) {
+        Object value = objectValue(config, keys);
+        if (value instanceof Number) {
+            return Integer.valueOf(((Number) value).intValue());
+        }
+        return value == null ? null : parseInt(String.valueOf(value));
+    }
+
+    private static Integer millisValue(Map<String, Object> config, String... keys) {
+        Object value = objectValue(config, keys);
+        if (value instanceof Number) {
+            Number number = (Number) value;
+            if (number.doubleValue() > 0 && number.doubleValue() < 1000) {
+                return Integer.valueOf((int) Math.ceil(number.doubleValue() * 1000.0d));
+            }
+            return Integer.valueOf(number.intValue());
+        }
+        return value == null ? null : parseMillis(String.valueOf(value));
+    }
+
+    private static Integer explicitMillisValue(Map<String, Object> config, String key) {
+        Object value = objectValue(config, key);
+        if (value instanceof Number) {
+            return Integer.valueOf(((Number) value).intValue());
+        }
+        if (value == null) {
+            return null;
+        }
+        String text = trimToNull(String.valueOf(value));
+        if (text == null) {
+            return null;
+        }
+        String lower = text.toLowerCase(java.util.Locale.ENGLISH);
+        if (lower.endsWith("s") && !lower.endsWith("ms")) {
+            return parseMillis(text);
+        }
+        try {
+            if (lower.endsWith("ms")) {
+                return Integer.valueOf((int) Math.ceil(Double.parseDouble(lower.substring(0, lower.length() - 2))));
+            }
+            return Integer.valueOf((int) Math.ceil(Double.parseDouble(lower)));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Boolean booleanValue(Map<String, Object> config, String... keys) {
+        Object value = objectValue(config, keys);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value == null) {
+            return null;
+        }
+        String text = trimToNull(String.valueOf(value));
+        return text == null ? null : Boolean.valueOf(text);
+    }
+
+    private static Object objectValue(Map<String, Object> config, String... keys) {
+        if (config == null) {
+            return null;
+        }
+        for (String key : keys) {
+            if (config.containsKey(key)) {
+                return config.get(key);
+            }
+        }
+        return null;
+    }
+
+    public static final class Builder {
+        private String providerId;
+        private String apiUrl;
+        private String apiKey;
+        private String templateId;
+        private String sandboxDomain;
+        private String envdBaseUrl;
+        private Integer envdPort;
+        private Integer timeoutSeconds;
+        private Integer requestTimeoutMillis;
+        private Boolean closeDestroysSandbox;
+        private Boolean allowInternetAccessDefault;
+        private String user;
+        private Integer connectEnvelopeLimitBytes;
+        private SandboxSpec spec;
+
+        private Builder() {
+        }
+
+        public Builder providerId(String providerId) {
+            if (providerId != null) {
+                this.providerId = providerId;
+            }
+            return this;
+        }
+
+        public Builder apiUrl(String apiUrl) {
+            if (apiUrl != null) {
+                this.apiUrl = apiUrl;
+            }
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            if (apiKey != null) {
+                this.apiKey = apiKey;
+            }
+            return this;
+        }
+
+        public Builder templateId(String templateId) {
+            if (templateId != null) {
+                this.templateId = templateId;
+            }
+            return this;
+        }
+
+        public Builder sandboxDomain(String sandboxDomain) {
+            if (sandboxDomain != null) {
+                this.sandboxDomain = sandboxDomain;
+            }
+            return this;
+        }
+
+        public Builder envdBaseUrl(String envdBaseUrl) {
+            if (envdBaseUrl != null) {
+                this.envdBaseUrl = envdBaseUrl;
+            }
+            return this;
+        }
+
+        public Builder envdPort(Integer envdPort) {
+            if (envdPort != null) {
+                this.envdPort = envdPort;
+            }
+            return this;
+        }
+
+        public Builder timeoutSeconds(Integer timeoutSeconds) {
+            if (timeoutSeconds != null) {
+                this.timeoutSeconds = timeoutSeconds;
+            }
+            return this;
+        }
+
+        public Builder requestTimeoutMillis(Integer requestTimeoutMillis) {
+            if (requestTimeoutMillis != null) {
+                this.requestTimeoutMillis = requestTimeoutMillis;
+            }
+            return this;
+        }
+
+        public Builder closeDestroysSandbox(Boolean closeDestroysSandbox) {
+            if (closeDestroysSandbox != null) {
+                this.closeDestroysSandbox = closeDestroysSandbox;
+            }
+            return this;
+        }
+
+        public Builder allowInternetAccessDefault(Boolean allowInternetAccessDefault) {
+            if (allowInternetAccessDefault != null) {
+                this.allowInternetAccessDefault = allowInternetAccessDefault;
+            }
+            return this;
+        }
+
+        public Builder user(String user) {
+            if (user != null) {
+                this.user = user;
+            }
+            return this;
+        }
+
+        public Builder connectEnvelopeLimitBytes(Integer connectEnvelopeLimitBytes) {
+            if (connectEnvelopeLimitBytes != null) {
+                this.connectEnvelopeLimitBytes = connectEnvelopeLimitBytes;
+            }
+            return this;
+        }
+
+        public Builder spec(SandboxSpec spec) {
+            this.spec = spec;
+            return this;
+        }
+
+        public CubeSandboxConfig build() {
+            return new CubeSandboxConfig(this);
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProvider.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProvider.java
@@ -60,10 +60,7 @@ public class CubeSandboxProvider implements SandboxProvider {
         if (extraMetadata != null) {
             metadata.putAll(CubeSandboxSanitizer.nonSensitiveStringMap(extraMetadata));
         }
-        Boolean allowInternetAccess = booleanConfig(requested, "allowInternetAccess");
-        if (allowInternetAccess == null) {
-            allowInternetAccess = Boolean.valueOf(config.isAllowInternetAccessDefault());
-        }
+        boolean allowInternetAccess = booleanConfig(requested, "allowInternetAccess", config.isAllowInternetAccessDefault());
         Object network = requested.getConfig().get("network");
 
         CubeSandboxClient client = new CubeSandboxClient(config);
@@ -131,15 +128,15 @@ public class CubeSandboxProvider implements SandboxProvider {
                 .build();
     }
 
-    private static Boolean booleanConfig(SandboxSpec spec, String key) {
+    private static boolean booleanConfig(SandboxSpec spec, String key, boolean defaultValue) {
         Object value = spec.getConfig().get(key);
         if (value instanceof Boolean) {
-            return (Boolean) value;
+            return ((Boolean) value).booleanValue();
         }
         if (value == null) {
-            return null;
+            return defaultValue;
         }
-        return Boolean.valueOf(String.valueOf(value));
+        return Boolean.parseBoolean(String.valueOf(value));
     }
 
     private static Map<String, String> stringMap(Object value) throws SandboxException {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProvider.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProvider.java
@@ -1,0 +1,170 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * CubeSandbox-backed {@link SandboxProvider}.
+ *
+ * <p>The adapter implements AI4J's provider-neutral sandbox SPI on top of the
+ * open-source TencentCloud/CubeSandbox control plane and envd process API. It
+ * is opt-in: no SDK call creates a CubeSandbox session unless host code
+ * explicitly constructs this provider and calls {@link #createSession(SandboxSpec)}.</p>
+ */
+public class CubeSandboxProvider implements SandboxProvider {
+
+    public static final String PROVIDER_ID = CubeSandboxConfig.DEFAULT_PROVIDER_ID;
+
+    private final CubeSandboxConfig baseConfig;
+
+    public CubeSandboxProvider() {
+        this(CubeSandboxConfig.fromEnvironment());
+    }
+
+    public CubeSandboxProvider(CubeSandboxConfig config) {
+        this.baseConfig = config == null ? CubeSandboxConfig.fromEnvironment() : config;
+    }
+
+    @Override
+    public String getProviderId() {
+        return baseConfig.getProviderId();
+    }
+
+    @Override
+    public boolean supports(SandboxSpec spec) {
+        if (spec == null || isBlank(spec.getProviderId())) {
+            return true;
+        }
+        return getProviderId().equalsIgnoreCase(spec.getProviderId())
+                || PROVIDER_ID.equalsIgnoreCase(spec.getProviderId());
+    }
+
+    @Override
+    public CubeSandboxSession createSession(SandboxSpec spec) throws SandboxException {
+        if (!supports(spec)) {
+            throw new SandboxException("unsupported sandbox provider for CubeSandbox: " + (spec == null ? null : spec.getProviderId()));
+        }
+        SandboxSpec requested = normalizeSpec(spec);
+        CubeSandboxConfig config = baseConfig.withSpecOverrides(requested);
+        String templateId = firstNonBlank(requested.getImage(), config.getTemplateId());
+        Map<String, String> envVars = stringMap(requested.getConfig().get("envVars"));
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.putAll(CubeSandboxSanitizer.nonSensitiveStringMap(requested.getLabels()));
+        metadata.put("ai4jProvider", getProviderId());
+        Map<String, String> extraMetadata = stringMap(requested.getConfig().get("metadata"));
+        if (extraMetadata != null) {
+            metadata.putAll(CubeSandboxSanitizer.nonSensitiveStringMap(extraMetadata));
+        }
+        Boolean allowInternetAccess = booleanConfig(requested, "allowInternetAccess");
+        if (allowInternetAccess == null) {
+            allowInternetAccess = Boolean.valueOf(config.isAllowInternetAccessDefault());
+        }
+        Object network = requested.getConfig().get("network");
+
+        CubeSandboxClient client = new CubeSandboxClient(config);
+        try {
+            CubeSandboxRemote remote = client.create(templateId,
+                    config.getTimeoutSeconds(),
+                    envVars,
+                    metadata,
+                    allowInternetAccess,
+                    network);
+            return new CubeSandboxSession(client, remote, requested, config, false);
+        } catch (CubeSandboxApiException e) {
+            throw new SandboxException("failed to create CubeSandbox session", e);
+        } catch (IOException e) {
+            throw new SandboxException("failed to create CubeSandbox session", e);
+        }
+    }
+
+    /**
+     * Connects to an existing CubeSandbox session without creating a new one.
+     */
+    public CubeSandboxSession connect(String sandboxId, SandboxSpec spec) throws SandboxException {
+        if (isBlank(sandboxId)) {
+            throw new SandboxException("sandboxId is required");
+        }
+        SandboxSpec requested = normalizeSpec(spec);
+        CubeSandboxConfig config = baseConfig.withSpecOverrides(requested);
+        CubeSandboxClient client = new CubeSandboxClient(config);
+        try {
+            CubeSandboxRemote remote = client.connect(sandboxId.trim());
+            return new CubeSandboxSession(client, remote, requested, config, true);
+        } catch (CubeSandboxApiException e) {
+            throw new SandboxException("failed to connect to CubeSandbox session", e);
+        } catch (IOException e) {
+            throw new SandboxException("failed to connect to CubeSandbox session", e);
+        }
+    }
+
+    /**
+     * Probes CubeAPI health. Useful for setup diagnostics and live validation.
+     */
+    public Map<String, Object> health() throws SandboxException {
+        CubeSandboxClient client = new CubeSandboxClient(baseConfig);
+        try {
+            return new LinkedHashMap<String, Object>(client.health());
+        } catch (CubeSandboxApiException e) {
+            throw new SandboxException("failed to query CubeSandbox health", e);
+        } catch (IOException e) {
+            throw new SandboxException("failed to query CubeSandbox health", e);
+        }
+    }
+
+    private SandboxSpec normalizeSpec(SandboxSpec spec) {
+        SandboxSpec safe = spec == null ? SandboxSpec.builder().providerId(getProviderId()).build() : spec.copy();
+        if (!isBlank(safe.getProviderId())) {
+            return safe;
+        }
+        return SandboxSpec.builder()
+                .providerId(getProviderId())
+                .profile(safe.getProfile())
+                .image(safe.getImage())
+                .workspaceId(safe.getWorkspaceId())
+                .labels(safe.getLabels())
+                .config(safe.getConfig())
+                .build();
+    }
+
+    private static Boolean booleanConfig(SandboxSpec spec, String key) {
+        Object value = spec.getConfig().get(key);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value == null) {
+            return null;
+        }
+        return Boolean.valueOf(String.valueOf(value));
+    }
+
+    private static Map<String, String> stringMap(Object value) throws SandboxException {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Map)) {
+            throw new SandboxException("CubeSandbox config value must be a map: " + value);
+        }
+        Map<?, ?> source = (Map<?, ?>) value;
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        for (Map.Entry<?, ?> entry : source.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            result.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+        }
+        return result;
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        return isBlank(first) ? second : first.trim();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxRemote.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxRemote.java
@@ -1,0 +1,90 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+
+final class CubeSandboxRemote {
+    private final String templateId;
+    private final String sandboxId;
+    private final String clientId;
+    private final String envdVersion;
+    private final String envdAccessToken;
+    private final String trafficAccessToken;
+    private final String domain;
+
+    CubeSandboxRemote(String templateId,
+                      String sandboxId,
+                      String clientId,
+                      String envdVersion,
+                      String envdAccessToken,
+                      String trafficAccessToken,
+                      String domain) {
+        this.templateId = trimToNull(templateId);
+        this.sandboxId = trimToNull(sandboxId);
+        this.clientId = trimToNull(clientId);
+        this.envdVersion = trimToNull(envdVersion);
+        this.envdAccessToken = trimToNull(envdAccessToken);
+        this.trafficAccessToken = trimToNull(trafficAccessToken);
+        this.domain = trimToNull(domain);
+    }
+
+    String getTemplateId() {
+        return templateId;
+    }
+
+    String getSandboxId() {
+        return sandboxId;
+    }
+
+    String getClientId() {
+        return clientId;
+    }
+
+    String getEnvdVersion() {
+        return envdVersion;
+    }
+
+    String getEnvdAccessToken() {
+        return envdAccessToken;
+    }
+
+    String getTrafficAccessToken() {
+        return trafficAccessToken;
+    }
+
+    String getDomain() {
+        return domain;
+    }
+
+    String host(int port, String fallbackDomain) throws SandboxException {
+        String effectiveDomain = domain == null ? fallbackDomain : domain;
+        validateHostPart(sandboxId, "sandboxID");
+        validateHostPart(effectiveDomain, "domain");
+        return port + "-" + sandboxId + "." + effectiveDomain;
+    }
+
+    private static void validateHostPart(String value, String field) throws SandboxException {
+        if (value == null || value.trim().isEmpty()) {
+            throw new SandboxException("CubeSandbox response missing " + field);
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            boolean allowed = (ch >= 'a' && ch <= 'z')
+                    || (ch >= 'A' && ch <= 'Z')
+                    || (ch >= '0' && ch <= '9')
+                    || ch == '-'
+                    || ch == '.'
+                    || ch == '_';
+            if (!allowed) {
+                throw new SandboxException("CubeSandbox response contains invalid " + field + " for virtual host");
+            }
+        }
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxSanitizer.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxSanitizer.java
@@ -1,0 +1,40 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+final class CubeSandboxSanitizer {
+
+    private CubeSandboxSanitizer() {
+    }
+
+    static Map<String, String> nonSensitiveStringMap(Map<String, String> source) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        if (source == null) {
+            return result;
+        }
+        for (Map.Entry<String, String> entry : source.entrySet()) {
+            if (entry == null || isSensitiveKey(entry.getKey()) || entry.getValue() == null) {
+                continue;
+            }
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    static boolean isSensitiveKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        String lower = key.toLowerCase(Locale.ENGLISH);
+        return lower.contains("secret")
+                || lower.contains("token")
+                || lower.contains("key")
+                || lower.contains("password")
+                || lower.contains("passwd")
+                || lower.contains("credential")
+                || lower.contains("authorization")
+                || lower.contains("cookie");
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxSession.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxSession.java
@@ -1,0 +1,186 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxArtifact;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxEvent;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxEventType;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Live CubeSandbox session bound to one AI4J Agent/Coding Agent session.
+ */
+public final class CubeSandboxSession implements SandboxSession {
+
+    private final CubeSandboxClient client;
+    private final CubeSandboxRemote remote;
+    private final SandboxSpec spec;
+    private final CubeSandboxConfig config;
+    private final boolean connectedExisting;
+    private final List<SandboxArtifact> artifacts = new ArrayList<SandboxArtifact>();
+    private SandboxStatus status = SandboxStatus.RUNNING;
+
+    CubeSandboxSession(CubeSandboxClient client,
+                       CubeSandboxRemote remote,
+                       SandboxSpec spec,
+                       CubeSandboxConfig config,
+                       boolean connectedExisting) {
+        this.client = client;
+        this.remote = remote;
+        this.spec = withRemoteLabels(spec, config, remote);
+        this.config = config;
+        this.connectedExisting = connectedExisting;
+    }
+
+    @Override
+    public String getSessionId() {
+        return remote.getSandboxId();
+    }
+
+    @Override
+    public String getProviderId() {
+        return config.getProviderId();
+    }
+
+    @Override
+    public SandboxSpec getSpec() {
+        return spec.copy();
+    }
+
+    @Override
+    public SandboxStatus getStatus() {
+        return status;
+    }
+
+    public boolean isConnectedExisting() {
+        return connectedExisting;
+    }
+
+    public String getTemplateId() {
+        return remote.getTemplateId();
+    }
+
+    public String getDomain() {
+        return remote.getDomain() == null ? config.getSandboxDomain() : remote.getDomain();
+    }
+
+    @Override
+    public synchronized SandboxResult execute(SandboxCommand command) throws SandboxException {
+        if (status == SandboxStatus.CLOSED) {
+            throw new SandboxException("CubeSandbox session is closed: " + getSessionId());
+        }
+        if (status == SandboxStatus.FAILED) {
+            throw new SandboxException("CubeSandbox session is failed: " + getSessionId());
+        }
+        SandboxCommand safeCommand = command.copy();
+        List<SandboxEvent> events = new ArrayList<SandboxEvent>();
+        events.add(event(SandboxEventType.COMMAND_STARTED, safeCommand.getCommandId(), "CubeSandbox command started"));
+        try {
+            CubeSandboxClient.ProcessRun run = client.runProcess(remote,
+                    safeCommand.getCommand(),
+                    firstNonBlank(safeCommand.getWorkingDirectory(), spec.getWorkspaceId()),
+                    safeCommand.getEnvironment(),
+                    safeCommand.getTimeoutMillis());
+            SandboxArtifact stdoutArtifact = SandboxArtifact.builder()
+                    .artifactId("cubesandbox-stdout-" + safeCommand.getCommandId())
+                    .name("stdout.txt")
+                    .path("cubesandbox://" + getSessionId() + "/commands/" + safeCommand.getCommandId() + "/stdout.txt")
+                    .mimeType("text/plain")
+                    .sizeBytes(Long.valueOf(run.getStdout() == null ? 0 : run.getStdout().length()))
+                    .build();
+            artifacts.add(stdoutArtifact);
+            events.add(event(SandboxEventType.COMMAND_FINISHED, safeCommand.getCommandId(), "CubeSandbox command finished"));
+            return SandboxResult.builder()
+                    .commandId(safeCommand.getCommandId())
+                    .exitCode(run.getExitCode())
+                    .stdout(run.getStdout())
+                    .stderr(run.getStderr())
+                    .durationMillis(run.getDurationMillis())
+                    .artifact(stdoutArtifact)
+                    .events(events)
+                    .build();
+        } catch (CubeSandboxApiException e) {
+            events.add(event(SandboxEventType.ERROR, safeCommand.getCommandId(), e.getMessage()));
+            throw new SandboxException("failed to execute command in CubeSandbox sandbox. event=" + safeCommand.getCommandId(), e);
+        } catch (IOException e) {
+            events.add(event(SandboxEventType.ERROR, safeCommand.getCommandId(), e.getMessage()));
+            throw new SandboxException("failed to execute command in CubeSandbox sandbox. event=" + safeCommand.getCommandId(), e);
+        }
+    }
+
+    @Override
+    public boolean cancel(String commandId) {
+        // CubeSandbox envd process start is synchronous in this adapter. There
+        // is no stable command-id kill endpoint in the current public SDK path.
+        return false;
+    }
+
+    @Override
+    public synchronized List<SandboxArtifact> listArtifacts() {
+        List<SandboxArtifact> copy = new ArrayList<SandboxArtifact>();
+        for (SandboxArtifact artifact : artifacts) {
+            copy.add(artifact.copy());
+        }
+        return copy;
+    }
+
+    @Override
+    public synchronized void close() throws SandboxException {
+        if (status == SandboxStatus.CLOSED) {
+            return;
+        }
+        try {
+            if (config.isCloseDestroysSandbox() && !connectedExisting) {
+                client.kill(getSessionId());
+            }
+            status = SandboxStatus.CLOSED;
+        } catch (CubeSandboxApiException e) {
+            status = SandboxStatus.FAILED;
+            throw new SandboxException("failed to close CubeSandbox session", e);
+        } catch (IOException e) {
+            status = SandboxStatus.FAILED;
+            throw new SandboxException("failed to close CubeSandbox session", e);
+        }
+    }
+
+    private SandboxEvent event(SandboxEventType type, String commandId, String message) {
+        return SandboxEvent.builder()
+                .type(type)
+                .sessionId(getSessionId())
+                .commandId(commandId)
+                .message(message)
+                .build();
+    }
+
+    private static SandboxSpec withRemoteLabels(SandboxSpec spec, CubeSandboxConfig config, CubeSandboxRemote remote) {
+        SandboxSpec safe = spec == null ? SandboxSpec.builder().providerId(config.getProviderId()).build() : spec.copy();
+        SandboxSpec.Builder builder = SandboxSpec.builder()
+                .providerId(config.getProviderId())
+                .profile(safe.getProfile())
+                .image(firstNonBlank(safe.getImage(), remote.getTemplateId()))
+                .workspaceId(safe.getWorkspaceId())
+                .labels(CubeSandboxSanitizer.nonSensitiveStringMap(safe.getLabels()))
+                .config(Collections.<String, Object>emptyMap());
+        for (Map.Entry<String, String> entry : config.safeConfigLabels().entrySet()) {
+            builder.label("cube." + entry.getKey(), entry.getValue());
+        }
+        builder.label("cube.templateId", remote.getTemplateId());
+        builder.label("cube.clientId", remote.getClientId());
+        builder.label("cube.envdVersion", remote.getEnvdVersion());
+        builder.label("cube.domain", remote.getDomain());
+        return builder.build();
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        return first == null || first.trim().isEmpty() ? second : first.trim();
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/cubesandbox/CubeSandboxLiveProviderTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/cubesandbox/CubeSandboxLiveProviderTest.java
@@ -1,0 +1,65 @@
+package io.github.lnyocly.agent.cubesandbox;
+
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxSession;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Real CubeSandbox smoke test.
+ *
+ * <p>Default Maven runs exclude {@link LiveProviderTest}. To run this against a
+ * live CubeSandbox deployment, set env vars only (never commit values):
+ * AI4J_CUBESANDBOX_LIVE=true, CUBE_API_URL, CUBE_TEMPLATE_ID, and optionally
+ * CUBE_API_KEY/E2B_API_KEY, CUBE_SANDBOX_DOMAIN, CUBE_ENVD_PORT.</p>
+ */
+@Category(LiveProviderTest.class)
+public class CubeSandboxLiveProviderTest {
+
+    @Test
+    public void liveCubeSandboxShouldCreateExecuteAndDestroy() throws Exception {
+        Assume.assumeTrue("Skip CubeSandbox live test unless AI4J_CUBESANDBOX_LIVE=true",
+                "true".equalsIgnoreCase(System.getenv("AI4J_CUBESANDBOX_LIVE")));
+        Assume.assumeTrue("Skip CubeSandbox live test because CUBE_API_URL/E2B_API_URL is missing",
+                hasText(firstEnv("CUBE_API_URL", "E2B_API_URL")));
+        Assume.assumeTrue("Skip CubeSandbox live test because CUBE_TEMPLATE_ID is missing",
+                hasText(System.getenv("CUBE_TEMPLATE_ID")));
+
+        CubeSandboxProvider provider = new CubeSandboxProvider();
+        CubeSandboxSession session = null;
+        try {
+            session = provider.createSession(SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .workspaceId("/workspace")
+                    .label("ai4jLiveTest", "true")
+                    .build());
+            SandboxResult result = session.execute(SandboxCommand.builder()
+                    .commandId("ai4j-live-cubesandbox")
+                    .command("printf ai4j-cubesandbox-ok")
+                    .workingDirectory("/workspace")
+                    .timeoutMillis(30000L)
+                    .build());
+            Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+            Assert.assertTrue(result.getStdout(), result.getStdout().contains("ai4j-cubesandbox-ok"));
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    private static String firstEnv(String first, String second) {
+        String value = System.getenv(first);
+        return hasText(value) ? value : System.getenv(second);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProviderTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/sandbox/cubesandbox/CubeSandboxProviderTest.java
@@ -1,0 +1,610 @@
+package io.github.lnyocly.ai4j.agent.sandbox.cubesandbox;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxStatus;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxConfig;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxSession;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+public class CubeSandboxProviderTest {
+
+    @Test
+    public void providerShouldCreateExecuteAndDestroyViaHttpProtocol() throws Exception {
+        TestCubeServer server = new TestCubeServer();
+        server.start();
+        try {
+            CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                    .apiUrl("http://127.0.0.1:" + server.port())
+                    .envdBaseUrl("http://127.0.0.1:" + server.port())
+                    .apiKey("unit-secret")
+                    .templateId("tpl-default")
+                    .sandboxDomain("cube.test")
+                    .requestTimeoutMillis(5000)
+                    .build());
+
+            Map<String, Object> config = new LinkedHashMap<String, Object>();
+            Map<String, String> envVars = new LinkedHashMap<String, String>();
+            envVars.put("AI4J_TEST", "1");
+            config.put("envVars", envVars);
+            config.put("allowInternetAccess", Boolean.FALSE);
+            config.put("apiKey", "must-not-persist");
+
+            CubeSandboxSession session = provider.createSession(SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .image("tpl-java")
+                    .workspaceId("/workspace")
+                    .label("task", "unit")
+                    .label("apiKey", "must-not-persist")
+                    .config(config)
+                    .build());
+
+            Assert.assertEquals("cubesandbox", session.getProviderId());
+            Assert.assertEquals("sb-unit", session.getSessionId());
+            Assert.assertEquals(SandboxStatus.RUNNING, session.getStatus());
+            Assert.assertEquals("tpl-java", server.createPayload.getString("templateID"));
+            Assert.assertEquals(Boolean.FALSE, server.createPayload.getBoolean("allowInternetAccess"));
+            Assert.assertEquals("Bearer unit-secret", server.createAuthorization);
+            Assert.assertFalse(session.getSpec().getLabels().containsKey("apiKey"));
+            Assert.assertFalse(session.getSpec().getLabels().containsKey("cube.apiUrl"));
+            Assert.assertFalse(server.createPayload.getJSONObject("metadata").containsKey("apiKey"));
+            Assert.assertFalse(server.createPayload.getJSONObject("metadata").containsKey("ai4jWorkspaceId"));
+
+            SandboxResult result = session.execute(SandboxCommand.builder()
+                    .commandId("cmd-1")
+                    .command("echo ai4j-cubesandbox-ok")
+                    .workingDirectory("/workspace")
+                    .environment("LANG", "C")
+                    .timeoutMillis(2000L)
+                    .build());
+
+            Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+            Assert.assertEquals("ai4j-cubesandbox-ok\n", result.getStdout());
+            Assert.assertEquals("", result.getStderr());
+            Assert.assertEquals("Basic cm9vdDo=", server.processAuthorization);
+            Assert.assertEquals("1", server.processConnectProtocol);
+            Assert.assertEquals("2000", server.processConnectTimeout);
+            Assert.assertEquals("envd-token", server.processAccessToken);
+            Assert.assertEquals("echo ai4j-cubesandbox-ok", server.processPayload.getJSONObject("process").getJSONArray("args").getString(2));
+            Assert.assertEquals("/workspace", server.processPayload.getJSONObject("process").getString("cwd"));
+            Assert.assertEquals(1, session.listArtifacts().size());
+
+            session.close();
+            Assert.assertEquals(SandboxStatus.CLOSED, session.getStatus());
+            Assert.assertTrue(server.deleted);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void providerShouldFailFastWhenTemplateIsMissing() throws Exception {
+        CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                .apiUrl("http://127.0.0.1:1")
+                .build());
+        try {
+            provider.createSession(SandboxSpec.builder().providerId("cubesandbox").build());
+            Assert.fail("expected sandbox exception");
+        } catch (SandboxException expected) {
+            // The exception is wrapped, so check the cause
+            Throwable cause = expected.getCause();
+            Assert.assertTrue("cause should contain templateID error",
+                    cause != null && (cause.getMessage().contains("templateID") || cause.getMessage().contains("templateID is required")));
+        }
+    }
+
+    @Test
+    public void explicitRequestTimeoutMillisShouldRemainMilliseconds() throws Exception {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("requestTimeoutMillis", Integer.valueOf(750));
+
+        CubeSandboxConfig resolved = CubeSandboxConfig.builder().build().withSpecOverrides(SandboxSpec.builder()
+                .providerId("cubesandbox")
+                .config(config)
+                .build());
+
+        Assert.assertEquals(750, resolved.getRequestTimeoutMillis());
+    }
+
+    @Test
+    public void providerShouldUseConfiguredEnvdBaseUrlForProcessRequests() throws Exception {
+        TestCubeServer server = new TestCubeServer();
+        server.start();
+        try {
+            CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                    .apiUrl("http://127.0.0.1:" + server.port())
+                    .envdBaseUrl("http://127.0.0.1:" + server.port())
+                    .apiKey("unit-secret")
+                    .templateId("tpl-default")
+                    .sandboxDomain("cube.test")
+                    .envdPort(Integer.valueOf(49999))
+                    .requestTimeoutMillis(5000)
+                    .build());
+
+            CubeSandboxSession session = provider.createSession(SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .image("tpl-java")
+                    .build());
+            SandboxResult result = session.execute(SandboxCommand.builder()
+                    .commandId("cmd-envd-base-url")
+                    .command("echo ai4j-cubesandbox-ok")
+                    .timeoutMillis(2000L)
+                    .build());
+
+            Assert.assertEquals(Integer.valueOf(0), result.getExitCode());
+            // When envdBaseUrl is set, requests go directly to that URL without the virtual Host header
+            Assert.assertNotNull(server.processPayload);
+            session.close();
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void providerShouldConnectExistingWithoutDestroyingOnClose() throws Exception {
+        TestCubeServer server = new TestCubeServer();
+        server.start();
+        try {
+            CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                    .apiUrl("http://127.0.0.1:" + server.port())
+                    .envdBaseUrl("http://127.0.0.1:" + server.port())
+                    .apiKey("unit-secret")
+                    .sandboxDomain("cube.test")
+                    .requestTimeoutMillis(5000)
+                    .build());
+
+            CubeSandboxSession session = provider.connect("sb-unit", SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .workspaceId("/workspace")
+                    .build());
+
+            Assert.assertTrue(session.isConnectedExisting());
+            Assert.assertEquals("sb-unit", session.getSessionId());
+            Assert.assertEquals(1, server.connectCount);
+
+            session.close();
+            Assert.assertEquals(SandboxStatus.CLOSED, session.getStatus());
+            Assert.assertFalse("closing an attached existing sandbox should not destroy the remote sandbox", server.deleted);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void connectEndStreamErrorShouldFailCommand() throws Exception {
+        TestCubeServer server = new TestCubeServer();
+        server.processMode = "connect-error";
+        server.start();
+        try {
+            CubeSandboxSession session = newProvider(server).createSession(SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .image("tpl-java")
+                    .build());
+            try {
+                session.execute(SandboxCommand.builder()
+                        .commandId("cmd-error")
+                        .command("echo ignored")
+                        .timeoutMillis(2000L)
+                        .build());
+                Assert.fail("expected sandbox exception");
+            } catch (SandboxException expected) {
+                // Check the cause for the actual error message
+                Throwable cause = expected.getCause();
+                Assert.assertTrue("cause should contain permission_denied or permission denied",
+                        cause != null && (cause.getMessage().contains("permission_denied") || cause.getMessage().contains("permission denied")));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void partialConnectEnvelopeShouldFailCommand() throws Exception {
+        TestCubeServer server = new TestCubeServer();
+        server.processMode = "partial";
+        server.start();
+        try {
+            CubeSandboxSession session = newProvider(server).createSession(SandboxSpec.builder()
+                    .providerId("cubesandbox")
+                    .image("tpl-java")
+                    .build());
+            try {
+                session.execute(SandboxCommand.builder()
+                        .commandId("cmd-partial")
+                        .command("echo ignored")
+                        .timeoutMillis(2000L)
+                        .build());
+                Assert.fail("expected sandbox exception");
+            } catch (SandboxException expected) {
+                // Partial envelope causes a read failure - just verify it fails with an IOException or CubeSandboxApiException cause
+                Throwable cause = expected.getCause();
+                Assert.assertTrue("cause should be IOException or CubeSandboxApiException",
+                        cause instanceof IOException || cause instanceof CubeSandboxApiException);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    // Additional config/provider-selection tests from current test file
+    @Test
+    public void configShouldMergeFromEnvironmentWithSpec() {
+        Map<String, String> env = new LinkedHashMap<String, String>();
+        env.put("CUBE_API_URL", "http://test-api:3000");
+        env.put("CUBE_API_KEY", "test-key");
+        env.put("CUBE_TEMPLATE_ID", "test-template");
+        env.put("CUBE_SANDBOX_DOMAIN", "test.domain");
+        env.put("CUBE_ENVD_PORT", "49999");
+        env.put("CUBE_ENVD_BASE_URL", "http://test-envd:49983");
+
+        CubeSandboxConfig config = CubeSandboxConfig.fromEnvironment(
+                SandboxSpec.builder()
+                        .providerId("cubesandbox")
+                        .config("requestTimeoutMillis", Integer.valueOf(10000))
+                        .build(),
+                env);
+
+        Assert.assertEquals("http://test-api:3000", config.getApiUrl());
+        Assert.assertEquals("test-key", config.getApiKey());
+        Assert.assertEquals("test-template", config.getTemplateId());
+        Assert.assertEquals("test.domain", config.getSandboxDomain());
+        Assert.assertEquals(49999, config.getEnvdPort());
+        Assert.assertEquals("http://test-envd:49983", config.getEnvdBaseUrl());
+        Assert.assertEquals(10000, config.getRequestTimeoutMillis());
+    }
+
+    @Test
+    public void configShouldProvideEmptyLabelsAndEnvironment() {
+        CubeSandboxConfig config = CubeSandboxConfig.builder()
+                .sandboxDomain("cube.test")
+                .envdPort(49983)
+                .build();
+
+        Map<String, String> labels = config.getLabels();
+        Map<String, String> environment = config.getEnvironment();
+
+        Assert.assertTrue("labels should not be null", labels != null);
+        Assert.assertTrue("environment should be empty", environment.isEmpty());
+        Assert.assertEquals("cube.test", labels.get("sandboxDomain"));
+        Assert.assertEquals("49983", labels.get("envdPort"));
+    }
+
+    @Test
+    public void providerShouldSupportCubeAndCubesandboxProviderIds() {
+        CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                .apiUrl("http://127.0.0.1:3000")
+                .apiKey("test-key")
+                .templateId("test-template")
+                .build());
+
+        Assert.assertTrue(provider.supports(SandboxSpec.builder().providerId("cubesandbox").build()));
+        Assert.assertTrue(provider.supports(SandboxSpec.builder().providerId("CUBESANDBOX").build()));
+        Assert.assertFalse(provider.supports(SandboxSpec.builder().providerId("cube").build()));
+        Assert.assertFalse(provider.supports(SandboxSpec.builder().providerId("daytona").build()));
+    }
+
+    @Test
+    public void providerShouldSupportNullProviderId() {
+        CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                .apiUrl("http://127.0.0.1:3000")
+                .apiKey("test-key")
+                .templateId("test-template")
+                .build());
+
+        Assert.assertTrue("null providerId should be supported", provider.supports(null));
+        Assert.assertTrue("empty providerId should be supported", provider.supports(SandboxSpec.builder().build()));
+    }
+
+    @Test
+    public void configShouldIgnoreApiKeyFromSpec() {
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("apiKey", "spec-secret-must-not-persist");
+
+        CubeSandboxConfig base = CubeSandboxConfig.builder()
+                .apiKey("env-secret")
+                .build();
+
+        CubeSandboxConfig merged = base.withSpecOverrides(SandboxSpec.builder()
+                .providerId("cubesandbox")
+                .config(config)
+                .build());
+
+        // apiKey should remain from env/builder, not from spec
+        Assert.assertEquals("env-secret", merged.getApiKey());
+        Assert.assertNotEquals("spec-secret-must-not-persist", merged.getApiKey());
+    }
+
+    @Test
+    public void fromEnvironmentShouldSupportE2BEnvVars() {
+        Map<String, String> env = new LinkedHashMap<String, String>();
+        env.put("E2B_API_URL", "http://e2b-proxy:3000");
+        env.put("E2B_API_KEY", "e2b-key");
+        env.put("CUBE_TEMPLATE_ID", "cube-template");
+
+        CubeSandboxConfig config = CubeSandboxConfig.fromEnvironment(null, env);
+
+        Assert.assertEquals("http://e2b-proxy:3000", config.getApiUrl());
+        Assert.assertEquals("e2b-key", config.getApiKey());
+        Assert.assertEquals("cube-template", config.getTemplateId());
+    }
+
+    @Test
+    public void fromEnvironmentShouldPreferCUBEEnvVarsOverE2B() {
+        Map<String, String> env = new LinkedHashMap<String, String>();
+        env.put("CUBE_API_URL", "http://cube-api:3000");
+        env.put("E2B_API_URL", "http://e2b-api:3000");
+        env.put("CUBE_API_KEY", "cube-key");
+        env.put("E2B_API_KEY", "e2b-key");
+
+        CubeSandboxConfig config = CubeSandboxConfig.fromEnvironment(null, env);
+
+        Assert.assertEquals("http://cube-api:3000", config.getApiUrl());
+        Assert.assertEquals("cube-key", config.getApiKey());
+    }
+
+    @Test
+    public void withSpecOverridesShouldMergeTimeoutValues() {
+        CubeSandboxConfig base = CubeSandboxConfig.builder()
+                .timeoutSeconds(300)
+                .requestTimeoutMillis(30000)
+                .build();
+
+        Map<String, Object> config = new LinkedHashMap<String, Object>();
+        config.put("timeoutSeconds", Integer.valueOf(600));
+        config.put("requestTimeoutMillis", Integer.valueOf(60000));
+
+        CubeSandboxConfig merged = base.withSpecOverrides(SandboxSpec.builder()
+                .providerId("cubesandbox")
+                .config(config)
+                .build());
+
+        Assert.assertEquals(600, merged.getTimeoutSeconds());
+        Assert.assertEquals(60000, merged.getRequestTimeoutMillis());
+    }
+
+    @Test
+    public void specFieldShouldBeCopiedNotMutated() {
+        SandboxSpec original = SandboxSpec.builder()
+                .providerId("cubesandbox")
+                .image("test-image")
+                .workspaceId("/workspace")
+                .build();
+
+        CubeSandboxConfig config = CubeSandboxConfig.builder()
+                .templateId("test-template")
+                .spec(original)
+                .build();
+
+        SandboxSpec retrieved = config.getSpec();
+        Assert.assertEquals("cubesandbox", retrieved.getProviderId());
+        Assert.assertEquals("test-image", retrieved.getImage());
+        Assert.assertEquals("/workspace", retrieved.getWorkspaceId());
+
+        // Modify retrieved spec should not affect config
+        retrieved.getLabels().put("test", "value");
+
+        SandboxSpec retrievedAgain = config.getSpec();
+        Assert.assertFalse(retrievedAgain.getLabels().containsKey("test"));
+    }
+
+    @Test
+    public void providerShouldReturnProviderId() {
+        CubeSandboxProvider provider = new CubeSandboxProvider(CubeSandboxConfig.builder()
+                .providerId("custom-cube")
+                .build());
+
+        Assert.assertEquals("custom-cube", provider.getProviderId());
+    }
+
+    @Test
+    public void providerShouldUseDefaultProviderIdWhenNotSpecified() {
+        CubeSandboxProvider provider = new CubeSandboxProvider();
+
+        Assert.assertEquals(CubeSandboxConfig.DEFAULT_PROVIDER_ID, provider.getProviderId());
+    }
+
+    private static CubeSandboxProvider newProvider(TestCubeServer server) {
+        return new CubeSandboxProvider(CubeSandboxConfig.builder()
+                .apiUrl("http://127.0.0.1:" + server.port())
+                .envdBaseUrl("http://127.0.0.1:" + server.port())
+                .apiKey("unit-secret")
+                .templateId("tpl-default")
+                .sandboxDomain("cube.test")
+                .requestTimeoutMillis(5000)
+                .build());
+    }
+
+    private static class TestCubeServer {
+        private HttpServer server;
+        private JSONObject createPayload;
+        private JSONObject processPayload;
+        private String createAuthorization;
+        private String processAuthorization;
+        private String processAccessToken;
+        private String processConnectProtocol;
+        private String processConnectTimeout;
+        private boolean deleted;
+        private int connectCount;
+        private String processMode = "ok";
+
+        void start() throws IOException {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/health", new JsonHandler(200, "{\"status\":\"ok\"}"));
+            server.createContext("/sandboxes", new HttpHandler() {
+                @Override
+                public void handle(HttpExchange exchange) throws IOException {
+                    if ("POST".equals(exchange.getRequestMethod())) {
+                        createAuthorization = exchange.getRequestHeaders().getFirst("Authorization");
+                        createPayload = JSON.parseObject(read(exchange));
+                        writeJson(exchange, 201, "{\"templateID\":\"" + createPayload.getString("templateID") + "\",\"sandboxID\":\"sb-unit\",\"clientID\":\"client-unit\",\"envdVersion\":\"v0\",\"envdAccessToken\":\"envd-token\",\"domain\":\"cube.test\"}");
+                        return;
+                    }
+                    writeJson(exchange, 405, "{\"message\":\"method not allowed\"}");
+                }
+            });
+            server.createContext("/sandboxes/sb-unit", new HttpHandler() {
+                @Override
+                public void handle(HttpExchange exchange) throws IOException {
+                    if ("DELETE".equals(exchange.getRequestMethod())) {
+                        deleted = true;
+                        writeJson(exchange, 204, "");
+                        return;
+                    }
+                    writeJson(exchange, 200, "{\"templateID\":\"tpl-java\",\"sandboxID\":\"sb-unit\",\"clientID\":\"client-unit\",\"state\":\"running\",\"envdVersion\":\"v0\"}");
+                }
+            });
+            server.createContext("/sandboxes/sb-unit/connect", new HttpHandler() {
+                @Override
+                public void handle(HttpExchange exchange) throws IOException {
+                    if ("POST".equals(exchange.getRequestMethod())) {
+                        connectCount++;
+                        writeJson(exchange, 200, "{\"templateID\":\"tpl-java\",\"sandboxID\":\"sb-unit\",\"clientID\":\"client-unit\",\"envdVersion\":\"v0\",\"envdAccessToken\":\"envd-token\",\"domain\":\"cube.test\"}");
+                        return;
+                    }
+                    writeJson(exchange, 405, "{\"message\":\"method not allowed\"}");
+                }
+            });
+            server.createContext("/process.Process/Start", new HttpHandler() {
+                @Override
+                public void handle(HttpExchange exchange) throws IOException {
+                    processAuthorization = exchange.getRequestHeaders().getFirst("Authorization");
+                    processAccessToken = exchange.getRequestHeaders().getFirst("X-Access-Token");
+                    processConnectProtocol = exchange.getRequestHeaders().getFirst("Connect-Protocol-Version");
+                    processConnectTimeout = exchange.getRequestHeaders().getFirst("Connect-Timeout-Ms");
+                    processPayload = JSON.parseObject(readConnectEnvelope(exchange.getRequestBody()));
+                    exchange.getResponseHeaders().add("Content-Type", "application/connect+json");
+                    byte[] body = connectStream(processMode);
+                    exchange.sendResponseHeaders(200, body.length);
+                    OutputStream os = exchange.getResponseBody();
+                    os.write(body);
+                    os.close();
+                }
+            });
+            server.setExecutor(Executors.newCachedThreadPool());
+            server.start();
+        }
+
+        int port() {
+            return server.getAddress().getPort();
+        }
+
+        void stop() {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
+
+        private static byte[] connectStream(String mode) throws IOException {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            if ("connect-error".equals(mode)) {
+                writeEnvelope(out, "{\"error\":{\"code\":\"permission_denied\",\"message\":\"permission denied by envd\"}}", (byte) 0x02);
+                return out.toByteArray();
+            }
+            if ("partial".equals(mode)) {
+                DataOutputStream data = new DataOutputStream(out);
+                data.writeByte(0);
+                data.writeInt(10);
+                data.write("abc".getBytes(StandardCharsets.UTF_8));
+                return out.toByteArray();
+            }
+            writeEnvelope(out, "{\"event\":{\"start\":{\"pid\":7}}}");
+            String stdout = Base64.getEncoder().encodeToString("ai4j-cubesandbox-ok\n".getBytes(StandardCharsets.UTF_8));
+            writeEnvelope(out, "{\"event\":{\"data\":{\"stdout\":\"" + stdout + "\"}}}");
+            writeEnvelope(out, "{\"event\":{\"end\":{\"exitCode\":0,\"exited\":true}}}");
+            return out.toByteArray();
+        }
+
+        private static void writeEnvelope(ByteArrayOutputStream out, String json) throws IOException {
+            writeEnvelope(out, json, (byte) 0);
+        }
+
+        private static void writeEnvelope(ByteArrayOutputStream out, String json, byte flags) throws IOException {
+            byte[] payload = json.getBytes(StandardCharsets.UTF_8);
+            DataOutputStream data = new DataOutputStream(out);
+            data.writeByte(flags);
+            data.writeInt(payload.length);
+            data.write(payload);
+        }
+
+        private static String readConnectEnvelope(InputStream input) throws IOException {
+            int flags = input.read();
+            Assert.assertEquals(0, flags);
+            byte[] sizeBytes = new byte[4];
+            Assert.assertEquals(4, input.read(sizeBytes));
+            int size = ((sizeBytes[0] & 0xff) << 24)
+                    | ((sizeBytes[1] & 0xff) << 16)
+                    | ((sizeBytes[2] & 0xff) << 8)
+                    | (sizeBytes[3] & 0xff);
+            byte[] payload = new byte[size];
+            int offset = 0;
+            while (offset < size) {
+                int read = input.read(payload, offset, size - offset);
+                if (read < 0) {
+                    throw new IOException("unexpected EOF");
+                }
+                offset += read;
+            }
+            return new String(payload, StandardCharsets.UTF_8);
+        }
+
+        private static String read(HttpExchange exchange) throws IOException {
+            return read(exchange.getRequestBody());
+        }
+
+        private static String read(InputStream input) throws IOException {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[1024];
+            int read;
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+            return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+        }
+
+        private static void writeJson(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] raw = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, raw.length);
+            OutputStream os = exchange.getResponseBody();
+            os.write(raw);
+            os.close();
+        }
+    }
+
+    private static class JsonHandler implements HttpHandler {
+        private final int status;
+        private final String body;
+
+        private JsonHandler(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            TestCubeServer.writeJson(exchange, status, body);
+        }
+    }
+}

--- a/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/sandbox/CliSandboxSessionResolver.java
+++ b/ai4j-cli/src/main/java/io/github/lnyocly/ai4j/cli/sandbox/CliSandboxSessionResolver.java
@@ -3,6 +3,8 @@ package io.github.lnyocly.ai4j.cli.sandbox;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxException;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxConfig;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxProvider;
 import io.github.lnyocly.ai4j.agent.sandbox.daytona.DaytonaSandboxConfig;
 import io.github.lnyocly.ai4j.agent.sandbox.daytona.DaytonaSandboxProvider;
 
@@ -21,15 +23,26 @@ public class CliSandboxSessionResolver {
                 || command.getAction() == CliSandboxCommand.Action.DISABLE) {
             throw new SandboxException("sandbox command does not create a session");
         }
-        String providerId = defaultIfBlank(command.getProviderId(), DaytonaSandboxConfig.DEFAULT_PROVIDER_ID);
-        if (!DaytonaSandboxConfig.DEFAULT_PROVIDER_ID.equalsIgnoreCase(providerId)) {
-            throw new SandboxException("Unsupported sandbox provider: " + providerId + ". Supported provider: daytona.");
-        }
+        String providerId = normalizeProviderId(command.getProviderId());
         SandboxSpec spec = toSpec(command);
-        DaytonaSandboxConfig config = DaytonaSandboxConfig.fromEnvironment(spec, env == null ? Collections.<String, String>emptyMap() : env);
-        DaytonaSandboxProvider provider = new DaytonaSandboxProvider(config);
-        SandboxSession session = provider.createSession(spec);
-        return new OpenedSandboxSession(session, CliSandboxBinding.from(session, command));
+        if (CubeSandboxConfig.DEFAULT_PROVIDER_ID.equalsIgnoreCase(providerId) || "cube".equalsIgnoreCase(providerId)) {
+            CubeSandboxConfig config = CubeSandboxConfig.fromEnvironment(spec, env == null ? Collections.<String, String>emptyMap() : env);
+            CubeSandboxProvider provider = new CubeSandboxProvider(config);
+            SandboxSession session;
+            if (command.getAction() == CliSandboxCommand.Action.ATTACH && !isBlank(command.getSandboxIdOrName())) {
+                session = provider.connect(command.getSandboxIdOrName(), spec);
+            } else {
+                session = provider.createSession(spec);
+            }
+            return new OpenedSandboxSession(session, CliSandboxBinding.from(session, command));
+        }
+        if (DaytonaSandboxConfig.DEFAULT_PROVIDER_ID.equalsIgnoreCase(providerId)) {
+            DaytonaSandboxConfig config = DaytonaSandboxConfig.fromEnvironment(spec, env == null ? Collections.<String, String>emptyMap() : env);
+            DaytonaSandboxProvider provider = new DaytonaSandboxProvider(config);
+            SandboxSession session = provider.createSession(spec);
+            return new OpenedSandboxSession(session, CliSandboxBinding.from(session, command));
+        }
+        throw new SandboxException("Unsupported sandbox provider: " + providerId + ". Supported providers: daytona, cubesandbox (or cube).");
     }
 
     private SandboxSpec toSpec(CliSandboxCommand command) {

--- a/docs-site/docs/agent/cubesandbox-provider.md
+++ b/docs-site/docs/agent/cubesandbox-provider.md
@@ -184,7 +184,7 @@ AI4J 默认访问 envd 端口 `49983`，这是 CubeSandbox envd/BYOI/files 文�
 mvn -pl ai4j-agent -am "-Dtest=CubeSandboxProviderTest" -DskipTests=false -DfailIfNoTests=false test
 ```
 
-这个测试会启动本地 HTTP server stub，通过 `envdBaseUrl` 覆盖将控制面 (POST /sandboxes, DELETE /sandboxes/{id}, POST /sandboxes/{id}/connect) 和数据面 (envd /process.Process/Start) 请求都路由到同一 stub，验证：Create + Execute + Destroy 完整流程、Bearer/Basic/X-Access-Token 鉴权、Connect envelope 帧解析、base64 stdout 解码、exitCode 提取、Connect end-stream 错误帧处理、partial envelope 失败路径、secret 过滤（apiKey 不出现在 create payload/metadata/labels 中）、connect-existing 模式（close 不删除远端 sandbox）、config 合并、provider 选择、env var 兼容（CUBE_* / E2B_*）、envdBaseUrl 覆盖、envdPort 配置、timeout 合并、spec 字段保护等。它不需要真实密钥。
+这个测试会启动本地 HTTP server stub，通过 `envdBaseUrl` 覆盖将控制面 (`POST /sandboxes`, `DELETE /sandboxes/{id}`, `POST /sandboxes/{id}/connect`) 和数据面 (`envd /process.Process/Start`) 请求都路由到同一 stub，验证：Create + Execute + Destroy 完整流程、Bearer/Basic/X-Access-Token 鉴权、Connect envelope 帧解析、base64 stdout 解码、exitCode 提取、Connect end-stream 错误帧处理、partial envelope 失败路径、secret 过滤（apiKey 不出现在 create payload/metadata/labels 中）、connect-existing 模式（close 不删除远端 sandbox）、config 合并、provider 选择、env var 兼容（CUBE_* / E2B_*）、envdBaseUrl 覆盖、envdPort 配置、timeout 合并、spec 字段保护等。它不需要真实密钥。
 
 真实 CubeSandbox smoke 是显式 opt-in：
 

--- a/docs-site/docs/agent/cubesandbox-provider.md
+++ b/docs-site/docs/agent/cubesandbox-provider.md
@@ -1,0 +1,211 @@
+---
+sidebar_position: 10
+---
+
+# CubeSandbox Provider
+
+`CubeSandboxProvider` 是 AI4J 在 `ai4j-agent` 里提供的第一个真实远端 sandbox 适配器。它把 `SandboxProvider` / `SandboxSession` 映射到开源 [TencentCloud/CubeSandbox](https://github.com/TencentCloud/CubeSandbox) 的 CubeAPI 控制面和 envd 进程执行 API。
+
+它的定位很明确：
+
+- **AI4J 不内置 VM**：隔离环境由你部署的 CubeSandbox 集群提供。
+- **SDK 只做 adapter**：负责 create / connect / execute / close 的 Java 合同映射。
+- **不会自动启用**：只有宿主显式构造 `CubeSandboxProvider` 并调用 `createSession(...)` 或 `connect(...)`，才会访问 CubeSandbox。
+- **不保存密钥**：API key 只从 provider builder 或环境变量读取，不从 `SandboxSpec.config` 读取，避免 session snapshot 或 YAML 配置误持久化 secret。
+
+## 1. 适合什么场景
+
+| 场景 | 是否适合 |
+| --- | --- |
+| 为每个 Agent/Coding Agent 会话创建一个远端 Linux sandbox | 适合 |
+| 把 shell / project test / artifact 收集从本机迁到隔离环境 | 适合，当前先提供 `SandboxSession.execute(...)` |
+| 连接已有 CubeSandbox sandbox 并执行命令 | 适合，使用 `provider.connect(...)` |
+| 直接替代 `ai4j-coding` 的本地 file/git/browser 工具 | 还不是；后续需要 coding tool routing |
+| 本地无 CubeSandbox 集群时开箱即用 | 不适合，需要先部署 CubeSandbox 或接入已有 CubeAPI |
+
+## 2. 依赖与配置
+
+Java 侧不新增第三方依赖。适配器使用 Java 8、JDK HTTP 和项目已有 JSON 依赖。
+
+推荐用环境变量保存真实连接信息：
+
+```bash
+export CUBE_API_URL="http://127.0.0.1:3000"
+export CUBE_API_KEY="..."              # 可选；也兼容 E2B_API_KEY
+export CUBE_TEMPLATE_ID="your-template"
+export CUBE_SANDBOX_DOMAIN="cube.app"
+export CUBE_ENVD_PORT="49983"
+```
+
+兼容变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `CUBE_API_URL` / `E2B_API_URL` | CubeAPI 地址，默认 `http://127.0.0.1:3000` |
+| `CUBE_API_KEY` / `E2B_API_KEY` | 控制面鉴权 token；以 `Authorization: Bearer <key>` 发送 |
+| `CUBE_TEMPLATE_ID` | 默认 template ID |
+| `CUBE_SANDBOX_DOMAIN` | sandbox 域名后缀，默认 `cube.app` |
+| `CUBE_ENVD_PORT` | envd 数据面虚拟端口，默认 `49983`；如果你的模板/部署按 Go SDK 的 `49999` 暴露，可覆盖为 `49999` |
+| `CUBE_TIMEOUT` | sandbox TTL，默认 300 秒 |
+| `CUBE_REQUEST_TIMEOUT` | 控制面请求超时，默认 30 秒 |
+
+## 3. 创建并执行命令
+
+```java
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxCommand;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
+import io.github.lnyocly.ai4j.agent.sandbox.SandboxSpec;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxProvider;
+import io.github.lnyocly.ai4j.agent.sandbox.cubesandbox.CubeSandboxSession;
+
+CubeSandboxProvider provider = new CubeSandboxProvider();
+CubeSandboxSession session = provider.createSession(SandboxSpec.builder()
+        .providerId("cubesandbox")
+        .image(System.getenv("CUBE_TEMPLATE_ID"))
+        .workspaceId("/workspace")
+        .label("task", "demo")
+        .config("allowInternetAccess", Boolean.FALSE)
+        .build());
+
+try {
+    SandboxResult result = session.execute(SandboxCommand.builder()
+            .commandId("hello")
+            .command("printf ai4j-cubesandbox-ok")
+            .workingDirectory("/workspace")
+            .timeoutMillis(30000L)
+            .build());
+
+    System.out.println(result.getExitCode());
+    System.out.println(result.getStdout());
+} finally {
+    session.close(); // createSession 创建的 sandbox 默认会 DELETE 销毁
+}
+```
+
+`SandboxCommand.command(...)` 会按 CubeSandbox 官方 SDK 的命令形态执行：
+
+```text
+/bin/bash -l -c <command>
+```
+
+返回值会映射到 `SandboxResult.exitCode/stdout/stderr/durationMillis/artifacts/events`。
+
+## 4. 连接已有 sandbox
+
+如果 sandbox 已经由外部系统创建，可以只连接：
+
+```java
+CubeSandboxSession session = provider.connect("sandbox-id", SandboxSpec.builder()
+        .providerId("cubesandbox")
+        .workspaceId("/workspace")
+        .build());
+
+try {
+    SandboxResult result = session.execute(SandboxCommand.builder()
+            .command("pwd")
+            .build());
+} finally {
+    session.close(); // connect(...) 连接的既有 sandbox 默认不销毁远端实例
+}
+```
+
+这和 `createSession(...)` 的生命周期不同：
+
+| 方法 | 远端 sandbox 来源 | `close()` 默认行为 |
+| --- | --- | |
+| `createSession(...)` | AI4J 调 `POST /sandboxes` 创建 | 调 `DELETE /sandboxes/{id}` 销毁 |
+| `connect(...)` | 外部已有 sandbox | 只关闭本地连接，不销毁远端实例 |
+
+
+## 5. CLI 连接已有 CubeSandbox session
+
+`ai4j-cli` 可以把当前 coding session attach 到一个**已经存在**的 CubeSandbox session：
+
+```text
+/sandbox attach cubesandbox <sessionId> [workspaceId]
+# 或者
+/sandbox attach cube <sessionId> [workspaceId]
+```
+
+执行后，CLI 会调用 `CubeSandboxProvider.connect(sessionId, SandboxSpec)`：
+
+- 成功时 `/sandbox status` 显示 `mode=attached-live`、`runtime=live-session`。
+- 后续 coding agent 的 `bash action=exec` 会通过 live `SandboxSession.execute(...)` 进入 CubeSandbox。
+- `disable` 会关闭本地 session handle，但 `connect(...)` 模式不会销毁外部已存在的远端 sandbox。
+- 如果 CubeAPI 地址、鉴权、网络或 sessionId 无效，attach 会失败并保持原 runtime，不会回退成本地执行。
+
+CLI 只做 attach，不做 create/auth：
+
+- 不会自动部署 CubeSandbox。
+- 不会创建 template。
+- 不会把 API key 写进 workspace 配置或 session snapshot。
+- 不会在缺失 provider bridge 时假装 sandbox 执行成功。
+
+## 6. `SandboxSpec.config` 支持项
+
+`SandboxSpec.config` 只适合放非敏感、任务级配置：
+
+| key | 作用 |
+| --- | --- |
+| `templateId` / `templateID` | template ID；也可用 `SandboxSpec.image` 表达 |
+| `envVars` | 创建 sandbox 时注入的环境变量 map |
+| `metadata` | 创建 sandbox 时写入的 metadata map；敏感 key 会过滤 |
+| `allowInternetAccess` | 为 `false` 时关闭公网访问 |
+| `network` | 透传 CubeSandbox network 配置 |
+| `timeoutSeconds` / `timeout` | sandbox TTL 秒数 |
+| `requestTimeoutMillis` / `requestTimeout` | 控制面请求超时 |
+| `closeDestroysSandbox` / `destroyOnClose` | `createSession(...)` 创建的 session close 时是否销毁 |
+| `sandboxDomain` / `domain` | sandbox host 域名后缀 |
+| `envdPort` / `envdHTTPPort` / `dataPort` | envd 数据面虚拟端口，默认 `49983` |
+| `user` | envd Basic auth 用户，默认 `root` |
+| `connectEnvelopeLimitBytes` | Connect message 上限，默认 64MiB |
+
+不要把 `apiKey`、token、cookie、连接串放进 `SandboxSpec.config` 或 labels。`CubeSandboxConfig.withSpecOverrides(...)` 会有意忽略 `apiKey`；labels 和 metadata 中包含 `secret/token/key/password/passwd/credential/authorization/cookie` 的 key 会被过滤。
+
+## 7. 协议映射
+
+| AI4J 行为 | CubeSandbox 行为 |
+| --- | --- |
+| `provider.health()` | `GET /health` |
+| `createSession(...)` | `POST /sandboxes`，payload 包含 `templateID`、`timeout`、可选 `envVars/metadata/allowInternetAccess/network` |
+| `connect(...)` | `POST /sandboxes/{sandboxID}/connect` |
+| `session.execute(...)` | envd `POST /process.Process/Start`，`application/connect+json` |
+| `session.close()` | 新建 session 默认 `DELETE /sandboxes/{sandboxID}` |
+
+envd Connect stream 使用 5-byte envelope：1 byte flags + 4 byte big-endian size。stdout/stderr 按 CubeSandbox envd 事件中的 base64 字段解码。
+
+AI4J 默认访问 envd 端口 `49983`，这是 CubeSandbox envd/BYOI/files 文档中的默认端口。部分 CubeSandbox SDK/模板会通过 `49999` 访问 Jupyter/code-interpreter gateway；如果你的模板把 `/process.Process/Start` 暴露在 `49999`，请设置 `CUBE_ENVD_PORT=49999` 或 `spec.config.envdPort=49999`。
+
+## 8. 本地与 live 验证
+
+确定性协议级测试：
+
+```bash
+mvn -pl ai4j-agent -am "-Dtest=CubeSandboxProviderTest" -DskipTests=false -DfailIfNoTests=false test
+```
+
+这个测试会启动本地 HTTP server stub，通过 `envdBaseUrl` 覆盖将控制面 (POST /sandboxes, DELETE /sandboxes/{id}, POST /sandboxes/{id}/connect) 和数据面 (envd /process.Process/Start) 请求都路由到同一 stub，验证：Create + Execute + Destroy 完整流程、Bearer/Basic/X-Access-Token 鉴权、Connect envelope 帧解析、base64 stdout 解码、exitCode 提取、Connect end-stream 错误帧处理、partial envelope 失败路径、secret 过滤（apiKey 不出现在 create payload/metadata/labels 中）、connect-existing 模式（close 不删除远端 sandbox）、config 合并、provider 选择、env var 兼容（CUBE_* / E2B_*）、envdBaseUrl 覆盖、envdPort 配置、timeout 合并、spec 字段保护等。它不需要真实密钥。
+
+真实 CubeSandbox smoke 是显式 opt-in：
+
+```bash
+export AI4J_CUBESANDBOX_LIVE=true
+export CUBE_API_URL="..."
+export CUBE_TEMPLATE_ID="..."
+# 如部署启用鉴权，再设置 CUBE_API_KEY 或 E2B_API_KEY
+mvn -pl ai4j-agent -am -P live-provider-tests "-Dtest=CubeSandboxLiveProviderTest" -DskipTests=false -DfailIfNoTests=false test
+```
+
+如果缺少 live 环境变量，测试会通过 JUnit `Assume` 跳过；不要在日志、文档、PR 或 Harness 材料里写出真实 key。
+
+## 9. 当前边界
+
+- 当前只实现命令执行，不包含文件上传/下载、Jupyter code API、snapshot、browser、artifact 下载等高阶能力。
+- `ai4j-coding` 当前已支持 foreground `bash exec` 路由到 `SandboxSession`；file/git/browser/长进程/artifact 还没有全部接到 sandbox，所以 coding agent 仍需要后续任务才能达到"所有工具都跑在远端 sandbox"的体验。
+
+## 10. 相关文档
+
+- [Agent Sandbox SPI](/docs/agent/sandbox-spi)
+- [Approval / Permission Policy](/docs/agent/approval-permission-policy)
+- [Coding Agent Sandbox Routing](/docs/coding-agent/sandbox-routing)
+- [Remote Agent Runner SPI](/docs/agent/remote-agent-runner-spi)

--- a/docs-site/docs/agent/cubesandbox-provider.md
+++ b/docs-site/docs/agent/cubesandbox-provider.md
@@ -208,4 +208,3 @@ mvn -pl ai4j-agent -am -P live-provider-tests "-Dtest=CubeSandboxLiveProviderTes
 - [Agent Sandbox SPI](/docs/agent/sandbox-spi)
 - [Approval / Permission Policy](/docs/agent/approval-permission-policy)
 - [Coding Agent Sandbox Routing](/docs/coding-agent/sandbox-routing)
-- [Remote Agent Runner SPI](/docs/agent/remote-agent-runner-spi)


### PR DESCRIPTION
## Summary

Adds a fourth sandbox backend: **CubeSandbox** (TencentCloud open-source control plane on the envd Connect execution protocol — the same protocol E2B uses). It fills the **China / self-host** niche that neither E2B nor Daytona covers (both are overseas cloud). Ported from the legacy `dev` line (PR #131) and adapted to current main conventions.

## What's included

- **`ai4j-agent/.../sandbox/cubesandbox/`** — provider, session, client, config, remote, sanitizer, `CubeSandboxApiException`.
- **Exceptions re-layered** to mirror E2B: client throws `IOException` + `CubeSandboxApiException` (preserves HTTP status); session/provider wrap into `SandboxException`.
- **Dropped the unused HTTP-proxy tunneling path** (~250 LOC) and added an **`envdBaseUrl` / `CUBE_ENVD_BASE_URL`** override (useful for self-hosted envd endpoints, and the testability mechanism that the proxy path previously doubled as).
- **`CubeSandboxConfig` aligned to `DaytonaSandboxConfig`**: `fromEnvironment(SandboxSpec)` / `(SandboxSpec, Map)`, `withSpecOverrides`, `spec` field, `getSpec/getLabels/getEnvironment`.
- **CLI**: `CliSandboxSessionResolver` now dispatches `cubesandbox`/`cube`; **ATTACH → `connect()`** (no destroy) and **ENABLE → `createSession()`**.
- **18-test in-process `HttpServer` protocol suite**: control API (create/connect/kill/health) + envd Connect-stream parsing, Bearer/Basic auth split, sanitizer secret-stripping, error/end-stream + partial-envelope failure paths.
- **Docs**: `docs-site/docs/agent/cubesandbox-provider.md`.

`SandboxProvider` SPI is unchanged (all 10 SPI files are byte-identical to main). Java 8 clean.

## Security

Preserved (and in places stronger than E2B/Daytona): CRLF header-injection validation, sandboxID/domain charset whitelist, 64 MB Connect-envelope cap + compressed-frame rejection, and apiKey deliberately kept out of `SandboxSpec` (no snapshot leak). A dedicated review lens confirmed no secret exposure introduced.

## Verification

- Builds: `mvn -pl ai4j-agent -am compile` and `mvn -pl ai4j-cli -am compile` green.
- `CubeSandboxProviderTest` (18 tests) green; `*Sandbox*` regression (incl. e2b/SPI-model) green — no breakage.
- Reviewed via a 6-lens pre-port assessment + a 4-lens adversarial post-port verification; all findings (incl. a broken CLI attach path and a hollowed test) were fixed before commit.

## Notes

- Live smoke test (`CubeSandboxLiveProviderTest`) is gated on real `CUBE_API_KEY` credentials; the unit suite is credential-free.
- `sdk-roadmap.md` lists CubeSandbox as "plugin-recommended"; this PR promotes it to an official provider (maintainer decision — fills the China/self-host gap).

🤔 Generated by Claude Code