### PR TITLE
docs(site): Stage 2 — content-type tags (concept/how-to/integration/reference)

### DIFF
--- a/docs-site/docs/agent/a2a.md
+++ b/docs-site/docs/agent/a2a.md
@@ -2,6 +2,7 @@
 sidebar_position: 12
 title: A2A Protocol (Agent-to-Agent)
 description: "Discover agents, exchange JSON-RPC tasks, stream SSE updates, and expose your ai4j agent as an A2A service with optional auth — JDK stdlib only."
+tags: [integration]
 ---
 
 # A2A Protocol (Agent-to-Agent)

--- a/docs-site/docs/agent/agent-blueprint.md
+++ b/docs-site/docs/agent/agent-blueprint.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: Agent Blueprint YAML
 description: "用声明式 YAML 描述单 Agent 的模型、指令、工具、memory、compact、sandbox 与 workflow 参数，支持加载、校验与模板化，并由宿主提供依赖后创建可运行 Agent。"
+tags: [reference]
 ---
 
 # Agent Blueprint YAML

--- a/docs-site/docs/agent/agent-teams-api-reference.md
+++ b/docs-site/docs/agent/agent-teams-api-reference.md
@@ -2,6 +2,7 @@
 sidebar_position: 15
 title: Agent Teams API Reference
 description: "以源码视角导航 Agent Teams runtime：AgentTeamBuilder 字段如何映射到运行链、task board 状态机、team 工具面、持久化恢复与扩展点。"
+tags: [reference]
 ---
 
 # Agent Teams API Reference

--- a/docs-site/docs/agent/agent-teams.md
+++ b/docs-site/docs/agent/agent-teams.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: Agent Teams
 description: "ai4j Agent Teams 是带控制面的团队运行时：planner 拆任务、task board 维护依赖与状态、成员注入 team_* 工具协作、synthesizer 汇总最终答案。"
+tags: [concept]
 ---
 
 # Agent Teams

--- a/docs-site/docs/agent/approval-permission-policy.md
+++ b/docs-site/docs/agent/approval-permission-policy.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: Agent Approval / Permission Policy
 description: "AgentPermissionPolicy 在工具执行前做权限判断：ALLOW / DENY / REQUIRE_APPROVAL，可被普通 Agent、Blueprint、CLI 审批界面与后续 Sandbox SPI 复用。"
+tags: [concept]
 ---
 
 # Agent Approval / Permission Policy

--- a/docs-site/docs/agent/architecture.md
+++ b/docs-site/docs/agent/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Agent Architecture
 description: "拆解 ai4j-agent 的 Builder、Runtime、ModelClient 三层边界，工具声明与执行双面，memory 作为状态源，以及事件流与 trace 的架构定位。"
+tags: [concept]
 ---
 
 # Agent Architecture

--- a/docs-site/docs/agent/codeact-custom-sandbox.md
+++ b/docs-site/docs/agent/codeact-custom-sandbox.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: CodeAct：自定义代码沙箱执行器
 description: "讲清 CodeAct 的代码执行边界与 CodeExecutor 扩展点：何时替换默认执行器、如何处理工具桥接，以及生产环境必须补齐的隔离与安全约束。"
+tags: [concept]
 ---
 
 # CodeAct：自定义代码沙箱执行器

--- a/docs-site/docs/agent/codeact-runtime.md
+++ b/docs-site/docs/agent/codeact-runtime.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: CodeAct 运行时
 description: "CodeActRuntime 用 code/final JSON 协议替代 native tool-calling，把模型生成的可执行代码纳入主循环，由 CodeExecutor 桥接工具并决定收口路径。"
+tags: [concept]
 ---
 
 # CodeAct 运行时

--- a/docs-site/docs/agent/cubesandbox-provider.md
+++ b/docs-site/docs/agent/cubesandbox-provider.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: CubeSandbox Provider
 description: "CubeSandboxProvider 是 ai4j 第一个真实远端 sandbox 适配器，把 SandboxProvider/SandboxSession 映射到 CubeSandbox 的 CubeAPI 控制面与 envd 执行 API。"
+tags: [integration]
 ---
 
 # CubeSandbox Provider

--- a/docs-site/docs/agent/memory-and-state.md
+++ b/docs-site/docs/agent/memory-and-state.md
@@ -1,6 +1,7 @@
 ---
 title: Memory and State
 description: 拆解 ai4j-agent 的 AgentMemory 状态模型：用户输入、模型输出与工具输出如何统一回灌下一轮 prompt，以及 InMemoryAgentMemory、JdbcAgentMemory 的写入、压缩与 session 隔离真实语义。
+tags: [concept]
 ---
 
 # Memory and State

--- a/docs-site/docs/agent/memory-compact-context.md
+++ b/docs-site/docs/agent/memory-compact-context.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Memory Compact Context Projector
 description: 介绍 ai4j-agent 的 ContextProjector 与 CompactPolicy：如何把 memory snapshot 投影成本轮 prompt、用结构化 CompactResult 压缩长程上下文，并让压缩过程可诊断、可恢复。
+tags: [concept]
 ---
 
 # Memory Compact Context Projector

--- a/docs-site/docs/agent/minimal-react-agent.md
+++ b/docs-site/docs/agent/minimal-react-agent.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: 最小 ReAct Agent
 description: 剖析最小但完整的 ReAct Agent 运行闭环：AgentBuilder 默认装配、ReActRuntime 与 BaseAgentRuntime 的关系、工具声明与执行边界，以及空工具 Agent 何时成立。
+tags: [concept]
 ---
 
 # 最小 ReAct Agent

--- a/docs-site/docs/agent/model-client-selection.md
+++ b/docs-site/docs/agent/model-client-selection.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: Model Client Selection
 description: 对比 ChatModelClient 与 ResponsesModelClient：systemPrompt/instructions 的协议映射、顶层字段下推差异、流式信号与 memoryItems 形状，帮你为 Agent 选对模型协议路径。
+tags: [concept]
 ---
 
 # Model Client Selection

--- a/docs-site/docs/agent/overview.md
+++ b/docs-site/docs/agent/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Agent Overview
 description: ai4j-agent 总览：它在 Core SDK 之上提供多步推理、工具闭环、memory、workflow、trace 与多 Agent 协作，何时该用 Agent、最小心智模型、runtime 选型与模块边界。
+tags: [concept]
 ---
 
 # Agent Overview

--- a/docs-site/docs/agent/plugin-lifecycle-hooks.md
+++ b/docs-site/docs/agent/plugin-lifecycle-hooks.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: Plugin Lifecycle Hooks
 description: 说明 ai4j-extension-api 的 Agent 生命周期 Hook：插件如何观察 BEFORE_TURN/BEFORE_MODEL_REQUEST/BEFORE_TOOL_CALL/ON_COMPACT 等事件，事件 payload、异常策略与 Guardrail 的区别。
+tags: [integration]
 ---
 
 # Plugin Lifecycle Hooks

--- a/docs-site/docs/agent/provider-config-examples.md
+++ b/docs-site/docs/agent/provider-config-examples.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Provider 配置样例
 description: Provider 配置样例已迁移至 Coding Agent 专题；本页保留兼容入口，指向新的配置体系、Provider Profile 与命令参考正式文档。
+tags: [integration]
 ---
 
 # 页面已迁移

--- a/docs-site/docs/agent/quickstart.md
+++ b/docs-site/docs/agent/quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: Agent Quickstart
 description: 用最小但真实的链路帮你跑通第一条 Agent 主线：AgentBuilder 默认装配、ReActRuntime step loop、AgentModelClient 协议适配、AgentMemory 回灌与 AgentResult 收口。
+tags: [how-to]
 ---
 
 # Agent Quickstart

--- a/docs-site/docs/agent/reference-core-classes.md
+++ b/docs-site/docs/agent/reference-core-classes.md
@@ -2,6 +2,7 @@
 sidebar_position: 14
 title: Agent 核心类参考
 description: ai4j-agent 核心类源码导航图：按装配、运行、模型适配、工具、memory、workflow、subagent、team、trace 分层，给出该先读哪条线、按问题类型选入口。
+tags: [reference]
 ---
 
 # Agent 核心类参考

--- a/docs-site/docs/agent/replay-recovery-audit.md
+++ b/docs-site/docs/agent/replay-recovery-audit.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: Replay, Recovery & Audit
 description: "Covers ai4j-agent's four production layers on the event stream: node I/O capture and replay, resume-cache failure recovery, durable session stores, and tamper-evident hash-chained audit logging."
+tags: [how-to]
 ---
 
 # Replay, Recovery & Audit

--- a/docs-site/docs/agent/runtime-implementations.md
+++ b/docs-site/docs/agent/runtime-implementations.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Runtime Implementations
 description: 拆解 ReActRuntime、CodeActRuntime、DeepResearchRuntime 三种 runtime：它们共享 BaseAgentRuntime 主循环，差异在于模型输出的中间表示，以及何时换中间表示、何时自定义 runtime。
+tags: [concept]
 ---
 
 # Runtime Implementations

--- a/docs-site/docs/agent/sandbox-spi.md
+++ b/docs-site/docs/agent/sandbox-spi.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: Agent Sandbox SPI
 description: 介绍 ai4j-agent 的 Sandbox SPI：SandboxProvider/SandboxSession 合同如何把执行交给隔离环境，AgentSessionSandboxBinding 只保存非敏感摘要，以及 Daytona、E2B 两个官方真实 provider。
+tags: [integration]
 ---
 
 # Agent Sandbox SPI

--- a/docs-site/docs/agent/sdk-roadmap.md
+++ b/docs-site/docs/agent/sdk-roadmap.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: AI4J Agent SDK Roadmap
 description: ai4j-agent 技术路线图：从 P0 运行内核（Session/Memory/Compact/Plugin/Permission）到 P1 Blueprint YAML、P2 Sandbox SPI、P3 Coding 沙箱路由、P4 CLI 与 P5 远端 Runner 的分阶段演进。
+tags: [reference]
 ---
 
 # AI4J Agent SDK Roadmap

--- a/docs-site/docs/agent/session-runtime.md
+++ b/docs-site/docs/agent/session-runtime.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Agent Session Runtime
 description: 讲解 AgentSession 长程运行态容器：sessionId、独立 memory、event log、snapshot/restore 与 AgentSessionStore，以及它与 memory/compact、Coding Agent/CLI 的边界和生产实现建议。
+tags: [concept]
 ---
 
 # Agent Session Runtime

--- a/docs-site/docs/agent/skills.md
+++ b/docs-site/docs/agent/skills.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: Agent Skills
 description: "Explains ai4j-agent Skills: how the SDK discovers and scopes SKILL.md, the workspace-safe vs user-home roots, request-scoped AgentSkillResolver for tenants, and why Skills never bypass tool authorization."
+tags: [how-to]
 ---
 
 # Agent Skills

--- a/docs-site/docs/agent/subagent-handoff-policy.md
+++ b/docs-site/docs/agent/subagent-handoff-policy.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: SubAgent 与 Handoff Policy
 description: 剖析 SubAgent 如何把另一个 Agent 包装成受治理工具：StaticSubAgentRegistry 暴露 schema、SubAgentToolExecutor 拦截 handoff，以及 HandoffPolicy 的深度、超时、deny/fallback 与 session 模式语义。
+tags: [concept]
 ---
 
 # SubAgent 与 Handoff Policy

--- a/docs-site/docs/agent/system-prompt-vs-instructions.md
+++ b/docs-site/docs/agent/system-prompt-vs-instructions.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: System Prompt vs Instructions
 description: 厘清 ai4j-agent 里 systemPrompt 与 instructions 的源码语义：两者都是 AgentContext 配置、每步重复进入模型，但在 Chat 与 Responses 路径映射不同，CodeAct 下更需分层。
+tags: [concept]
 ---
 
 # System Prompt vs Instructions

--- a/docs-site/docs/agent/tool-interceptor.md
+++ b/docs-site/docs/agent/tool-interceptor.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: Interception Hooks
 description: ai4j-agent 的拦截层：ToolInterceptor(block/modify/routeTo sandbox) 与 PromptInterceptor 对应 Claude Code 的 PreToolUse/PostToolUse/UserPromptSubmit，加上 observe-only 生命周期 Hook，附 hooks 门面与 CLI 配置。
+tags: [how-to]
 ---
 
 # Interception Hooks (block / modify / route-to-sandbox + observe events)

--- a/docs-site/docs/agent/tools-and-registry.md
+++ b/docs-site/docs/agent/tools-and-registry.md
@@ -1,6 +1,7 @@
 ---
 title: Tools and Registry
 description: 拆解 ai4j-agent 工具体系：AgentToolRegistry 只管暴露面、ToolExecutor 管执行与权限边界，runtime 如何归一化、校验、执行工具并把结果回灌 memory，以及审批拦截该放哪层。
+tags: [concept]
 ---
 
 # Tools and Registry

--- a/docs-site/docs/agent/trace-observability.md
+++ b/docs-site/docs/agent/trace-observability.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: Trace 与可观测性
 description: 讲解 ai4j-agent 的 trace 与可观测性：traceExporter 才是开关、默认全记录需脱敏截断、事件如何折叠成 span、各 exporter 适用边界，以及与 OTel/Langfuse/FlowGram 的真实关系。
+tags: [concept]
 ---
 
 # Trace 与可观测性

--- a/docs-site/docs/agent/use-cases-and-paths.md
+++ b/docs-site/docs/agent/use-cases-and-paths.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: Agent 使用路径与场景选择
 description: 按系统结构帮你选抽象层：ReAct 是默认起点，CodeAct 换中间表示，Workflow 加显式节点，SubAgent 做受控委派，Teams 引入协作模型；附决策表与常见误判。
+tags: [concept]
 ---
 
 # Agent 使用路径与场景选择

--- a/docs-site/docs/agent/weather-workflow-cookbook.md
+++ b/docs-site/docs/agent/weather-workflow-cookbook.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: 实战：天气分析双 Agent Workflow
 description: 用天气分析双 Agent workflow 讲清 SequentialWorkflow 的 outputText 接力、WorkflowContext side channel、节点 session 隔离与 NamedNode 最小观测，以及何时该升级到 StateGraphWorkflow。
+tags: [how-to]
 ---
 
 # 实战：天气分析双 Agent Workflow

--- a/docs-site/docs/agent/why-agent.md
+++ b/docs-site/docs/agent/why-agent.md
@@ -1,6 +1,7 @@
 ---
 title: Why Agent
 description: 回答 ai4j 为什么要单独的 Agent 层：多步执行迟早会逼出 runtime、状态源与工具治理，Agent 把主循环、状态语义、治理边界和可观测性统一下来，而不是平行再造框架。
+tags: [concept]
 ---
 
 # Why Agent

--- a/docs-site/docs/agent/workflow-stategraph.md
+++ b/docs-site/docs/agent/workflow-stategraph.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Workflow 与 StateGraph
 description: 讲解 ai4j-agent 的 Workflow 与 StateGraph：编排层而非 runtime、节点默认只传 outputText、WorkflowContext 是 side channel、StateGraph 边解析优先级与 maxSteps 保险丝语义。
+tags: [concept]
 ---
 
 # Workflow 与 StateGraph

--- a/docs-site/docs/coding-agent/acp-integration.md
+++ b/docs-site/docs/coding-agent/acp-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: ACP 集成
 description: 讲清 ACP 作为 headless host 接入 IDE/桌面壳的真实链路：newline-delimited JSON-RPC、session 生命周期 RPC、available_commands_update、session/load replay 与服务端反向 session/request_permission。
+tags: [integration]
 ---
 
 # ACP 集成

--- a/docs-site/docs/coding-agent/architecture.md
+++ b/docs-site/docs/coding-agent/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Coding Agent Architecture
 description: 从执行主链拆解 Coding Agent 的分层架构：CodingAgentBuilder 装配点、WorkspaceContext 边界、CodingSession 容器、delegation runtime、审批 decorator 与 host runtime 的职责划分。
+tags: [concept]
 ---
 
 # Coding Agent Architecture

--- a/docs-site/docs/coding-agent/cli-and-tui.md
+++ b/docs-site/docs/coding-agent/cli-and-tui.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: CLI / TUI 使用指南
 description: 讲清 code 与 tui 两种入口如何共用同一套 coding runtime、在哪里分叉（JLINE/legacy/TUI runtime），以及 slash command、/stream、session store 等宿主层行为的真实边界。
+tags: [concept]
 ---
 
 # CLI / TUI 使用指南

--- a/docs-site/docs/coding-agent/command-reference.md
+++ b/docs-site/docs/coding-agent/command-reference.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: 命令参考
 description: 汇总 Coding Agent 已实现的高频 slash 命令（provider/model/mcp/session/process/team/compact 等）的作用域、常用参数与 CLI/TUI/ACP 三种宿主的命令可见性差异。
+tags: [reference]
 ---
 
 # 命令参考

--- a/docs-site/docs/coding-agent/compact-and-checkpoint.md
+++ b/docs-site/docs/coding-agent/compact-and-checkpoint.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Compact 与 Checkpoint 机制
 description: 讲清 ai4j-coding 的 compact/checkpoint 管线：tool-result microcompact、checkpoint 总结、aggressive compact、fallback 与 auto-compact circuit breaker 的职责划分和调优入口。
+tags: [concept]
 ---
 
 # Compact 与 Checkpoint 机制

--- a/docs-site/docs/coding-agent/configuration.md
+++ b/docs-site/docs/coding-agent/configuration.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: 配置体系
 description: 讲清 Coding Agent 配置的三层（全局 provider 资产、全局 MCP 定义、工作区绑定）、逐字段求值优先级，以及哪些改动会触发当前 session runtime 重绑。
+tags: [reference]
 ---
 
 # 配置体系

--- a/docs-site/docs/coding-agent/install-and-release.md
+++ b/docs-site/docs/coding-agent/install-and-release.md
@@ -1,6 +1,7 @@
 ---
 title: Install and Release
 description: 分清 Coding Agent 的构建、Maven 发布与终端 CLI 安装三层，说明当前仓库已提供 fat jar 与平台 launcher，并明确 fat jar 为最稳分发基线及 release 缺口。
+tags: [how-to]
 ---
 
 # Install and Release

--- a/docs-site/docs/coding-agent/mcp-and-acp.md
+++ b/docs-site/docs/coding-agent/mcp-and-acp.md
@@ -1,6 +1,7 @@
 ---
 title: MCP and ACP
 description: 厘清 Coding Agent 里 MCP（把外部能力接进模型工具面）与 ACP（把 coding session 协议化暴露给宿主）两条完全不同的边界，说明它们如何在同一会话里同时生效。
+tags: [concept]
 ---
 
 # MCP and ACP

--- a/docs-site/docs/coding-agent/mcp-integration.md
+++ b/docs-site/docs/coding-agent/mcp-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: MCP 对接
 description: 讲清 MCP 在 Coding Agent 里如何变成活的工具面：全局定义与 workspace 启用两层配置、五种 server 运行状态、tool 名冲突校验，以及 ACP 下按会话注入 MCP 的独立链路。
+tags: [integration]
 ---
 
 # MCP 对接

--- a/docs-site/docs/coding-agent/overview.md
+++ b/docs-site/docs/coding-agent/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Coding Agent 总览
 description: AI4J Coding Agent 的模块分工、三种宿主入口(CLI/TUI/ACP)与核心概念总览，帮你判断本地代码仓任务是否适合使用 Coding Agent 运行时。
+tags: [concept]
 ---
 
 # Coding Agent 总览

--- a/docs-site/docs/coding-agent/prompt-assembly.md
+++ b/docs-site/docs/coding-agent/prompt-assembly.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Prompt 组装与上下文来源
 description: 拆解送进模型的 5 类 prompt 来源（base system prompt、workspace prompt、instructions、session memory、当前 turn）与独立的 tool schemas，帮你定位行为偏差时该按什么顺序排查。
+tags: [concept]
 ---
 
 # Prompt 组装与上下文来源

--- a/docs-site/docs/coding-agent/provider-profiles.md
+++ b/docs-site/docs/coding-agent/provider-profiles.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Provider Profile 与模型切换
 description: 说明 provider profile 作为可切换、可回退的 provider runtime binding 的真实语义，覆盖 activeProfile/effectiveProfile 解析、/provider 与 /model 命令及 session runtime 重绑行为。
+tags: [concept]
 ---
 
 # Provider Profile 与模型切换

--- a/docs-site/docs/coding-agent/quickstart.md
+++ b/docs-site/docs/coding-agent/quickstart.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: Coding Agent 快速开始
 description: 用最短路径把 ai4j-cli 跑起来：构建 fat jar、跑通 one-shot 与持续会话，并核对 session、workspace、provider/model 状态以完成最小验证。
+tags: [how-to]
 ---
 
 # Coding Agent 快速开始

--- a/docs-site/docs/coding-agent/runtime-architecture.md
+++ b/docs-site/docs/coding-agent/runtime-architecture.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: Runtime 架构
 description: 拆解 Coding Agent runtime 的 5 层装配链（factory、builder、session、host、MCP runtime），说明每层持有什么状态、决定什么行为以及与相邻层的边界。
+tags: [concept]
 ---
 
 # Runtime 架构

--- a/docs-site/docs/coding-agent/sandbox-routing.md
+++ b/docs-site/docs/coding-agent/sandbox-routing.md
@@ -2,6 +2,7 @@
 sidebar_position: 11
 title: Sandbox Routing
 description: 说明 ai4j-coding 如何把 Coding Agent 的 bash exec 路由到 live SandboxSession（P3 首切片），覆盖当前 API、未路由的工具、与审批的关系以及非敏感 sandbox 摘要的安全边界。
+tags: [integration]
 ---
 
 # Sandbox Routing

--- a/docs-site/docs/coding-agent/session-runtime.md
+++ b/docs-site/docs/coding-agent/session-runtime.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: 会话、流式与进程
 description: 说明 Coding Agent session runtime 如何把一次本地代码任务做成可持续、可中断、可恢复的工作会话：CodingSession、outer loop、事件账本、进程面与 headless 事件流。
+tags: [concept]
 ---
 
 # 会话、流式与进程

--- a/docs-site/docs/coding-agent/skills.md
+++ b/docs-site/docs/coding-agent/skills.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: Skills 使用与组织
 description: 讲清 Skill 在 Coding Agent 里作为文件化工作流知识的真实位置：发现链路、扫描与去重规则、SKILL.md 字段解析，以及 skill 如何同时影响 prompt 与只读路径边界。
+tags: [concept]
 ---
 
 # Skills 使用与组织

--- a/docs-site/docs/coding-agent/tools-and-approvals.md
+++ b/docs-site/docs/coding-agent/tools-and-approvals.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Tools 与审批机制
 description: 拆解 Coding Agent 的内置工具(bash/read_file/write_file/apply_patch)装配与执行器路由、审批 decorator 拦截位置，以及审批与 workspace 边界为何必须分开理解。
+tags: [concept]
 ---
 
 # Tools 与审批机制

--- a/docs-site/docs/coding-agent/tui-customization.md
+++ b/docs-site/docs/coding-agent/tui-customization.md
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: TUI 定制与主题
 description: 讲清 TUI 的四层定制（config、theme、renderer、runtime）：主题查找顺序、tui.json 的文件级 override 语义、--theme 与 /theme 的区别，以及 useAlternateScreen 对 runtime backend 的影响。
+tags: [concept]
 ---
 
 # TUI 定制与主题

--- a/docs-site/docs/coding-agent/why-coding-agent.md
+++ b/docs-site/docs/coding-agent/why-coding-agent.md
@@ -1,6 +1,7 @@
 ---
 title: Why Coding Agent
 description: 解释 Coding Agent 在通用 Agent 之上叠加的 5 层本地交付语义（workspace、coding tools、多回合 loop、session/compact/restore、CLI/TUI/ACP 宿主），界定它和普通 Agent 的真实边界。
+tags: [concept]
 ---
 
 # Why Coding Agent

--- a/docs-site/docs/comparison/overview.md
+++ b/docs-site/docs/comparison/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Comparison and Positioning
 description: AI4J 与 Spring AI、LangChain4j、AgentScope Java、Pi Agent 等方案的定位对比。不做拉踩，而是讲清 AI4J 专注 Java 8+ 多模块 SDK、渐进接入能力和更轻的按需取用路径，帮你判断何时选 AI4J。
+tags: [concept]
 ---
 
 # Comparison and Positioning

--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -2,6 +2,7 @@
 sidebar_position: 14
 title: Contribute to AI4J
 description: How to contribute to AI4J — reporting issues, proposing changes, running docs-site local checks and Java module tests, and following the security disclosure policy.
+tags: [how-to]
 ---
 
 # Contribute to AI4J

--- a/docs-site/docs/core-sdk/architecture-and-module-map.md
+++ b/docs-site/docs/core-sdk/architecture-and-module-map.md
@@ -1,6 +1,7 @@
 ---
 title: Architecture and Module Map
 description: 把 AI4J 仓库的 Maven 模块主线、依赖方向和代码定位入口落到真实工程上，帮助你在读源码或评估模块边界时找到正确落点。
+tags: [concept]
 ---
 
 # Architecture and Module Map

--- a/docs-site/docs/core-sdk/audio.md
+++ b/docs-site/docs/core-sdk/audio.md
@@ -2,6 +2,7 @@
 sidebar_position: 31
 title: Audio 接口
 description: 介绍 AI4J 音频 service 面：TTS、转录、翻译的统一入口、OpenAI 实现、请求对象校验以及资源与失败语义等接入要点。
+tags: [concept]
 ---
 
 # Audio 接口

--- a/docs-site/docs/core-sdk/extension/ask-user-plugin.md
+++ b/docs-site/docs/core-sdk/extension/ask-user-plugin.md
@@ -1,6 +1,7 @@
 ---
 title: Ask User Plugin
 description: 讲清 ai4j-plugin-ask-user 样板插件：它把 Agent 需要的人类确认表达成 host-mediated JSON envelope，贡献 ask_user tool 与 command/Skill/Prompt 资源，本身不打开 UI、不读 stdin、不阻塞，由宿主决定展示与恢复。
+tags: [integration]
 ---
 
 # Ask User Plugin

--- a/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
+++ b/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
@@ -1,6 +1,7 @@
 ---
 title: Dynamic Workflow Plugin
 description: 讲清 ai4j-plugin-dynamic-workflow 样板插件：模型把复杂任务写成确定性 workflow script，插件只返回 host-mediated 请求 envelope，实际执行由 ai4j-agent runtime 可选接管，内置 Nashorn 执行器默认关闭 Java interop。
+tags: [integration]
 ---
 
 # Dynamic Workflow Plugin

--- a/docs-site/docs/core-sdk/extension/model-extension.md
+++ b/docs-site/docs/core-sdk/extension/model-extension.md
@@ -1,6 +1,7 @@
 ---
 title: Model Extension
 description: 讲清 AI4J model extension：在不新增 PlatformType 的前提下，把新模型能力吸收进现有 provider 与现有契约，主战场是请求对象和 provider 适配层，强调把 provider 差异收敛在 provider service 内部而非泄漏到业务层。
+tags: [concept]
 ---
 
 # Model Extension

--- a/docs-site/docs/core-sdk/extension/overview.md
+++ b/docs-site/docs/core-sdk/extension/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Extension 总览
 description: 建立 AI4J 扩展面心智：provider/service 走 PlatformType+AiService+Registry 代码主链，HTTP 并发与连接治理走底层 SPI，第三方插件包走 ai4j-extension-api+ServiceLoader+ExtensionRegistry，扩展面并不对称。
+tags: [concept]
 ---
 
 # Extension 总览

--- a/docs-site/docs/core-sdk/extension/plugin-author-cookbook.md
+++ b/docs-site/docs/core-sdk/extension/plugin-author-cookbook.md
@@ -1,6 +1,7 @@
 ---
 title: Plugin Author Cookbook
 description: 面向第三方插件作者的动手指南：用 CLI 生成最小插件项目，稳定 manifest 与公共 ID 命名规则，写结构化 tool input schema，把 apply() 保持为轻量注册函数，完成 manifest/资源/schema 校验与发布前声明。
+tags: [how-to]
 ---
 
 # Plugin Author Cookbook

--- a/docs-site/docs/core-sdk/extension/plugin-packages.md
+++ b/docs-site/docs/core-sdk/extension/plugin-packages.md
@@ -1,6 +1,7 @@
 ---
 title: Plugin Packages
 description: 讲清 AI4J plugin package：第三方 jar + ServiceLoader 发现 + ExtensionRegistry 三段式门禁 discover/enable/exposeTool，区分 tool/command/Skill/Prompt/Guardrail 资源进入方式，默认不自动暴露工具给模型。
+tags: [concept]
 ---
 
 # Plugin Packages

--- a/docs-site/docs/core-sdk/extension/plugin-recipes.md
+++ b/docs-site/docs/core-sdk/extension/plugin-recipes.md
@@ -1,6 +1,7 @@
 ---
 title: Plugin Recipes
 description: 插件使用者的组装配方：jar 进 classpath 后如何用 CLI plan/check 做接入前检查，按 Java、Spring Boot、Agent、Coding Agent、多插件组合分别给出 enable/allow/expose 配置，区分 command 与 tool 暴露语义。
+tags: [how-to]
 ---
 
 # Plugin Recipes

--- a/docs-site/docs/core-sdk/extension/provider-extension.md
+++ b/docs-site/docs/core-sdk/extension/provider-extension.md
@@ -1,6 +1,7 @@
 ---
 title: Provider Extension
 description: 讲清 AI4J provider extension：新增模型平台是显式工厂分发扩展，必须同时触碰 PlatformType、Configuration、AiService、DefaultAiServiceRegistry 与 Spring Boot starter，provider 支持矩阵显式维护而非自动发现。
+tags: [concept]
 ---
 
 # Provider Extension

--- a/docs-site/docs/core-sdk/extension/service-extension.md
+++ b/docs-site/docs/core-sdk/extension/service-extension.md
@@ -1,6 +1,7 @@
 ---
 title: Service Extension
 description: 讲清 AI4J service extension：新增顶层能力契约会扩大整个 SDK 公共 API 面，必须同步 AiService、AiServiceRegistry 与 FreeAiService 兼容入口，AiServiceFactory 不是 service 插件总线，仅在现有契约无法承载时才值得新增。
+tags: [concept]
 ---
 
 # Service Extension

--- a/docs-site/docs/core-sdk/extension/spi-http-stack.md
+++ b/docs-site/docs/core-sdk/extension/spi-http-stack.md
@@ -1,6 +1,7 @@
 ---
 title: SPI HTTP Stack
 description: 讲清 AI4J HTTP stack SPI：通过 ServiceLoader 把 Dispatcher 与 ConnectionPool 注入 starter 构造的统一 OkHttpClient，默认实现靠 META-INF/services 注册，丢失会导致启动失败，仅 starter 装配链自动生效。
+tags: [concept]
 ---
 
 # SPI HTTP Stack

--- a/docs-site/docs/core-sdk/image-generation.md
+++ b/docs-site/docs/core-sdk/image-generation.md
@@ -2,6 +2,7 @@
 sidebar_position: 32
 title: Image 接口（生成与流式）
 description: 讲解 IImageService 图像生成与流式监听用法，覆盖 OpenAI 与豆包适配、请求字段、事件模型和常见接入问题。
+tags: [how-to]
 ---
 
 # Image 接口（生成与流式）

--- a/docs-site/docs/core-sdk/mcp/protocol-capabilities.md
+++ b/docs-site/docs/core-sdk/mcp/protocol-capabilities.md
@@ -1,6 +1,7 @@
 ---
 title: Protocol Capabilities
 description: 讲清 AI4J MCP 协议面：服务端支持 tools/resources/prompts 三类 capability 与 list_changed 通知，legacy profile 需 initialize 握手而现代 Streamable HTTP 无状态，transport 会影响 capability 边界。
+tags: [concept]
 ---
 
 # Protocol Capabilities

--- a/docs-site/docs/core-sdk/memory/chat-memory.md
+++ b/docs-site/docs/core-sdk/memory/chat-memory.md
@@ -1,6 +1,7 @@
 ---
 title: "Chat Memory"
 description: "深入 ChatMemory 契约：ChatMemoryItem 承载多模态与工具事实、InMemory 与 Jdbc 两种存储、窗口与摘要策略、快照恢复，及投影到 Chat 与 Responses 的共享基座。"
+tags: [concept]
 ---
 
 # Chat Memory

--- a/docs-site/docs/core-sdk/memory/memory-and-tool-boundaries.md
+++ b/docs-site/docs/core-sdk/memory/memory-and-tool-boundaries.md
@@ -1,6 +1,7 @@
 ---
 title: "Memory and Tool Boundaries"
 description: "厘清 ChatMemory、Tool、MCP 三层职责边界：memory 只保存会话事实，工具审批与副作用治理归 runtime；说明为何不该把执行控制耦合进 memory 抽象。"
+tags: [concept]
 ---
 
 # Memory and Tool Boundaries

--- a/docs-site/docs/core-sdk/memory/overview.md
+++ b/docs-site/docs/core-sdk/memory/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "Memory 总览"
 description: "总览 AI4J Core SDK 会话事实层：ChatMemory 记录多轮对话与工具结果，存储与裁剪策略分离，可同时投影为 Chat 与 Responses 输入，支持快照恢复与摘要压缩。"
+tags: [concept]
 ---
 
 # Memory 总览

--- a/docs-site/docs/core-sdk/model-access/chat-vs-responses.md
+++ b/docs-site/docs/core-sdk/model-access/chat-vs-responses.md
@@ -1,6 +1,7 @@
 ---
 title: Chat vs Responses
 description: 从输入心智、provider 覆盖、工具集成、流式语义和多模态投影等维度对比 Chat 与 Responses 两条主线，帮你完成选型。
+tags: [concept]
 ---
 
 # Chat vs Responses

--- a/docs-site/docs/core-sdk/model-access/chat.md
+++ b/docs-site/docs/core-sdk/model-access/chat.md
@@ -1,6 +1,7 @@
 ---
 title: Chat
 description: 解析 AI4J Chat 主线的请求对象、自动 tool loop、passThroughToolCalls、SseListener 流式聚合和多模态接入等运行时行为。
+tags: [concept]
 ---
 
 # Chat

--- a/docs-site/docs/core-sdk/model-access/messages.md
+++ b/docs-site/docs/core-sdk/model-access/messages.md
@@ -1,6 +1,7 @@
 ---
 title: Messages（Anthropic 原生）
 description: 讲解 IMessagesService 原生 Anthropic 协议主线：原生 in/out 零转换、coding-plan 接入、thinking 映射、鉴权与异常处理。
+tags: [concept]
 ---
 
 # Messages（Anthropic 原生）

--- a/docs-site/docs/core-sdk/model-access/multimodal.md
+++ b/docs-site/docs/core-sdk/model-access/multimodal.md
@@ -1,6 +1,7 @@
 ---
 title: Multimodal
 description: 说明图文输入如何作为会话事实经 ChatMemoryItem 投影到 Chat 与 Responses 两条主线，区分模型原生输入与外部视觉工具。
+tags: [concept]
 ---
 
 # Multimodal

--- a/docs-site/docs/core-sdk/model-access/overview.md
+++ b/docs-site/docs/core-sdk/model-access/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Model Access 总览
 description: 总览模型请求在 AI4J 基座里如何被建模、投影、发送、流式消费和回读，厘清 Chat、Responses、Messages 三条主线的边界。
+tags: [concept]
 ---
 
 # Model Access 总览

--- a/docs-site/docs/core-sdk/model-access/request-and-response-conventions.md
+++ b/docs-site/docs/core-sdk/model-access/request-and-response-conventions.md
@@ -1,6 +1,7 @@
 ---
 title: Request and Response Conventions
 description: 统一讲解请求构造与返回读取约定，区分本地注册字段与 provider payload 字段、extraBody 角色及常见接入误区。
+tags: [concept]
 ---
 
 # Request and Response Conventions

--- a/docs-site/docs/core-sdk/model-access/responses.md
+++ b/docs-site/docs/core-sdk/model-access/responses.md
@@ -1,6 +1,7 @@
 ---
 title: Responses
 description: 解析 AI4J Responses 主线的 ResponseRequest 语义、工具解析基座、payload 构建、流式事件聚合与 runtime 友好的运行模型。
+tags: [concept]
 ---
 
 # Responses

--- a/docs-site/docs/core-sdk/model-access/streaming.md
+++ b/docs-site/docs/core-sdk/model-access/streaming.md
@@ -1,6 +1,7 @@
 ---
 title: Streaming
 description: 讲解 Chat 与 Responses 两条流式主线的聚合模型：SseListener 与 ResponseSseListener 维护的状态、tool call 聚合与终止条件差异。
+tags: [concept]
 ---
 
 # Streaming

--- a/docs-site/docs/core-sdk/overview.md
+++ b/docs-site/docs/core-sdk/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Core SDK 总览
 description: 总览 ai4j 基座能力线：模型访问、Tool、Skill、MCP、Memory、RAG 与扩展，帮你选择第一条主线并理解与上层模块的关系。
+tags: [concept]
 ---
 
 # Core SDK 总览

--- a/docs-site/docs/core-sdk/package-map.md
+++ b/docs-site/docs/core-sdk/package-map.md
@@ -1,6 +1,7 @@
 ---
 title: Package Map
 description: 用包簇心智模型梳理 ai4j 模块源码分层，指明主能力面与支撑层包的职责，并给出读源码的推荐顺序。
+tags: [concept]
 ---
 
 # Package Map

--- a/docs-site/docs/core-sdk/platform-service-matrix.md
+++ b/docs-site/docs/core-sdk/platform-service-matrix.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: 平台与服务矩阵
 description: 以 AiService 实现为准列出各 provider 对 Chat、Responses、Messages、Embedding、Rerank、Audio、Realtime、Image 的支持矩阵。
+tags: [reference]
 ---
 
 # 平台与服务矩阵

--- a/docs-site/docs/core-sdk/realtime.md
+++ b/docs-site/docs/core-sdk/realtime.md
@@ -2,6 +2,7 @@
 sidebar_position: 33
 title: Realtime 接口（WebSocket）
 description: 讲解 IRealtimeService 长连接能力面：当前仅支持 OpenAI，统一入口、默认鉴权头、WebSocket 建连主线及回调注意事项。
+tags: [concept]
 ---
 
 # Realtime 接口（WebSocket）

--- a/docs-site/docs/core-sdk/search-and-rag/chunking-strategies.md
+++ b/docs-site/docs/core-sdk/search-and-rag/chunking-strategies.md
@@ -1,6 +1,7 @@
 ---
 title: Chunking Strategies
 description: 讲清 AI4J 默认 RecursiveTextChunker 的真实行为与边界：它只填充 documentId/content/chunkIndex，不自动生成 chunkId、页码或章节元数据，以及 chunk 边界稳定性如何决定后续检索去重与引用质量。
+tags: [concept]
 ---
 
 # Chunking Strategies

--- a/docs-site/docs/core-sdk/search-and-rag/citations-and-trace.md
+++ b/docs-site/docs/core-sdk/search-and-rag/citations-and-trace.md
@@ -1,6 +1,7 @@
 ---
 title: Citations and Trace
 description: 区分 AI4J 的 citation 与 trace 两条链：citation 由 DefaultRagContextAssembler 基于最终命中生成，trace 记录检索与 rerank 中间状态，generation usage 与 judge 分数需上层显式回填。
+tags: [concept]
 ---
 
 # Citations and Trace

--- a/docs-site/docs/core-sdk/search-and-rag/embedding.md
+++ b/docs-site/docs/core-sdk/search-and-rag/embedding.md
@@ -1,6 +1,7 @@
 ---
 title: Embedding
 description: 讲清 AI4J embedding 层的薄接口与强约束：它统一 provider 调用但只支持 OPENAI/OLLAMA，ingest 与 query 必须使用同一模型，混用不会被框架自动阻止，是索引级协议的一部分。
+tags: [concept]
 ---
 
 # Embedding

--- a/docs-site/docs/core-sdk/search-and-rag/hybrid-retrieval.md
+++ b/docs-site/docs/core-sdk/search-and-rag/hybrid-retrieval.md
@@ -1,6 +1,7 @@
 ---
 title: Hybrid Retrieval
 description: 讲清 AI4J HybridRetriever 的本质是多检索器结果融合器而非固定 Dense+BM25 套餐：默认 RRF 按排名融合，用稳定 key 去重，融合后 score 语义变化以及无 getHybridRagService 便利入口的设计原因。
+tags: [concept]
 ---
 
 # Hybrid Retrieval

--- a/docs-site/docs/core-sdk/search-and-rag/ingestion-pipeline.md
+++ b/docs-site/docs/core-sdk/search-and-rag/ingestion-pipeline.md
@@ -1,6 +1,7 @@
 ---
 title: Ingestion Pipeline
 description: 讲清 AI4J IngestionPipeline 这条 RAG 入库编排层：source 加载、文本清洗、chunk、metadata 富化、批量 embedding 与 vector upsert 如何串成统一流水线，以及 documentId/contentHash 稳定性与可插拔扩展位点。
+tags: [concept]
 ---
 
 # Ingestion Pipeline

--- a/docs-site/docs/core-sdk/search-and-rag/online-search.md
+++ b/docs-site/docs/core-sdk/search-and-rag/online-search.md
@@ -1,6 +1,7 @@
 ---
 title: Online Search
 description: 讲清 AI4J Online Search 的真实定位：它不是统一检索框架，而是包裹 IChatService 的联网搜索增强层，用最后一条消息做 query 调 SearXNG，把结果 JSON 直接拼进用户 prompt，并会原地改写请求。
+tags: [concept]
 ---
 
 # Online Search

--- a/docs-site/docs/core-sdk/search-and-rag/overview.md
+++ b/docs-site/docs/core-sdk/search-and-rag/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Search and RAG 总览
 description: 建立 AI4J Search & RAG 的源码心智：离线私域路线 IngestionPipeline→VectorStore→Retriever→Reranker→ContextAssembler 与在线公网路线 ChatWithWebSearchEnhance 两条并行边界，以及默认骨架与可选增强的区别。
+tags: [concept]
 ---
 
 # Search and RAG 总览

--- a/docs-site/docs/core-sdk/search-and-rag/query-planning.md
+++ b/docs-site/docs/core-sdk/search-and-rag/query-planning.md
@@ -1,6 +1,7 @@
 ---
 title: Query Planning
 description: 讲清 AI4J RagQueryPlanner 检索前处理层：它在 Retriever 之前产出 rewrite/multi-query/HyDE/step-back 检索计划，多 variant 用 RRF 融合，rerank 与上下文组装仍回原 query，planner 异常自动回退。
+tags: [concept]
 ---
 
 # Query Planning

--- a/docs-site/docs/core-sdk/search-and-rag/rerank.md
+++ b/docs-site/docs/core-sdk/search-and-rag/rerank.md
@@ -1,6 +1,7 @@
 ---
 title: Rerank
 description: 讲清 AI4J rerank 层：它夹在 retrieval 与 context assembly 之间做排序修正，默认 NoopReranker 不远程重排，ModelReranker 靠 provider 返回 index 映射，finalTopK 在 rerank 之后裁剪，returnDocuments 可能改写命中内容。
+tags: [concept]
 ---
 
 # Rerank

--- a/docs-site/docs/core-sdk/search-and-rag/vector-store-and-backends.md
+++ b/docs-site/docs/core-sdk/search-and-rag/vector-store-and-backends.md
@@ -1,6 +1,7 @@
 ---
 title: Vector Store and Backends
 description: 讲清 AI4J VectorStore 统一契约如何收口 Pinecone/Qdrant/Milvus/PgVector/Redis 五个后端：dataset 是硬边界，capabilities() 显式暴露 returnStoredVector/metadataLookup 差异，统一调用但不抹平存储现实。
+tags: [concept]
 ---
 
 # Vector Store and Backends

--- a/docs-site/docs/core-sdk/service-entry-and-registry.md
+++ b/docs-site/docs/core-sdk/service-entry-and-registry.md
@@ -1,6 +1,7 @@
 ---
 title: Service Entry and Registry
 description: 厘清 AiService 单实例入口与 AiServiceRegistry 多实例注册表的真实职责、配置回退和扩展边界。
+tags: [concept]
 ---
 
 # Service Entry and Registry

--- a/docs-site/docs/core-sdk/skills/discovery-and-loading.md
+++ b/docs-site/docs/core-sdk/skills/discovery-and-loading.md
@@ -1,6 +1,7 @@
 ---
 title: "Discovery and Loading"
 description: "详解 Skills 发现与加载：扫描工作区与全局根目录、识别 SKILL.md、提取名称描述、按名去重，以及 allowedReadRoots 如何把 skill 目录联动进宿主只读安全边界。"
+tags: [concept]
 ---
 
 # Discovery and Loading

--- a/docs-site/docs/core-sdk/skills/overview.md
+++ b/docs-site/docs/core-sdk/skills/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "Skills 总览"
 description: "总览 AI4J Skills 方法论与上下文治理层：发现 SKILL.md、生成技能目录、按需懒加载正文并将 skill roots 纳入只读边界，厘清 Skill 与 Tool、MCP 的职责分工。"
+tags: [concept]
 ---
 
 # Skills 总览

--- a/docs-site/docs/core-sdk/skills/skill-vs-tool-vs-mcp.md
+++ b/docs-site/docs/core-sdk/skills/skill-vs-tool-vs-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: "Skill vs Tool vs MCP"
 description: "用定义、对比表与源码入口区分 AI4J 三大基座概念：Skill 管方法论上下文、Tool 管宿主内执行、MCP 管外部协议接入，澄清投影与归属的常见混淆。"
+tags: [concept]
 ---
 
 # Skill vs Tool vs MCP

--- a/docs-site/docs/core-sdk/strengths-and-differentiators.md
+++ b/docs-site/docs/core-sdk/strengths-and-differentiators.md
@@ -1,6 +1,7 @@
 ---
 title: Strengths and Differentiators
 description: 从能力统一、边界清晰、provider 非对称、向上演进路径等维度说明 AI4J 作为 Java AI 基座的差异点与适用场景。
+tags: [concept]
 ---
 
 # Strengths and Differentiators

--- a/docs-site/docs/core-sdk/tools/annotation-based-tools.md
+++ b/docs-site/docs/core-sdk/tools/annotation-based-tools.md
@@ -1,6 +1,7 @@
 ---
 title: "Annotation-based Tools"
 description: "深入 @FunctionCall、@FunctionRequest、@FunctionParameter 三注解如何把 Java 类型绑定为 provider tool schema，详解 ToolUtil 生成链、类型映射规则与真实约束。"
+tags: [concept]
 ---
 
 # Annotation-based Tools

--- a/docs-site/docs/core-sdk/tools/function-calling.md
+++ b/docs-site/docs/core-sdk/tools/function-calling.md
@@ -1,6 +1,7 @@
 ---
 title: "Function Calling"
 description: "讲清 AI4J 基座层 Function Calling 执行链：用注解声明工具、ToolUtil 按白名单生成 provider tool schema、请求挂载与 tool call 回流，及其与 MCP、Agent 的边界。"
+tags: [concept]
 ---
 
 # Function Calling

--- a/docs-site/docs/core-sdk/tools/overview.md
+++ b/docs-site/docs/core-sdk/tools/overview.md
@@ -1,6 +1,7 @@
 ---
 title: "Tools 总览"
 description: "解析 AI4J 工具子系统四层结构：工具声明、请求级白名单、provider schema 投影与本地执行回流，阐明 ToolUtil 作为调度中心的完整执行链与能力边界。"
+tags: [concept]
 ---
 
 # Tools 总览

--- a/docs-site/docs/core-sdk/tools/tool-execution-model.md
+++ b/docs-site/docs/core-sdk/tools/tool-execution-model.md
@@ -1,6 +1,7 @@
 ---
 title: "Tool Execution Model"
 description: "拆解 AI4J 工具执行模型四段链：发现注册、请求级白名单、provider 返回 tool call、本地调用路由与执行，讲清 built-in/Function/MCP 优先级与结果文本化回流。"
+tags: [concept]
 ---
 
 # Tool Execution Model

--- a/docs-site/docs/core-sdk/tools/tool-whitelist-and-security.md
+++ b/docs-site/docs/core-sdk/tools/tool-whitelist-and-security.md
@@ -1,6 +1,7 @@
 ---
 title: "Tool Whitelist and Security"
 description: "讲清 AI4J 工具安全两层防线：请求级 functions/mcpServices 白名单与 BuiltInToolContext 工作区读写边界，剖析 bash 等高风险 built-in 与待补的审批沙箱治理。"
+tags: [concept]
 ---
 
 # Tool Whitelist and Security

--- a/docs-site/docs/deploy/cloudflare-pages.md
+++ b/docs-site/docs/deploy/cloudflare-pages.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Cloudflare Pages 部署
 description: AI4J 文档站推荐部署方案：Docusaurus + Cloudflare Pages + 自定义域名。覆盖 GitHub 集成自动构建、全球 CDN 分发、免费额度、自定义域名配置与持续发布流程。
+tags: [how-to]
 ---
 
 # Cloudflare Pages 部署

--- a/docs-site/docs/faq.md
+++ b/docs-site/docs/faq.md
@@ -2,6 +2,7 @@
 sidebar_position: 998
 title: FAQ
 description: AI4J 文档站常见问题收敛：第一次该看哪里、SDK 与 AI 基座的关系，以及 Chat/Responses、Function Call/Tool、MCP/Agent、Skill/Tool、ACP/MCP 等概念辨析与路径判断。
+tags: [reference]
 ---
 
 # FAQ

--- a/docs-site/docs/flowgram/agent-tool-knowledge-integration.md
+++ b/docs-site/docs/flowgram/agent-tool-knowledge-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: Agent、Tool、知识库与 MCP 接入
 description: 讲清 Flowgram 当前已内置的能力接法（LLM/TOOL/KNOWLEDGE）与只能扩展的能力（Agent/MCP 无内置专属节点），给出 Tool 节点复用工具总线、KNOWLEDGE 复用 RAG 抽象的真实链路。
+tags: [concept]
 ---
 
 # Agent、Tool、知识库与 MCP 接入

--- a/docs-site/docs/flowgram/api-and-runtime.md
+++ b/docs-site/docs/flowgram/api-and-runtime.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: Flowgram API 与运行时
 description: 面向外部调用者的 task 控制面 contract：validate/run/report/result/cancel 五个 HTTP 入口、DTO 经 adapter 与 facade 的变形，以及真正改变外部行为的配置项。
+tags: [reference]
 ---
 
 # Flowgram API 与运行时

--- a/docs-site/docs/flowgram/architecture.md
+++ b/docs-site/docs/flowgram/architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Flowgram Architecture
 description: 拆解 Flowgram 前端画布加 AI4J 后端执行层的四层架构：画布、适配、Spring Boot 平台接入与执行引擎，讲清编辑态与执行态 schema 的差异和默认安全姿态。
+tags: [concept]
 ---
 
 # Flowgram Architecture

--- a/docs-site/docs/flowgram/built-in-nodes.md
+++ b/docs-site/docs/flowgram/built-in-nodes.md
@@ -1,6 +1,7 @@
 ---
 title: Built-in Nodes
 description: 区分 Flowgram runtime 内核节点（START/END/LLM/CONDITION/LOOP）与 starter 注册的 executor 节点（HTTP/VARIABLE/CODE/TOOL/KNOWLEDGE），讲清共享值解析模型与各节点输入输出。
+tags: [concept]
 ---
 
 # Built-in Nodes

--- a/docs-site/docs/flowgram/custom-node-extension.md
+++ b/docs-site/docs/flowgram/custom-node-extension.md
@@ -2,6 +2,7 @@
 sidebar_position: 13
 title: Flowgram 自定义节点扩展
 description: 只讲后端 executor 这一半：FlowGramNodeExecutor 接口、runtime 识别与注册时机、getType 协议名稳定性、execute 前 runtime 已完成的输入解析与上下文字段。
+tags: [how-to]
 ---
 
 # Flowgram 自定义节点扩展

--- a/docs-site/docs/flowgram/custom-nodes.md
+++ b/docs-site/docs/flowgram/custom-nodes.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Nodes
 description: 自定义节点是把能力正式接入 Flowgram 前后端执行契约：后端 FlowGramNodeExecutor 扩展点、getType 协议名、输入输出 contract 稳定性原则与前后端协同三件事。
+tags: [how-to]
 ---
 
 # Custom Nodes

--- a/docs-site/docs/flowgram/frontend-backend-integration.md
+++ b/docs-site/docs/flowgram/frontend-backend-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: 前端画布与后端 Runtime 对接
 description: Flowgram.ai 画布与 AI4J Java 后端执行层对齐的三个契约：workflow schema、task lifecycle、report/result/trace 读侧，讲清 schema 归一化、轮询与权限接入点。
+tags: [concept]
 ---
 
 # 前端画布与后端 Runtime 对接

--- a/docs-site/docs/flowgram/frontend-custom-node-development.md
+++ b/docs-site/docs/flowgram/frontend-custom-node-development.md
@@ -2,6 +2,7 @@
 sidebar_position: 12
 title: 前端自定义节点开发
 description: 在 ai4j-flowgram-webapp-demo 里把新节点做成可编辑、可校验、可序列化、可映射到后端的前端节点：type 枚举、FlowNodeRegistry、onAdd schema 工厂与 backend type 映射。
+tags: [how-to]
 ---
 
 # 前端自定义节点开发

--- a/docs-site/docs/flowgram/overview.md
+++ b/docs-site/docs/flowgram/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: FlowGram 总览
 description: AI4J FlowGram 是围绕 FlowGram.ai 画布的 Java 后端执行层，把前端画出的工作流图转换成可验证、可运行、可取消、可观测的异步 task。
+tags: [concept]
 ---
 
 # FlowGram 总览

--- a/docs-site/docs/flowgram/quickstart.md
+++ b/docs-site/docs/flowgram/quickstart.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: Agentic 工作流平台快速开始
 description: 最短路径确认 starter 装配、task API 暴露、无 LLM 与带 LLM 两条最小流程跑通 validate -> run -> result -> report 链路，附 demo 默认模型配置踩坑与排障顺序。
+tags: [how-to]
 ---
 
 # Agentic 工作流平台快速开始

--- a/docs-site/docs/flowgram/runtime.md
+++ b/docs-site/docs/flowgram/runtime.md
@@ -1,6 +1,7 @@
 ---
 title: Flowgram Runtime
 description: Flowgram 后端执行真相：FlowGramRuntimeService 把 workflow schema 变成异步任务，节点图变成有状态执行链，节点输出变成 report/result/trace 读侧结构。
+tags: [concept]
 ---
 
 # Flowgram Runtime

--- a/docs-site/docs/flowgram/use-cases-and-paths.md
+++ b/docs-site/docs/flowgram/use-cases-and-paths.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: Flowgram 使用路径与场景选择
 description: 按任务目标给出 Flowgram 的五条进入路径，并对比何时选 Flowgram、Agent、Coding Agent 或 MCP，附推荐演进顺序、常见误判与按角色的最短阅读路径。
+tags: [concept]
 ---
 
 # Flowgram 使用路径与场景选择

--- a/docs-site/docs/flowgram/why-flowgram.md
+++ b/docs-site/docs/flowgram/why-flowgram.md
@@ -1,6 +1,7 @@
 ---
 title: Why Flowgram
 description: Flowgram 存在的价值：补上 Agent 给不了的平台化后端结构——工作流契约、任务生命周期、节点执行边界与面向平台的读侧输出，同时讲清当前边界与适用场景。
+tags: [concept]
 ---
 
 # Why Flowgram

--- a/docs-site/docs/flowgram/workflow-execution-pipeline.md
+++ b/docs-site/docs/flowgram/workflow-execution-pipeline.md
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: 前端工作流如何在后端执行
 description: 把一条 workflow 从编辑态到执行态的完整管线拆成六个 stage：JSON 导出、归一化、runtime plugin 调用编排、controller/facade/runtime 分层执行与读侧投影。
+tags: [concept]
 ---
 
 # 前端工作流如何在后端执行

--- a/docs-site/docs/glossary.md
+++ b/docs-site/docs/glossary.md
@@ -2,6 +2,7 @@
 sidebar_position: 999
 title: 术语表
 description: AI4J 文档核心术语统一表：定义 Agent、AiService、Chat、Coding Agent、Function Call、MCP、Memory、Skill、Responses、Tool Registry 等关键概念，避免跨专题混淆。
+tags: [reference]
 ---
 
 # 术语表

--- a/docs-site/docs/guides/blog-migration-map.md
+++ b/docs-site/docs/guides/blog-migration-map.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: 历史博客迁移映射
 description: 把 AI4J 历史 CSDN 博客文章映射到结构化文档，方便持续维护与版本同步。覆盖 Spring Boot + OpenAI 快速接入、DeepSeek/Qwen/Llama 本地模型接入等历史内容与对应新文档路径。
+tags: [reference]
 ---
 
 # 历史博客迁移映射

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: AI4J 文档中心
 description: AI4J 是面向 Java 8+ 的 AI SDK 入口：按需取用的模型调用、工具、RAG、MCP、Spring Boot、Agent、Coding Agent 与 FlowGram building blocks 的总览、推荐起点与仓库模块地图。
+tags: [concept]
 ---
 
 # AI4J 文档中心

--- a/docs-site/docs/mcp/build-your-mcp-server.md
+++ b/docs-site/docs/mcp/build-your-mcp-server.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: 构建并对外发布 MCP Server
 description: 讲解 AI4J 如何用 @McpService/@McpTool 注解、adapter 和 McpServerEngine 把 Java 能力发布成 MCP Server，覆盖 Tool/Resource/Prompt 三类能力链与三种服务端 transport 的真实差异。
+tags: [how-to]
 ---
 
 # 构建并对外发布 MCP Server

--- a/docs-site/docs/mcp/client-integration.md
+++ b/docs-site/docs/mcp/client-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: MCP Client 接入（单服务模式）
 description: 聚焦单服务模式：McpClient 的真实生命周期、connect() 与 AUTO/legacy profile 的差异、缓存与心跳重连语义，以及 callTool 的失败语义和常见排障路径。
+tags: [how-to]
 ---
 
 # MCP Client 接入（单服务模式）

--- a/docs-site/docs/mcp/configuration-and-gateway-reference.md
+++ b/docs-site/docs/mcp/configuration-and-gateway-reference.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: MCP 配置与网关参考
 description: 区分 mcp-servers-config.json 里哪些字段真正进入 transport/client/gateway 运行时，哪些只是治理元数据，避免把字段存在误写成能力已生效。
+tags: [reference]
 ---
 
 # MCP 配置与网关参考

--- a/docs-site/docs/mcp/gateway-management.md
+++ b/docs-site/docs/mcp/gateway-management.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: MCP Gateway 管理（多服务聚合与治理）
 description: McpGateway 作为多服务 MCP 运行时的真实职责：key 规则多租户隔离、tool registry 映射、配置源热更新与动态增删的重建式目录更新策略。
+tags: [concept]
 ---
 
 # MCP Gateway 管理（多服务聚合与治理）

--- a/docs-site/docs/mcp/mcp-agent-end-to-end.md
+++ b/docs-site/docs/mcp/mcp-agent-end-to-end.md
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: MCP 与 Agent 一体化实战（端到端）
 description: 拆开第三方 MCP 从配置文件一路进入 Agent 推理循环并被模型调用的 7 层执行链，覆盖投影、调用分发、多租户回退与 trace 诊断点。
+tags: [how-to]
 ---
 
 # MCP 与 Agent 一体化实战（端到端）

--- a/docs-site/docs/mcp/mysql-dynamic-datasource.md
+++ b/docs-site/docs/mcp/mysql-dynamic-datasource.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: MySQL 动态 MCP 服务管理
 description: AI4J 未内置 MySQL 配置中心，但预留了 McpConfigSource 与 McpGatewayConfigSourceBinding 扩展点；本页讲如何实现数据库配置源并补齐命名、密钥、审计治理。
+tags: [integration]
 ---
 
 # MySQL 动态 MCP 服务管理

--- a/docs-site/docs/mcp/overview.md
+++ b/docs-site/docs/mcp/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: MCP 总览
 description: AI4J 把 MCP 做成覆盖 client、transport、gateway、server 四个平面的能力连接子系统，而不是单一工具接入选项。本页给出整体地图与推荐阅读顺序。
+tags: [concept]
 ---
 
 # MCP 总览

--- a/docs-site/docs/mcp/streamable-http.md
+++ b/docs-site/docs/mcp/streamable-http.md
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: Streamable HTTP
 description: "Streamable HTTP transport for AI4J MCP: AUTO profile discovery, modern vs initialization-era peers, protocol headers, publishing a server, and upgrade paths."
+tags: [integration]
 ---
 
 # Streamable HTTP

--- a/docs-site/docs/mcp/third-party-mcp-integration.md
+++ b/docs-site/docs/mcp/third-party-mcp-integration.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: 接入第三方 MCP（全部方式）
 description: 把第三方 MCP 在 AI4J 里的 5 种集成深度拆开：单 client 直连、配置驱动 gateway、运行时动态增删、用户级隔离与 Agent 暴露白名单，附常见踩坑。
+tags: [integration]
 ---
 
 # 接入第三方 MCP（全部方式）

--- a/docs-site/docs/mcp/tool-exposure-semantics.md
+++ b/docs-site/docs/mcp/tool-exposure-semantics.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Tool 暴露语义与安全边界
 description: 讲清 MCP 工具暴露的安全边界：getAllTools 显式白名单与 getLocalMcpTools 本地枚举是两套语义，调用优先级与暴露面也是两套逻辑，附代码审查清单。
+tags: [concept]
 ---
 
 # Tool 暴露语义与安全边界

--- a/docs-site/docs/mcp/transport-types.md
+++ b/docs-site/docs/mcp/transport-types.md
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: MCP 传输类型详解（STDIO / SSE / Streamable HTTP）
 description: 对比 STDIO、SSE、Streamable HTTP 三种 MCP transport 的适用场景、优缺点与默认连接行为，讲清 TransportConfig 统一配置平面与选型责任归属。
+tags: [concept]
 ---
 
 # MCP 传输类型详解（STDIO / SSE / Streamable HTTP）

--- a/docs-site/docs/mcp/use-cases-and-paths.md
+++ b/docs-site/docs/mcp/use-cases-and-paths.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: MCP 使用路径与场景选择
 description: 按"要解决的问题"把 MCP 拆成三条路线：接一个现成 MCP、治理多个 MCP、把自己的 Java 能力发布成 MCP，给出每条路线的关键对象与阅读顺序。
+tags: [concept]
 ---
 
 # MCP 使用路径与场景选择

--- a/docs-site/docs/migration/overview.md
+++ b/docs-site/docs/migration/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Migration Guide
 description: AI4J 文档站从旧 getting-started/ai-basics/guides 结构收敛到按模块组织的 canonical 结构。说明迁移规则：不直接删除强内容、先迁稳定结论、加 legacy notice、以 sidebar 为正式阅读路径。
+tags: [reference]
 ---
 
 # Migration Guide

--- a/docs-site/docs/operations/production-checklist.md
+++ b/docs-site/docs/operations/production-checklist.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Production Checklist
 description: AI4J 接入真实项目前的上线检查清单。不要求一次性启用所有能力，而是按已使用的模块确认风险边界：最小模块选择、密钥管理、网络隔离、Tool 暴露、本地文件边界。
+tags: [reference]
 ---
 
 # Production Checklist

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -2,6 +2,7 @@
 title: API Reference
 sidebar_position: 1
 description: Versioned Javadoc entry points for each AI4J Maven module, indexed by capability for Core SDK, Agent, Coding Agent, and extension SPI Java types and signatures.
+tags: [reference]
 ---
 
 # API Reference

--- a/docs-site/docs/reference/release-and-artifacts.md
+++ b/docs-site/docs/reference/release-and-artifacts.md
@@ -2,6 +2,7 @@
 title: Release and Artifacts
 sidebar_position: 2
 description: AI4J 的发布 artifact、Maven 坐标与 BOM 版本对齐策略，说明各模块角色、依赖引入方式与版本升级顺序。
+tags: [reference]
 ---
 
 # Release and Artifacts

--- a/docs-site/docs/reference/release-checklist.md
+++ b/docs-site/docs/reference/release-checklist.md
@@ -2,6 +2,7 @@
 title: Release Checklist
 sidebar_position: 3
 description: 维护者把 AI4J 发布到 Maven Central 与 GitHub Release 的前后检查清单，覆盖版本策略、本地验证与发布后核对。
+tags: [reference]
 ---
 
 # Release Checklist

--- a/docs-site/docs/reference/version-compatibility.md
+++ b/docs-site/docs/reference/version-compatibility.md
@@ -2,6 +2,7 @@
 title: Version Compatibility
 sidebar_position: 1
 description: AI4J 的版本评估与升级前检查：基线、模块兼容矩阵、Java 8 兼容说明、provider 能力差异与升级顺序建议。
+tags: [reference]
 ---
 
 # Version Compatibility

--- a/docs-site/docs/security/overview.md
+++ b/docs-site/docs/security/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Security Overview
 description: AI4J 安全边界由密钥、网络、Tool、MCP、RAG、Agent、Coding Agent 和 FlowGram 多层组成。接入前明确：哪些能力能被模型看见、调用、回写到用户或日志。密钥不入仓、Tool 最小暴露、本地边界约束。
+tags: [concept]
 ---
 
 # Security Overview

--- a/docs-site/docs/solutions/deepseek-stream-search-rag.md
+++ b/docs-site/docs/solutions/deepseek-stream-search-rag.md
@@ -1,6 +1,7 @@
 ---
 title: DeepSeek Stream Search RAG
 description: 组合流式输出、公网搜索与私域 RAG 的回答链方案，讲解职责分层、引用证据策略与升级判断。
+tags: [concept]
 ---
 
 # DeepSeek Stream Search RAG

--- a/docs-site/docs/solutions/flowgram-mysql-taskstore.md
+++ b/docs-site/docs/solutions/flowgram-mysql-taskstore.md
@@ -1,6 +1,7 @@
 ---
 title: Flowgram MySQL Task Store
 description: 把 FlowGram 从单进程 demo 提升到平台后端的 JDBC 持久化方案，讲解任务生命周期与 task store 边界。
+tags: [integration]
 ---
 
 # Flowgram MySQL Task Store

--- a/docs-site/docs/solutions/legal-assistant.md
+++ b/docs-site/docs/solutions/legal-assistant.md
@@ -1,6 +1,7 @@
 ---
 title: Legal Assistant
 description: 高证据要求法律助手的 RAG 方案，强调元数据治理、证据引用与人工复核，区别于普通聊天加长 prompt。
+tags: [concept]
 ---
 
 # Legal Assistant

--- a/docs-site/docs/solutions/overview.md
+++ b/docs-site/docs/solutions/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Solutions 总览
 description: AI4J 场景组合入口总览，按常见业务问题给出方案选型路线、模块组合与回到主线的判断。
+tags: [concept]
 ---
 
 # Solutions 总览

--- a/docs-site/docs/solutions/pinecone-vector-workflow.md
+++ b/docs-site/docs/solutions/pinecone-vector-workflow.md
@@ -1,6 +1,7 @@
 ---
 title: Pinecone Vector Workflow
 description: 在 Pinecone 后端上搭建入库、检索、rerank 工作流的标准方案，讲解 namespace 知识隔离与统一抽象边界。
+tags: [integration]
 ---
 
 # Pinecone Vector Workflow

--- a/docs-site/docs/solutions/rag-ingestion-vector-store.md
+++ b/docs-site/docs/solutions/rag-ingestion-vector-store.md
@@ -1,6 +1,7 @@
 ---
 title: RAG Ingestion Vector Store
 description: AI4J 的标准 RAG 工程基线方案，串联文档入库、embedding、向量存储与检索链，不绑定特定向量库品牌。
+tags: [concept]
 ---
 
 # RAG Ingestion Vector Store

--- a/docs-site/docs/solutions/searxng-web-search.md
+++ b/docs-site/docs/solutions/searxng-web-search.md
@@ -1,6 +1,7 @@
 ---
 title: SearXNG Web Search
 description: 给回答链补上公网实时搜索能力的增强方案，讲解 SearXNG 配置、与 RAG 的边界及降级策略。
+tags: [integration]
 ---
 
 # SearXNG Web Search

--- a/docs-site/docs/solutions/spi-dispatcher-connectionpool.md
+++ b/docs-site/docs/solutions/spi-dispatcher-connectionpool.md
@@ -1,6 +1,7 @@
 ---
 title: SPI Dispatcher ConnectionPool
 description: AI4J 的 HTTP 栈扩展方案，通过 DispatcherProvider 与 ConnectionPoolProvider SPI 治理生产并发、连接池与网络隔离。
+tags: [integration]
 ---
 
 # SPI Dispatcher ConnectionPool

--- a/docs-site/docs/solutions/springboot-jdbc-agent-memory.md
+++ b/docs-site/docs/solutions/springboot-jdbc-agent-memory.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot JDBC Agent Memory
 description: 把 Agent 会话持久化到 JDBC 的方案，覆盖工具结果、runtime state 与压缩摘要的跨实例恢复。
+tags: [integration]
 ---
 
 # Spring Boot + JDBC Agent Memory

--- a/docs-site/docs/solutions/springboot-mysql-chat-memory.md
+++ b/docs-site/docs/solutions/springboot-mysql-chat-memory.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot MySQL Chat Memory
 description: 基于 Spring Boot + MySQL 的多轮聊天会话持久化方案，讲解 JdbcChatMemory 接入、sessionId 绑定与裁剪策略。
+tags: [integration]
 ---
 
 # Spring Boot + MySQL Chat Memory

--- a/docs-site/docs/spring-boot/auto-configuration.md
+++ b/docs-site/docs/spring-boot/auto-configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot Auto Configuration
 description: 深入解析 ai4j-spring-boot-starter 的真实装配链、初始化顺序与条件装配边界，理解统一 Configuration 与失败传播路径。
+tags: [integration]
 ---
 
 # Spring Boot Auto Configuration

--- a/docs-site/docs/spring-boot/bean-extension.md
+++ b/docs-site/docs/spring-boot/bean-extension.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot Bean Extension
 description: 讲解在 Spring Boot 中沿 AI4J 抽象层覆盖默认 Bean 的时机、层级选择与典型覆盖点，避免绕开统一容器模型。
+tags: [integration]
 ---
 
 # Spring Boot Bean Extension

--- a/docs-site/docs/spring-boot/common-patterns.md
+++ b/docs-site/docs/spring-boot/common-patterns.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot Common Patterns
 description: 归纳 Spring Boot 接入 AI4J 的推荐分层与工程组织模式，明确 Web、AI4J 调用与 Tool、RAG、Workflow 的责任边界。
+tags: [integration]
 ---
 
 # Spring Boot Common Patterns

--- a/docs-site/docs/spring-boot/configuration-reference.md
+++ b/docs-site/docs/spring-boot/configuration-reference.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot Configuration Reference
 description: 按 ai.* 能力面前缀梳理 AI4J 的 Spring Boot 配置，说明单实例与多实例注册表配置的流向与分层判断。
+tags: [reference]
 ---
 
 # Spring Boot Configuration Reference

--- a/docs-site/docs/spring-boot/overview.md
+++ b/docs-site/docs/spring-boot/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot 总览
 description: ai4j-spring-boot-starter 的总览定位：何时使用、最小接入路径、装配能力与扩展点，以及上线前检查清单。
+tags: [integration]
 ---
 
 # Spring Boot 总览

--- a/docs-site/docs/spring-boot/quickstart.md
+++ b/docs-site/docs/spring-boot/quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot Quickstart
 description: Spring Boot 接入 AI4J 的最短成功路径：引入 starter、配置 ai.*、注入 AiService 并发出第一个 ChatCompletion。
+tags: [how-to]
 ---
 
 # Spring Boot Quickstart

--- a/docs-site/docs/start-here/architecture-at-a-glance.md
+++ b/docs-site/docs/start-here/architecture-at-a-glance.md
@@ -1,6 +1,7 @@
 ---
 title: Architecture at a Glance
 description: 用一张四层图建立 AI4J 的整体心智模型：Start Here、Core SDK、上层模块（Spring Boot/Agent/Coding Agent/FlowGram）与 Solutions，并厘清 Function Call、Skill、MCP 三个最易混淆的概念边界。
+tags: [concept]
 ---
 
 # Architecture at a Glance

--- a/docs-site/docs/start-here/choose-your-path.md
+++ b/docs-site/docs/start-here/choose-your-path.md
@@ -1,6 +1,7 @@
 ---
 title: Choose Your Path
 description: 按目标选择进入 AI4J 的主线：默认阅读顺序，以及快速发起模型请求、Spring Boot 接入、Tool/MCP/Agent/Coding Agent/FlowGram 各自的推荐起点与切深时机。
+tags: [concept]
 ---
 
 # Choose Your Path

--- a/docs-site/docs/start-here/documentation-map.md
+++ b/docs-site/docs/start-here/documentation-map.md
@@ -2,6 +2,7 @@
 sidebar_position: 5
 title: Documentation Map
 description: AI4J 文档站的正式阅读路径：列出 canonical 主线入口、legacy 来源目录的定位，以及每个能力应该从哪条唯一路径进入，避免在旧页与新页之间来回跳。
+tags: [reference]
 ---
 
 # Documentation Map

--- a/docs-site/docs/start-here/feature-map.md
+++ b/docs-site/docs/start-here/feature-map.md
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: Feature Map
 description: AI4J 功能地图：用成熟度标记（stable/advanced/preview/experimental）列出每个能力的状态、所属模块、适合场景与继续阅读入口，帮助按需取用最小模块。
+tags: [reference]
 ---
 
 # Feature Map

--- a/docs-site/docs/start-here/first-tool-call.md
+++ b/docs-site/docs/start-here/first-tool-call.md
@@ -1,6 +1,7 @@
 ---
 title: First Tool Call
 description: 讲清 AI4J 里“第一次工具调用”的真正含义：本地 Function Call 的最短示例，以及 Function Call、Skill、MCP 为什么必须分开理解，并给出下一步专题树。
+tags: [concept]
 ---
 
 # First Tool Call

--- a/docs-site/docs/start-here/openai-compatible-and-trovebox.md
+++ b/docs-site/docs/start-here/openai-compatible-and-trovebox.md
@@ -3,6 +3,7 @@ sidebar_label: OpenAI-compatible / TroveBox
 title: OpenAI-compatible 与 TroveBox 中转平台配置
 slug: /start-here/openai-compatible-and-trovebox
 description: OpenAI-compatible 中转平台（含 TroveBox）如何在 AI4J 里配置：普通 Java 与 Spring Boot 单/多 profile 写法、endpoint path 判断，以及常见 401/404 排查。
+tags: [integration]
 ---
 
 # OpenAI-compatible 与 TroveBox 中转平台配置

--- a/docs-site/docs/start-here/quickstart-java.md
+++ b/docs-site/docs/start-here/quickstart-java.md
@@ -1,6 +1,7 @@
 ---
 title: Quickstart for Java
 description: 普通 Java / Maven 项目接入 AI4J 的最短路径：从依赖、环境变量到第一条同步 Chat 请求，给出可复制的 Configuration→AiService→IChatService 闭环代码与成功标准。
+tags: [how-to]
 ---
 
 # Quickstart for Java

--- a/docs-site/docs/start-here/quickstart-spring-boot.md
+++ b/docs-site/docs/start-here/quickstart-spring-boot.md
@@ -1,6 +1,7 @@
 ---
 title: Quickstart for Spring Boot
 description: Spring Boot 项目接入 AI4J 的最短路径：引入 starter、最小 application.yml 配置、AiService Bean 注入，并给出 controller 发出第一条模型请求的完整示例。
+tags: [how-to]
 ---
 
 # Quickstart for Spring Boot

--- a/docs-site/docs/start-here/why-ai4j.md
+++ b/docs-site/docs/start-here/why-ai4j.md
@@ -1,6 +1,7 @@
 ---
 title: Why AI4J
 description: 回答在 Java 项目里为什么可以考虑 AI4J：面向 Java 8+ 的渐进式 AI SDK 取舍、可按阶段取用的模块分层，以及与 Spring AI、LangChain4j 的差异和适合场景。
+tags: [concept]
 ---
 
 # Why AI4J

--- a/docs-site/docs/troubleshooting/overview.md
+++ b/docs-site/docs/troubleshooting/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Troubleshooting
 description: AI4J 生产排障入口。不列出所有异常栈，而是按能力层把问题定位到正确页面和检查项：模型请求失败查 provider key、Chat 能用 Responses 不能用查 provider 支持、Streaming 没增量查消费方式。
+tags: [how-to]
 ---
 
 # Troubleshooting


### PR DESCRIPTION
Stage 2 of the docs refresh — adds a **content-type axis** additively (no reorg, no link breaks).

Every page gets one frontmatter `tags` entry → Docusaurus auto-generates `/docs/tags/<type>` browse pages, so readers can filter the whole site by **concept / how-to / integration / reference** on top of the existing subsystem structure (Core SDK / Agent / MCP / ...).

Why additive, not a full content-type reorg: at ai4j's scale (168 pages) the subsystem structure is a good primary axis; forcing all pages into Concept/How-to/Integration/API-ref buckets (LangChain-style) would dismantle it and break links for little gain. Tags deliver the blueprint's "content-type as first-class axis" safely.

Distribution: concept 100 · integration 24 · how-to 23 · reference 21 (168/168). Purely additive (one `tags:` line per page). The provider capability matrix the blueprint also recommended already exists (`core-sdk/platform-service-matrix.md`).

🤔 Generated by Claude Code