### PR TITLE
docs(site): Pi-style ability-domain landing pages (Extend + Programmatic)

### DIFF
--- a/docs-site/docs/start-here/extend-ai4j.md
+++ b/docs-site/docs/start-here/extend-ai4j.md
@@ -1,0 +1,138 @@
+---
+sidebar_position: 8
+title: 扩展 ai4j
+description: 把 ai4j 让 agent 与 SDK 做更多的四条扩展线收进一个入口：插件包贡献合约（discover/enable/allow/expose）、按需加载的 Skill 方法论、插件 Prompt 资源、新增 LLM 后端的 provider/model/service 扩展，标清各自入口与安全边界。
+tags: [concept]
+---
+
+# 扩展 ai4j
+
+> **ai4j 的"扩展"= 给 agent / SDK 增加它出厂时不带的能力。** 但 ai4j 把这件事拆成了四条线，每条线的入口、代价和安全边界都不一样——选错线，就会改错地方。
+
+这页是一个聚合入口：它不重复每个专题页的内容，只负责告诉你**四条扩展线分别是什么、解决什么问题、从哪一页开始读**。每条线下面都有一句定义和一个真实的文档入口。
+
+---
+
+## 先看一张总表
+
+| 扩展线 | 一句话 | 入口机制 | 是否模型可见 |
+| --- | --- | --- | --- |
+| **插件包（Plugin）** | 把工具 / 命令 / Skill / Prompt / Guardrail 打成一个 jar 贡献给 agent | `ai4j-extension-api` + `ServiceLoader` + 三段式门禁 | 工具需 `exposeTool` 后才可见 |
+| **Skill** | 给模型按需读取的方法论资源（"这类任务该怎么做"） | `.ai4j/skills` 扫描 + `SKILL.md` | 模型先看摘要，再 `read_file` |
+| **Prompt** | 插件贡献的可复用提示资源，进 agent 的 `available_prompts` | 插件 `prompts().register(...)` | 否，宿主或 agent 按需读取 |
+| **Provider / Model / Service 扩展** | 给 SDK 新增一个 LLM 后端或顶层能力面 | 改 `PlatformType` + `AiService` + `Registry` 主链 | 不涉及，是协议层扩展 |
+
+这四条线的边界是 ai4j 文档里最容易被混掉的部分。下面逐条展开。
+
+---
+
+## 1. 插件包：贡献合约（`ai4j-extension-api`）
+
+第三方开发者把工具、命令、Skill、Prompt、Guardrail 打包成一个普通 Maven jar，使用者引入 classpath 后再**发现、启用、授权、暴露**。它不是应用商店，也不是远程下载器——稳定路径是 jar + `ServiceLoader` + 显式门禁。
+
+关键边界是**三段式门禁**：`discover()` 只发现不执行，`enable(...)` 注册资源但不暴露给模型，`exposeTool(...)` 才把指定工具交给 agent tool registry。这个设计刻意不做"安装即自动可用"。
+
+→ [Plugin Packages](/docs/core-sdk/extension/plugin-packages)（概念与门禁）｜[Plugin Recipes](/docs/core-sdk/extension/plugin-recipes)（可复制接入配方）
+
+---
+
+## 2. Skill：按需加载的方法论能力
+
+`Skill` 不是"给模型补一点说明文字"，而是一套正式的**上下文治理机制**：session 启动时只发现摘要（名称 + 描述），任务真正匹配时模型再用 `read_file` 读取 `SKILL.md` 正文。它属于 Core SDK（`Skills.java`），不只 是 Coding Agent 的产品特性。
+
+最常见的载体就是 `SKILL.md`。它解决"方法论如何复用"，而不是"动作如何执行"——所以它不直接承担执行，也不会自动塞满上下文。
+
+→ [Skills 总览](/docs/core-sdk/skills/overview)｜[Discovery and Loading](/docs/core-sdk/skills/discovery-and-loading)｜[Skill vs Tool vs MCP](/docs/core-sdk/skills/skill-vs-tool-vs-mcp)｜[Coding Agent Skills 使用与组织](/docs/coding-agent/skills)
+
+---
+
+## 3. Prompt：可复用提示资源
+
+ai4j 没有独立的"slash 提示模板引擎"。**Prompt 是插件资源的一种**：插件在 `apply(...)` 里用 `context.prompts().register(...)` 注册一个 `ExtensionPromptResource`（指向 jar 内的 markdown 资源），启用后它会被物化成只读文件，进入 agent 的 `<available_prompts>` 清单，由宿主或 Coding Agent 按需读取。
+
+也就是说，ai4j 的 Prompt 和 Skill 共享同一套"摘要先行、按需读取"的上下文治理思路，区别在资源类型。官方 `ask-user` 插件是同时贡献 tool + command + Skill + Prompt 的样板，最适合作为这条线的参考实现。
+
+→ [Ask User Plugin](/docs/core-sdk/extension/ask-user-plugin)（同时贡献 Prompt 的样板）｜[Dynamic Workflow Plugin](/docs/core-sdk/extension/dynamic-workflow-plugin)（脚本化 Prompt + Skill 样板）
+
+---
+
+## 4. Provider / Model / Service 扩展：新增 LLM 后端
+
+这条线和插件包**不是一回事**。它是改 SDK 代码主链，把一个新的模型平台或顶层能力面正式纳入平台分发体系。当前 ai4j 对 provider 的建模是**显式枚举驱动**，不是"注册一个实现就自动可见"。
+
+三个粒度按代价从轻到重排：
+
+- **Model Extension**——同 provider 下补模型名、请求字段或能力变体，主战场在请求对象和 provider 适配层，不碰 `PlatformType`。
+- **Provider Extension**——新增一个模型平台（新 `PlatformType` + 配置 + 工厂分支 + Registry + starter），必须同时触碰一整条链。
+- **Service Extension**——新增一条顶层能力契约（如新的 `IXxxService`），会扩大整个 SDK 的公共 API 面，代价最高。
+
+:::warning 边界提醒
+插件包**不能**用来新增 provider。要接一个新 LLM 后端，仍然走代码主链；插件包只负责给 agent 暴露运行时资源（工具 / 命令 / Skill / Prompt / Guardrail）。
+:::
+
+→ [Provider Extension](/docs/core-sdk/extension/provider-extension)｜[Model Extension](/docs/core-sdk/extension/model-extension)｜[Service Extension](/docs/core-sdk/extension/service-extension)｜[Extension 总览](/docs/core-sdk/extension/overview)
+
+---
+
+## 最小可跑示例：让一个 Agent 多一个工具
+
+最常见的"扩展"动作，是把一个插件工具接进通用 Agent loop。下面用官方 `ask-user` 插件演示 discover → enable → expose 三步（Java 8 风格）。
+
+引入依赖：
+
+```xml
+<dependency>
+  <groupId>io.github.lnyo-cly</groupId>
+  <artifactId>ai4j-plugin-ask-user</artifactId>
+  <version>2.4.2</version>
+</dependency>
+```
+
+启用并暴露给 Agent：
+
+```java
+import io.github.lnyocly.ai4j.extension.ExtensionRegistry;
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.Agents;
+
+// 1. discover: 从 classpath 发现插件（不执行工具，不暴露给模型）
+// 2. enable:   调用插件 apply(...) 注册 tool / command / Skill / Prompt / Guardrail
+// 3. exposeTool: 把指定工具交给模型可见的 tool registry
+ExtensionRegistry registry = ExtensionRegistry.discover()
+        .enable("ask-user")
+        .exposeTool("ask_user");
+
+Agent agent = Agents.react()
+        .modelClient(modelClient)
+        .model("glm-4.5-flash")
+        .extensions(registry)
+        .build();
+```
+
+运行时会把暴露出的 `ExtensionToolSpec` 转成普通 `Tool`，把 `ExtensionToolExecutor` 路由到现有 `ToolExecutor`——Agent 主循环不用认识插件实现类。
+
+:::note Spring Boot
+Spring Boot 项目可以用配置完成同一件事：`ai.extensions.enabled` + `ai.extensions.tools.expose`，starter 会自动装配 `ExtensionRegistry` / `ExtensionRuntimeSnapshot`，但不会自动创建 Agent。详见 [Plugin Recipes](/docs/core-sdk/extension/plugin-recipes)。
+:::
+
+---
+
+## 边界一句话
+
+- **插件包** = 可插拔的**贡献合约**（jar 贡献资源，门禁控制可见性）。
+- **Skill** = 按需加载的**方法论资源**（告诉模型"这类任务怎么做"）。
+- **Prompt** = 插件贡献的**可复用提示资源**（进 `available_prompts`，按需读取）。
+- **Provider / Model / Service 扩展** = 改 SDK **代码主链**新增 LLM 后端或能力面。
+
+遇到"现有 SDK 不够用"时，先判断你碰到的是**资源复用**（走插件包 / Skill）、还是**平台边界 / 模型变体 / 能力新增**（走 provider/model/service 扩展）。判断顺序见 [Extension 总览 §5 扩展决策顺序](/docs/core-sdk/extension/overview)。
+
+---
+
+## 继续阅读
+
+- [Extension 总览](/docs/core-sdk/extension/overview)——四条扩展线的全景与决策顺序
+- [Plugin Packages](/docs/core-sdk/extension/plugin-packages)——插件包概念与三段式门禁
+- [Skills 总览](/docs/core-sdk/skills/overview)——Skill 作为上下文治理层
+- [Tools](/docs/core-sdk/tools/overview)——工具是模型在宿主内的执行能力（Skill / Tool / MCP 三者对比见 [Skill vs Tool vs MCP](/docs/core-sdk/skills/skill-vs-tool-vs-mcp)）
+- [Agent Runtime](/docs/agent/overview)——插件工具接入通用 Agent loop 的宿主
+- [Coding Agent](/docs/coding-agent/overview)——插件工具 + Skill + Prompt 在 coding session 里的使用

--- a/docs-site/docs/start-here/programmatic-integration.md
+++ b/docs-site/docs/start-here/programmatic-integration.md
@@ -1,6 +1,6 @@
 ---
 title: 编程式集成
-description: 如何把 ai4j 嵌进你的应用：把 AiService 编程入口、ACP 宿主协议、trace/replay 事件流、CLI/TUI 嵌入与 Spring Boot 自动装配五条散落的集成主线收进一个落地页，每条给一句定位和深链。
+description: 如何把 ai4j 嵌进你的应用：把 AiService 编程入口、ACP 宿主协议、trace/replay 可观测、CLI/TUI 嵌入与 Spring Boot 自动装配五条散落的集成主线收进一个落地页，每条给一句定位和深链。
 tags: [concept]
 ---
 
@@ -22,11 +22,13 @@ ai4j 是 Java，集成面的划分和 Pi（Node / TypeScript）不同，但能�
 | --- | --- | --- |
 | SDK（`createAgentSession` 编程 API） | `AiService` / `AiServiceRegistry` 编程工厂 | [服务入口与注册表](/docs/core-sdk/service-entry-and-registry) |
 | RPC（stdin / stdout JSON-RPC 子进程协议） | ACP headless host（换行分隔 JSON-RPC） | [ACP 集成](/docs/coding-agent/acp-integration) |
-| JSON event stream（`--mode json` 事件流） | runtime 事件流 → trace span + replay 事件账本 | [Trace 与可观测性](/docs/agent/trace-observability) |
+| JSON event stream（`--mode json` 一次性事件流→stdout） | **无 turnkey 等价**（构建块见下文①） | — |
 | TUI（交互终端） | `ai4j-cli` 的 `code` / `tui` 宿主 | [CLI / TUI 使用指南](/docs/coding-agent/cli-and-tui) |
 | —（Pi 无对应，ai4j 独有） | Spring Boot 自动装配 | [Spring Boot Auto Configuration](/docs/spring-boot/auto-configuration) |
 
 最关键的差别：ai4j 没有"一个 SDK 对象包办一切"的单一 session 工厂。能力工厂（`AiService`）和会话协议（ACP）是分开的两层——前者是程序内调用，后者是跨进程协议。
+
+> ① Pi 的 `--mode json` 是"跑一个 prompt、把整个 agent 事件流以 JSONL 打到 stdout 供管道 / `jq` 消费"的**一次性 headless 模式**。ai4j **没有**这种 turnkey 模式：runtime 事件流（`MODEL_REQUEST` / `TOOL_CALL` 等）的**事件类型**与 Pi 同源，但在 ai4j 里它是给 **trace / replay** 做**可观测性与恢复**用的进程内机制（主线 4），不是"事件流→stdout"的集成模式；ACP（主线 3）也会往外发 agent 事件，但它是**双向控制协议**（≈ Pi RPC），不是一次性管道。若需要 Pi `--mode json` 那种用法，得用 runtime 事件流 + 自己加一个 stdout 发射器。
 
 ## 五条集成主线
 
@@ -48,9 +50,13 @@ ACP 是 ai4j 面向 IDE / 桌面壳的标准接入面：换行分隔 JSON-RPC（
 
 → [ACP 集成](/docs/coding-agent/acp-integration) · 与 MCP 的边界见 [MCP and ACP](/docs/coding-agent/mcp-and-acp)
 
-### 4. trace / replay 事件流 —— 嵌入可观测与恢复
+### 4. trace / replay —— 可观测性与恢复
 
-runtime 已经发布统一事件（`MODEL_REQUEST` / `MODEL_RESPONSE` / `TOOL_CALL` / `TOOL_RESULT`），trace 和 replay 都是这些事件的消费者而非埋点：`AgentTraceListener` 把事件折叠成 span 并导出到 OTel / Langfuse / JSONL；`IoCaptureAgentListener` + `NodeReplayer` 做节点级重放，`ResumeCache` 做崩溃续跑，`HashChainedEventLog` 做防篡改审计。这是 Pi 的 `--mode json` 事件流在 ai4j 里更生产化的形态。
+runtime 已经发布统一事件（`MODEL_REQUEST` / `MODEL_RESPONSE` / `TOOL_CALL` / `TOOL_RESULT`），trace 和 replay 都是这些事件的消费者而非埋点：`AgentTraceListener` 把事件折叠成 span 并导出到 OTel / Langfuse / JSONL；`IoCaptureAgentListener` + `NodeReplayer` 做节点级重放，`ResumeCache` 做崩溃续跑，`HashChainedEventLog` 做防篡改审计。
+
+:::note 这不是 Pi `--mode json` 的等价物
+trace / replay 是 ai4j 的**可观测性与可靠性**层（进程内 tracing、节点重放、崩溃续跑、防篡改审计），不是"把 agent 事件流一次性打到 stdout"的集成模式。它消费的事件类型与 Pi 的事件流同源，但**定位不同**——见上表①。Pi JSON 模式的"管道消费"用法在 ai4j 里需要自己用 runtime 事件流加一个发射器。
+:::
 
 → [Trace 与可观测性](/docs/agent/trace-observability) · 续跑 / 重放 / 审计见 [Replay, Recovery & Audit](/docs/agent/replay-recovery-audit)
 

--- a/docs-site/docs/start-here/programmatic-integration.md
+++ b/docs-site/docs/start-here/programmatic-integration.md
@@ -1,0 +1,149 @@
+---
+title: 编程式集成
+description: 如何把 ai4j 嵌进你的应用：把 AiService 编程入口、ACP 宿主协议、trace/replay 事件流、CLI/TUI 嵌入与 Spring Boot 自动装配五条散落的集成主线收进一个落地页，每条给一句定位和深链。
+tags: [concept]
+---
+
+# 编程式集成
+
+把 ai4j 当作库嵌进你的应用，而不是只跑它的 CLI。这页是聚合落地页：把散落在各子系统里的五条集成主线收拢到一处，每条只给一句定位和一个深链，让你先选对入口，再去读对应专题页。
+
+## 这页解决什么
+
+ai4j 的集成入口按能力分散在不同子系统里：模型 / 服务访问在 Core SDK，宿主协议在 Coding Agent 的 ACP，可观测事件流在 Agent 的 trace / replay，终端嵌入在 CLI / TUI，配置化接入在 Spring Boot。如果你按"我要把它嵌进应用"这个意图去找，很可能在五个目录间来回跳。
+
+这页不重复各专题页的内容，只负责让你在五条主线里选对起点。
+
+## 从 Pi 的集成面到 ai4j 的对应物
+
+ai4j 是 Java，集成面的划分和 Pi（Node / TypeScript）不同，但能一一对应：
+
+| Pi 的集成面 | ai4j 的对应物 | 入口 |
+| --- | --- | --- |
+| SDK（`createAgentSession` 编程 API） | `AiService` / `AiServiceRegistry` 编程工厂 | [服务入口与注册表](/docs/core-sdk/service-entry-and-registry) |
+| RPC（stdin / stdout JSON-RPC 子进程协议） | ACP headless host（换行分隔 JSON-RPC） | [ACP 集成](/docs/coding-agent/acp-integration) |
+| JSON event stream（`--mode json` 事件流） | runtime 事件流 → trace span + replay 事件账本 | [Trace 与可观测性](/docs/agent/trace-observability) |
+| TUI（交互终端） | `ai4j-cli` 的 `code` / `tui` 宿主 | [CLI / TUI 使用指南](/docs/coding-agent/cli-and-tui) |
+| —（Pi 无对应，ai4j 独有） | Spring Boot 自动装配 | [Spring Boot Auto Configuration](/docs/spring-boot/auto-configuration) |
+
+最关键的差别：ai4j 没有"一个 SDK 对象包办一切"的单一 session 工厂。能力工厂（`AiService`）和会话协议（ACP）是分开的两层——前者是程序内调用，后者是跨进程协议。
+
+## 五条集成主线
+
+### 1. AiService —— 编程式服务工厂
+
+`AiService` 是把模型访问、检索增强和组合能力统一收束在一个入口对象下的显式工厂（`getChatService` / `getResponsesService` / `getEmbeddingService` / `getRagService` 等），内部用一组 `switch(platform)` 决定创建哪个实现类。这是普通 Java 应用嵌 ai4j 的第一条链。
+
+→ [服务入口与注册表](/docs/core-sdk/service-entry-and-registry) · 首聊代码见 [Quickstart for Java](/docs/start-here/quickstart-java)
+
+### 2. AiServiceRegistry —— 多实例 / 多 profile
+
+多账号、多租户、多 provider profile 共存时，用 `AiServiceRegistry` 按 `id` 管理多套注册项，每项绑定 `PlatformType`，对外直接暴露按 `id` 取 Chat / Embedding / RAG 的便利方法；未知 `id` 会直接抛错，适合做正式多实例入口而非松散查找。
+
+→ [服务入口与注册表](/docs/core-sdk/service-entry-and-registry) · OpenAI-compatible profile 见 [OpenAI-compatible 与 TroveBox](/docs/start-here/openai-compatible-and-trovebox)
+
+### 3. ACP —— 把 coding session 协议化暴露给宿主
+
+ACP 是 ai4j 面向 IDE / 桌面壳的标准接入面：换行分隔 JSON-RPC（不是 LSP 的 `Content-Length` framing），暴露 session 创建 / 加载、prompt 执行、权限确认和结构化事件；权限确认是服务端反向发起的 `session/request_permission` RPC。它是 Pi RPC 模式在 ai4j 里的等价物，但底层和 `code` 命令共用同一套 coding runtime。
+
+→ [ACP 集成](/docs/coding-agent/acp-integration) · 与 MCP 的边界见 [MCP and ACP](/docs/coding-agent/mcp-and-acp)
+
+### 4. trace / replay 事件流 —— 嵌入可观测与恢复
+
+runtime 已经发布统一事件（`MODEL_REQUEST` / `MODEL_RESPONSE` / `TOOL_CALL` / `TOOL_RESULT`），trace 和 replay 都是这些事件的消费者而非埋点：`AgentTraceListener` 把事件折叠成 span 并导出到 OTel / Langfuse / JSONL；`IoCaptureAgentListener` + `NodeReplayer` 做节点级重放，`ResumeCache` 做崩溃续跑，`HashChainedEventLog` 做防篡改审计。这是 Pi 的 `--mode json` 事件流在 ai4j 里更生产化的形态。
+
+→ [Trace 与可观测性](/docs/agent/trace-observability) · 续跑 / 重放 / 审计见 [Replay, Recovery & Audit](/docs/agent/replay-recovery-audit)
+
+### 5. CLI / TUI —— 嵌入终端宿主
+
+`code` 和 `tui` 共用同一套 coding runtime、session manager、MCP runtime 和审批语义，只在宿主层（JLINE / legacy / TUI runtime）分叉。session 是否持久化由 `--no-session` / `--session-dir` 决定，与 `code` 还是 `tui` 无关。要嵌入或替换终端宿主时从这里进入。
+
+→ [CLI / TUI 使用指南](/docs/coding-agent/cli-and-tui) · 主题与四层定制见 [TUI 定制与主题](/docs/coding-agent/tui-customization)
+
+### 6. Spring Boot 自动装配 —— 配置化接入
+
+`ai4j-spring-boot-starter` 用 `AiConfigAutoConfiguration` 把 `ai.*` 属性绑成统一 `Configuration`，按固定顺序组装 OkHttpClient → provider → `AiService` / `AiServiceRegistry` / `FreeAiService` → 条件性创建 VectorStore / RAG / Reranker，关键 Bean 都是 `@ConditionalOnMissingBean`，可被业务实现接管。
+
+→ [Spring Boot Auto Configuration](/docs/spring-boot/auto-configuration) · 快速接入见 [Quickstart for Spring Boot](/docs/start-here/quickstart-spring-boot)
+
+## 最小可运行示例：编程式首聊
+
+这是主线 1 的最小闭环——`Configuration` → `AiService` → `IChatService` → 同步 Chat。Java 8 风格，可直接复制。
+
+依赖（注意真实的 Maven groupId 是 `io.github.lnyo-cly`）：
+
+```xml
+<dependency>
+  <groupId>io.github.lnyo-cly</groupId>
+  <artifactId>ai4j</artifactId>
+  <version>2.4.2</version>
+</dependency>
+```
+
+代码：
+
+```java
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletion;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletionResponse;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IChatService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+
+public class EmbedAi4j {
+    public static void main(String[] args) {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            throw new IllegalStateException("Missing OPENAI_API_KEY");
+        }
+
+        OpenAiConfig openAiConfig = new OpenAiConfig();
+        openAiConfig.setApiKey(apiKey);
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(openAiConfig);
+
+        // 编程入口：AiService 是统一能力工厂
+        AiService aiService = new AiService(configuration);
+        IChatService chatService = aiService.getChatService(PlatformType.OPENAI);
+
+        ChatCompletion request = ChatCompletion.builder()
+                .model("gpt-4o-mini")
+                .message(ChatMessage.withUser("用一句话介绍 AI4J"))
+                .build();
+
+        ChatCompletionResponse response = chatService.chatCompletion(request);
+        String text = response.getChoices().get(0).getMessage().getContent().getText();
+        System.out.println(text);
+    }
+}
+```
+
+预期输出（文本随 provider / 模型变化）：
+
+```text
+AI4J 是一个统一多家大模型、屏蔽 provider 差异的 Java AI SDK。
+```
+
+跑通这条链之后，要继续往上接 Tool / MCP / RAG / Agent，都从同一个 `AiService` 工厂扩展，不必换入口。
+
+## 选哪条主线
+
+- 只想把模型能力调起来 → 主线 1，首聊即可。
+- 一个应用里多 provider / 多账号 → 主线 2。
+- 在 IDE / 桌面壳里驱动一个持久 coding session → 主线 3。
+- 要在线上观测、重放、续跑 agent → 主线 4。
+- 要做或替换终端产品壳 → 主线 5。
+- 已是 Spring Boot 项目，想用配置和 Bean 接入 → 主线 6。
+
+## 继续阅读
+
+- [Quickstart for Java](/docs/start-here/quickstart-java) · [Quickstart for Spring Boot](/docs/start-here/quickstart-spring-boot)
+- [服务入口与注册表](/docs/core-sdk/service-entry-and-registry)
+- [ACP 集成](/docs/coding-agent/acp-integration) · [MCP and ACP](/docs/coding-agent/mcp-and-acp)
+- [Trace 与可观测性](/docs/agent/trace-observability) · [Replay, Recovery & Audit](/docs/agent/replay-recovery-audit)
+- [CLI / TUI 使用指南](/docs/coding-agent/cli-and-tui) · [TUI 定制与主题](/docs/coding-agent/tui-customization)
+- [Spring Boot Auto Configuration](/docs/spring-boot/auto-configuration)
+- 想看完整能力地图：[Feature Map](/docs/start-here/feature-map)

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -14,6 +14,8 @@ const sidebars: SidebarsConfig = {
         'start-here/openai-compatible-and-trovebox',
         'start-here/feature-map',
         'start-here/why-ai4j',
+        'start-here/extend-ai4j',
+        'start-here/programmatic-integration',
       ],
     },
     {


### PR DESCRIPTION
Two new aggregation landing pages that give ai4j the Pi-style "ability-domain" entry points (study of Pi docs at pi.dev / earendil-works/pi). No pages moved — both only LINK to existing pages (all 27 links verified).

- **[扩展 ai4j](/docs/start-here/extend-ai4j)** — groups the 4 extension lines: Plugin packages (contribution contract), Skills (on-demand methodology), Prompt resources, Provider/Model/Service extensions. Clarifies ai4j-specific boundaries (plugins ≠ providers; no standalone slash-prompt engine). Minimal `discover→enable→expose` Java example.
- **[编程式集成](/docs/start-here/programmatic-integration)** — groups the 5 integration main lines: AiService entry, ACP host (≈Pi RPC), trace+replay event stream (≈Pi JSON event stream), CLI/TUI, Spring Boot auto-config.

Both follow Pi's page skeleton (one-line def → overview table → per-feature one-liner+link → minimal example → cross-links), zh-Hans, `tags:[concept]`. Added to the Start Here sidebar. 170/170 doc ids, 0 orphans.

🤔 Generated by Claude Code