### PR TITLE
docs(site): minor gap fixes + javadoc.io deep-links

### DIFF
--- a/docs-site/docs/coding-agent/acp-integration.md
+++ b/docs-site/docs/coding-agent/acp-integration.md
@@ -485,3 +485,5 @@ ACP 最常见的通知仍然是：
 3. [MCP 与 ACP](/docs/coding-agent/mcp-and-acp)
 4. [MCP 对接](/docs/coding-agent/mcp-integration)
 5. [命令参考](/docs/coding-agent/command-reference)
+
+→ API Javadoc：[`AcpJsonRpcServer`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j-cli/2.4.2/io/github/lnyocly/ai4j/cli/acp/AcpJsonRpcServer.html)（`ai4j-cli` 模块，ACP stdio server 的协议主类）

--- a/docs-site/docs/coding-agent/command-reference.md
+++ b/docs-site/docs/coding-agent/command-reference.md
@@ -718,6 +718,32 @@ tags: [reference]
 
 ---
 
+### 自定义命令模板文件
+
+`/commands`、`/palette`、`/cmd` 背后是同一套自定义命令模板机制（`CustomCommandRegistry`）。把常用提示词写成命令文件后，即可用 `/cmd <name>` 把正文注入当前 turn。
+
+**发现路径**（后加载者覆盖同名命令）：
+
+| 位置 | 作用域 |
+| --- | --- |
+| `~/.ai4j/commands/` | 用户全局，所有工作区可见 |
+| `<workspace>/.ai4j/commands/` | 当前工作区，覆盖同名全局命令 |
+
+支持的扩展名：`.md`、`.txt`、`.prompt`。命令名 = 文件名去掉扩展名（`review.md` → `/cmd review`）。
+
+**文件格式**：第一行以 `#` 开头时，该行去掉 `#` 作为命令描述，第二行起才是 prompt 正文；第一行不以 `#` 开头时，整文件都是正文、无描述。正文里的 `$key` 占位符在渲染时按变量替换。
+
+一个最小示例，`<workspace>/.ai4j/commands/refactor.md`：
+
+```text
+# 审阅并重构代码
+请审阅当前 workspace 的代码，按 $language 的惯用法重构，并指出潜在问题。
+```
+
+随后在会话内执行 `/cmd refactor` 即把正文注入当前 turn。
+
+---
+
 ### `/clear`
 
 打印一个新的屏幕分区，相当于重新整理当前终端视图。

--- a/docs-site/docs/coding-agent/install-and-release.md
+++ b/docs-site/docs/coding-agent/install-and-release.md
@@ -61,11 +61,14 @@ manifest 主类当前是：
 
 ### 2.3 `Ai4jCli` 本身已经完成了命令分发
 
-当前它直接支持：
+当前它直接支持的顶层子命令：
 
-- `code`
-- `tui`
-- `acp`
+- `code` —— coding session CLI host（最常用）
+- `tui` —— 等价于 `code --ui tui`
+- `acp` —— coding session 作为 ACP stdio server
+- `run` —— 跑一次 Agent Blueprint YAML（一次性、无 session）
+- `extension` —— 检查 / 装配 / 运行扩展包
+- `trust` —— 管理工作区钩子信任目录
 
 而且：
 
@@ -269,7 +272,7 @@ ai4j-cli-<version>/
 
 而是：
 
-- 一个带 `code` / `tui` / `acp` 三种入口的宿主程序
+- 一个带 `code` / `tui` / `acp` / `run` / `extension` / `trust` 等多种顶层子命令的宿主程序
 
 这也是为什么 release 文档必须同时谈：
 

--- a/docs-site/docs/coding-agent/overview.md
+++ b/docs-site/docs/coding-agent/overview.md
@@ -67,6 +67,10 @@ Coding Agent 装配时会同时决定：
 | TUI | 长时间在终端里工作的人 | slash command、状态视图、交互密度 |
 | ACP | IDE、桌面应用、自定义前端 | JSON-RPC session、permission request、宿主注入能力 |
 
+:::note 顶层子命令不止三个
+上表按 **host 交互模式** 区分了 CLI/TUI/ACP 三类入口。但 `ai4j-cli` 可执行文件本身还暴露了更多顶层子命令：除 `code`/`tui`/`acp` 这三个会话型入口外，还有 `run`（跑一次 Agent Blueprint YAML）、`extension`（检查/装配/运行扩展包）、`trust`（管理工作区钩子信任目录）。完整清单见 [命令参考 §7](/docs/coding-agent/command-reference)。
+:::
+
 如果你只是评估功能，先从 [Quickstart](/docs/coding-agent/quickstart) 和 [CLI / TUI](/docs/coding-agent/cli-and-tui) 开始。
 
 ## 核心概念

--- a/docs-site/docs/coding-agent/quickstart.md
+++ b/docs-site/docs/coding-agent/quickstart.md
@@ -15,20 +15,25 @@ tags: [how-to]
 
 ---
 
-## 1. 先知道当前真正的三个入口
+## 1. 先知道当前真正的入口
 
-`Ai4jCli` 当前暴露的是三个命令面：
+`Ai4jCli` 当前暴露的顶层子命令有六个：
 
-- `code`
-- `tui`
-- `acp`
+- `code` —— coding session 的 CLI host（最常用）
+- `tui` —— 等价于 `code --ui tui`
+- `acp` —— 把 coding session 作为 ACP stdio server 启动
+- `run` —— 跑一次单 agent 的 Agent Blueprint YAML（不进入交互式 session）
+- `extension` —— 检查 / 装配 / 运行 classpath 上的扩展包
+- `trust` —— 管理工作区钩子的信任目录
+
+quickstart 只关心前三类**会话型入口**（`code`/`tui`/`acp`）；`run`/`extension`/`trust` 是单次工具型子命令，完整说明见 [命令参考 §7](/docs/coding-agent/command-reference)。
 
 而且它还有两个常被忽略的行为：
 
 - 如果你直接写 `ai4j-cli --model ...`，默认按 `code` 处理
 - `tui` 本质上只是给 `code` 额外补上 `--ui tui`
 
-所以当前入口关系可以压成：
+所以当前会话型入口关系可以压成：
 
 ```text
 ai4j-cli code ...   -> coding session CLI host
@@ -300,7 +305,7 @@ quickstart 只能证明最小主链打通，不能替代完整运行验证。
 
 ## 11. 这页最该记住的结论
 
-- 当前真正的运行入口是 `code`、`tui`、`acp`
+- 会话型运行入口是 `code`、`tui`、`acp`；此外 `ai4j-cli` 还有 `run`、`extension`、`trust` 三个单次工具型子命令（见 [命令参考](/docs/coding-agent/command-reference)）
 - `tui` 只是 `code --ui tui` 的宿主别名，不是另一套 runtime
 - quickstart 最稳的直接产物是 `ai4j-cli-<version>-jar-with-dependencies.jar`
 - `--prompt` 决定 one-shot；不传 `--prompt` 才进入持续会话

--- a/docs-site/docs/coding-agent/runtime-architecture.md
+++ b/docs-site/docs/coding-agent/runtime-architecture.md
@@ -380,3 +380,5 @@ AI4J 当前的 Coding Agent runtime 不是单层系统，而是一条清晰的�
 2. [Tools 与审批机制](/docs/coding-agent/tools-and-approvals)
 3. [Compact 与 Checkpoint 机制](/docs/coding-agent/compact-and-checkpoint)
 4. [MCP 与 ACP](/docs/coding-agent/mcp-and-acp)
+
+→ API Javadoc：[`CodingAgentBuilder`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j-coding/2.4.2/io/github/lnyocly/ai4j/coding/CodingAgentBuilder.html)（`ai4j-coding` 模块，本页 §3 装配分叉点的核心类）

--- a/docs-site/docs/coding-agent/tools-and-approvals.md
+++ b/docs-site/docs/coding-agent/tools-and-approvals.md
@@ -491,3 +491,5 @@ AI4J 当前的 Coding Agent tools 机制，不是“8 个函数 + 一个确认�
 3. [Sandbox Routing](/docs/coding-agent/sandbox-routing)
 4. [生命周期钩子与工作区信任](/docs/coding-agent/lifecycle-hooks)
 5. [Runtime 架构](/docs/coding-agent/runtime-architecture)
+
+→ API Javadoc：[`BuiltInToolExecutor`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/tool/BuiltInToolExecutor.html)（`ai4j` 模块，内置工具执行路由的入口类）

--- a/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
+++ b/docs-site/docs/core-sdk/extension/dynamic-workflow-plugin.md
@@ -6,6 +6,12 @@ tags: [integration]
 
 # Dynamic Workflow Plugin
 
+:::tip 🚀 生产级参考插件
+`ai4j-plugin-dynamic-workflow` 是 ai4j 的**旗舰参考插件**——同时展示全部 4 种扩展能力（Tool + Command + Skill + Prompt），零运行时依赖（仅 `ai4j-extension-api`），安全设计（host-mediated 请求信封，不执行 JS / 不 spawn agent / 不碰文件），含 9 个单元测试 + 3 个 live 闭环烟测（MiniMax M3 → 脚本 → 信封 → agent 执行 → E2B 沙箱），Java 8 兼容，GitHub Actions CI。
+
+**GitHub**：[LnYo-Cly/ai4j-plugin-dynamic-workflow](https://github.com/LnYo-Cly/ai4j-plugin-dynamic-workflow)
+:::
+
 `ai4j-plugin-dynamic-workflow` 是 AI4J 的动态工作流样板插件，推荐作为独立 GitHub 仓库维护和单独发版，而不是并入 `ai4j-sdk` reactor。它采用 Claude Code style dynamic workflow 的生态模式：**模型先把复杂任务写成一段可检查的 workflow script，再由宿主决定如何把脚本拆给 subagent、worktree、审批和模型路由执行**。
 
 AI4J 这个插件首版刻意保持在 `ai4j-extension-api` 边界内：插件只贡献 tool、command、Skill 和 Prompt 资源，并返回 host-mediated JSON envelope；它不会在插件进程里执行 JavaScript、创建子 Agent、操作 git worktree 或绕过宿主审批。真正执行由宿主侧 `ai4j-agent` dynamic workflow runtime 可选接管。

--- a/docs-site/docs/core-sdk/service-entry-and-registry.md
+++ b/docs-site/docs/core-sdk/service-entry-and-registry.md
@@ -163,3 +163,7 @@ IChatService chatService = aiServiceRegistry.getChatService("trovebox-low-cost")
 ## 10. 这一页的结论
 
 > AI4J 当前的服务入口体系是显式且分层的：`AiService` 负责单实例统一能力工厂，`AiServiceRegistry` 负责正式多实例注册与路由，`FreeAiService` 只承担兼容壳角色。理解这条入口链，比记住单个 provider 的 API 更重要，因为后面的支持矩阵、扩展成本和上层装配都建立在这条链上。
+
+## 11. API Javadoc
+
+→ [`AiService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/factory/AiService.html) · [`AiServiceRegistry`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/factory/AiServiceRegistry.html)

--- a/docs-site/docs/core-sdk/skills/overview.md
+++ b/docs-site/docs/core-sdk/skills/overview.md
@@ -147,6 +147,10 @@ skill 不负责：
 
 这四层一起构成的，才是当前 AI4J 的 skill 体系。
 
+:::note 第三方 Skill 也可以走扩展 SPI
+除内置的 `.ai4j/skills` 目录发现外，第三方 jar 同样能通过扩展 SPI（`ServiceLoader` + `ExtensionRegistry`）把 Skill 作为资源注入，门禁规则与 Tool/Prompt 一致，默认不自动暴露。见 [Plugin Packages](/docs/core-sdk/extension/plugin-packages)。
+:::
+
 ## 7. 典型工作流是什么
 
 一条标准 skill 工作流通常是：
@@ -249,3 +253,7 @@ AI4J 的 `Skill` 是基座里的方法论与上下文治理层。
 - 让读取边界和宿主工具约束保持一致
 
 这正是它和 Tool、MCP 根本不同的地方。
+
+## 继续阅读
+
+- → [Skills API Javadoc](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/skill/Skills.html)（`discoverDefault(...)` / `buildAvailableSkillsPrompt(...)` / `createToolContext(...)` 等 skill 治理入口）

--- a/docs-site/docs/core-sdk/strengths-and-differentiators.md
+++ b/docs-site/docs/core-sdk/strengths-and-differentiators.md
@@ -173,3 +173,7 @@ AI4J 的优势不是“所有场景都绝对更强”，而是它优化目标很
 ## 9. 这一页的结论
 
 > AI4J 的差异点不在“它也能调很多模型”，而在它把多 provider 访问、工具、Skill、MCP、RAG 和向上 runtime 演进路径放进了一套连续的 Java 工程模型里。它更像长期系统的基础能力层，而不是一次性 demo SDK。
+
+## 10. API Javadoc
+
+→ [`AiService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/factory/AiService.html)

--- a/docs-site/docs/core-sdk/tools/annotation-based-tools.md
+++ b/docs-site/docs/core-sdk/tools/annotation-based-tools.md
@@ -215,7 +215,41 @@ public class QueryWeatherFunction implements Function<QueryWeatherFunction.Reque
 - 执行层可以是普通 `apply(...)`
 - 也可以是 built-in 专用执行器
 
-## 9. 最稳的设计建议
+## 9. 本地 MCP 工具也有一套对应注解
+
+前面三节讲的都是 `@FunctionCall` 这套**本地 Function 工具**注解。如果工具要走 MCP 协议（transport、服务化、被 `McpGateway` 统一治理），AI4J 另有一组**方法级**注解，无需写 `Function<Request,String>`，直接标在类和方法上即可：
+
+- `@McpService`（标在类上）—— 定义服务 identity：`name` / `version` / `description` / `transport`（`stdio`/`sse`/`streamable_http`）/ `port` / `autoStart`
+- `@McpTool`（标在方法上）—— 定义工具：`name`（默认方法名）/ `description` / `inputSchema`（不填则按方法参数自动生成）
+- `@McpParameter`（标在参数上）—— 定义参数：`name`（默认参数名）/ `description` / `required` / `defaultValue`
+
+一个最小例子：
+
+```java
+@McpService(name = "weather-service", description = "Weather MCP service")
+public class WeatherMcpService {
+
+    @McpTool(name = "query_weather", description = "Query weather by city")
+    public String queryWeather(@McpParameter(name = "city", description = "City name") String city,
+                               @McpParameter(name = "days", required = false, defaultValue = "3") int days) {
+        return "Weather(" + city + ", " + days + "d)";
+    }
+}
+```
+
+它和 Function 注解的关键区别：
+
+| | `@FunctionCall` 工具 | `@McpService`/`@McpTool` 工具 |
+|---|---|---|
+| 标注粒度 | 类 + 内部 request 类 + 字段 | 类 + 方法 + 方法参数 |
+| 参数载体 | `@FunctionRequest` 静态内部类 | 直接是方法形参 |
+| 执行链 | 反射调 `apply(Request)` | 先 parse 成 `Map` 再按参数逐个类型转换 |
+| 暴露名 | `@FunctionCall(name)` 原样 | 由 `generateApiFunctionName(service, tool)` 生成（仅保留字母/数字/下划线/连字符，最长 64，必要时加 `tool_` 前缀） |
+| 扫描入口 | `ToolUtil.scanFunctionTools()` | `ToolUtil.scanMcpTools()` |
+
+两套注解最终都会被 `ToolUtil` 扫描、缓存，并投影成统一的 `Tool.Function` 视图进入请求白名单（见 [Tool Execution Model](/docs/core-sdk/tools/tool-execution-model)）。完整的 transport 启停、网关治理、远端/本地投影语义属于 MCP 协议层，见 [构建 MCP 服务](/docs/mcp/build-your-mcp-server)。
+
+## 10. 最稳的设计建议
 
 基于当前实现，最稳妥的工具设计通常是：
 
@@ -228,7 +262,7 @@ public class QueryWeatherFunction implements Function<QueryWeatherFunction.Reque
 
 这会显著降低 schema 漂移和模型误调用概率。
 
-## 10. 这页最该记住的结论
+## 11. 这页最该记住的结论
 
 AI4J 的注解式工具，不是“给类贴几个标签”，而是一条从 Java 类型到 provider tool schema 的生成链。
 

--- a/docs-site/docs/core-sdk/tools/overview.md
+++ b/docs-site/docs/core-sdk/tools/overview.md
@@ -81,6 +81,10 @@ tags: [concept]
 
 这就是为什么模型看到的“一个工具列表”，在实现层其实可能来自多条不同的能力来源。
 
+### 3.5 第三方扩展插件（SPI）
+
+上述四类都是基座内置来源。若要让**第三方 jar** 也注入工具（或命令、Skill、Prompt、Guardrail），走的是扩展 SPI——`ServiceLoader` 发现 + `ExtensionRegistry` 的 `discover/enable/exposeTool` 三段式门禁，**默认不自动把插件工具暴露给模型**。这条注入路径与本章的注解/白名单机制互补，详见 [Plugin Packages](/docs/core-sdk/extension/plugin-packages)。
+
 ## 4. 一条最重要的主线
 
 如果只记一条链，可以先记这个：

--- a/docs-site/docs/core-sdk/tools/tool-execution-model.md
+++ b/docs-site/docs/core-sdk/tools/tool-execution-model.md
@@ -121,6 +121,34 @@ ToolUtil.getAllTools(functionList, mcpServerIds, userId)
 
 因此暴露层和执行层不是简单一一对应的。
 
+### 5.1 多租户路由：`user_{userId}_tool_{toolName}` 命名约定
+
+优先级里排在 built-in 之后的“用户级远程 MCP 工具”不是靠额外参数识别的，而是靠**函数名编码**。`ToolUtil.invoke(...)` 在 built-in 未命中后，会先用 `extractUserIdFromFunctionName(functionName)` 检查名字是否匹配：
+
+```text
+user_{userId}_tool_{toolName}
+```
+
+例如 `user_123_tool_create_issue` 会被解析成 `userId=123`、`toolName=create_issue`，然后直接走：
+
+```java
+gateway.callUserTool("123", "create_issue", argumentObject).join()
+```
+
+这条路径绕过了本地 MCP / Function / 全局 gateway 的常规查找，把调用定向到该用户专属的 `McpClient`。配套地，工具面组装侧的 `ToolUtil.getUserMcpTools(mcpServerIds, userId)` / `getAllTools(functionList, mcpServerIds, userId)` 只会把该用户已注册的用户级服务工具投影进本次请求，因此模型看到的 `user_123_tool_*` 名字与它能调用的用户工具一一对应。
+
+也可以不走名字编码，直接显式传 `userId` 调用：
+
+```java
+ToolUtil.invoke("create_issue", argument, "123");   // 等价于上面的路由
+```
+
+设计要点：
+
+- **隔离靠 key，不靠运行时判断**：用户级 MCP 客户端按 `user_{userId}_service_{serviceId}` / `user_{userId}_tool_{toolName}` 注册进 gateway，隔离在映射层就完成。
+- **用户级优先于全局**：一旦函数名命中 `user_..._tool_...`，就不会再落到全局 gateway 查找，同名工具不会串租户。
+- **这是 SaaS / 多租户宿主的能力**：单租户场景用不到这套约定，模型拿到的就是普通工具名。
+
 ## 6. 内建工具为什么是特殊路径
 
 `ToolUtil.invoke(...)` 一开始就会先尝试：
@@ -336,3 +364,7 @@ AI4J 当前的工具执行模型，本质上是一个“统一工具路由器”
 - 结果统一文本化回流给上层 runtime
 
 理解这条链后，再去看 Agent 或 Coding Agent 的审批、trace、长任务治理，层次就不会混。
+
+## 继续阅读
+
+- → [ToolUtil API Javadoc](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/tool/ToolUtil.html)（`getAllTools(...)` / `invoke(...)` / `getUserMcpTools(...)` 等工具调度入口）

--- a/docs-site/docs/core-sdk/tools/tool-whitelist-and-security.md
+++ b/docs-site/docs/core-sdk/tools/tool-whitelist-and-security.md
@@ -197,6 +197,15 @@ context.resolveReadablePath(path)
 
 从安全面看，这意味着 `bash` 的能力面比“跑一条命令”大得多：`start` 可以留下持续占用资源、长期读写工作区或外联网络的后台进程。给模型开放 `bash` 即等于同时开放了后台进程治理，宿主应把 `start`/`write`/`stop` 视作与 `exec` 同级的副作用动作纳入审批与审计。
 
+#### bash 输出的字符集解析（Windows GBK 兜底）
+
+`bash` 的 stdout/stderr 在回流前要先按某个 `Charset` 解码成字符串。`BuiltInToolExecutor`（以及后台进程的 `BuiltInProcessRegistry`、`ai4j-coding` 的 `ShellCommandSupport.resolveShellCharset()`）按下面的顺序解析这个字符集：
+
+1. **显式覆盖优先**：系统属性 `ai4j.shell.encoding`（或环境变量 `AI4J_SHELL_ENCODING`）只要指向一个 JVM 支持的字符集就立即采用，常用于把 Windows 控制台强制钉成 UTF-8。
+2. **平台兜底**：未显式指定时，非 Windows 一律按 UTF-8；Windows 则依次尝试 `native.encoding` → `sun.jnu.encoding` → `file.encoding` → `Charset.defaultCharset()`——在中文 Windows 上这通常解析成 **GBK**。
+
+所以同一个 `bash` 工具，在 Linux/macOS 默认返回 UTF-8 文本，在中文 Windows 默认按 GBK 解码。若模型看到乱码，几乎都是控制台实际编码与上述推断不一致，这时用 `-Dai4j.shell.encoding=UTF-8`（或 `AI4J_SHELL_ENCODING=UTF-8`）显式钉死即可，无需改代码。
+
 ## 7. `readOnlyCodingToolNames()` 的边界要说清楚
 
 `BuiltInTools` 里当前有：
@@ -209,8 +218,10 @@ readOnlyCodingToolNames()
 
 - `bash`
 - `read_file`
+- `glob`
+- `grep`
 
-归到一个只读集合。
+归到一个只读集合（对应源码 `READ_ONLY_CODING_TOOL_NAMES = {BASH, READ_FILE, GLOB, GREP}`）。
 
 但要注意，这更像一个分类辅助，而不是完整的策略引擎。单靠这个集合本身，并不会自动阻止 `bash` 执行有副作用命令。
 
@@ -280,3 +291,7 @@ AI4J 当前的工具安全，不是“全量自动发现后再补救”，而是
 - 再用 `BuiltInToolContext` 收窄 built-in 宿主边界
 
 这已经构成了基座层的第一道防线；但审批、鉴权、审计、真正的进程隔离，仍然属于更上层 runtime 和宿主治理问题。
+
+## 继续阅读
+
+- → [BuiltInTools API Javadoc](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/tool/BuiltInTools.html)（`allCodingToolNames()` / `readOnlyCodingToolNames()` 等内建工具契约）

--- a/docs-site/docs/flowgram/frontend-backend-integration.md
+++ b/docs-site/docs/flowgram/frontend-backend-integration.md
@@ -324,6 +324,8 @@ Runtime 负责：
 
 也就是说，权限控制不在前端 runtime plugin，而在后端 facade 这一层。
 
+另外，前端画布与后端任务 API 通常部署在不同 origin，浏览器跨域调用 `/flowgram/**` 需要后端放行 CORS：把编辑器来源加进 `ai4j.flowgram.cors.allowed-origins`（默认空列表，绑定 `CorsProperties`）。完整字段见 [Spring Boot Configuration Reference](/docs/spring-boot/configuration-reference) §5（`ai4j.flowgram.*` / CORS）。
+
 ## 11. 最重要的对接原则
 
 最稳的对接方式，不是让前端知道更多后端细节，而是守住这 3 条边界：

--- a/docs-site/docs/spring-boot/bean-extension.md
+++ b/docs-site/docs/spring-boot/bean-extension.md
@@ -71,6 +71,19 @@ public RagContextAssembler ragContextAssembler() {
 不确定 encoding 时，不需要硬猜；保留模型名或只传 budget，让 SDK 使用默认估算并设置更保守的 budget。
 :::
 
+### OkHttp SPI 扩展点：Dispatcher 与 ConnectionPool
+
+OkHttp 的并发调度和连接池**不走 `@Bean` 覆盖**，而是走 Java SPI（`META-INF/services`）。两个扩展点都在 `io.github.lnyocly.ai4j.network`：
+
+- `DispatcherProvider` —— 控制并发请求调度（默认实现 `DefaultDispatcherProvider`）
+- `ConnectionPoolProvider` —— 控制连接复用与回收（默认实现 `DefaultConnectionPoolProvider`）
+
+要换实现，在自己的 JAR 里放 `META-INF/services/io.github.lnyocly.ai4j.network.DispatcherProvider`（或 `...ConnectionPoolProvider`），写入实现类全名即可，无需改 starter 或业务 Bean。超时、代理、SSL 等可调参数仍由 `ai.okhttp.*` 控制（见 [Configuration Reference §4](/docs/spring-boot/configuration-reference#4-aiokhttp-的位置)）。
+
+:::tip 何时走 SPI 而不是 @Bean
+Spring `@Bean` 适合替换业务/容器层对象（`RagContextAssembler`、`VectorStore` 等）。`OkHttpClient` 的并发原语被整个 starter 共享，且 starter 通过 SPI 解析它们，所以这里用 SPI 才是正确层级；不要试图用 `@Bean OkHttpClient` 硬覆盖去间接改调度策略。
+:::
+
 ## 5. 工程原则
 
 - 优先替换统一抽象后的 Bean，而不是修改底层 provider 私有实现

--- a/docs-site/docs/start-here/extend-ai4j.md
+++ b/docs-site/docs/start-here/extend-ai4j.md
@@ -50,7 +50,10 @@ tags: [concept]
 
 ai4j 没有独立的"slash 提示模板引擎"。**Prompt 是插件资源的一种**：插件在 `apply(...)` 里用 `context.prompts().register(...)` 注册一个 `ExtensionPromptResource`（指向 jar 内的 markdown 资源），启用后它会被物化成只读文件，进入 agent 的 `<available_prompts>` 清单，由宿主或 Coding Agent 按需读取。
 
-也就是说，ai4j 的 Prompt 和 Skill 共享同一套"摘要先行、按需读取"的上下文治理思路，区别在资源类型。官方 `ask-user` 插件是同时贡献 tool + command + Skill + Prompt 的样板，最适合作为这条线的参考实现。
+也就是说，ai4j 的 Prompt 和 Skill 共享同一套"摘要先行、按需读取"的上下文治理思路，区别在资源类型。ai4j 有**两个官方参考插件**，各有侧重：
+
+- **`ask-user`**——最小插件（host-mediated 用户澄清 tool + command + Skill + Prompt），适合学习扩展的基本骨架。
+- **`dynamic-workflow`**——🚀 **生产级旗舰参考**（同时贡献 4 种能力 + host-mediated workflow 信封 + 零运行时依赖 + live 闭环测试）。适合学习如何构建一个完整的、安全的、可发布的 ai4j 插件。详见 [Dynamic Workflow Plugin](/docs/core-sdk/extension/dynamic-workflow-plugin)。
 
 → [Ask User Plugin](/docs/core-sdk/extension/ask-user-plugin)（同时贡献 Prompt 的样板）｜[Dynamic Workflow Plugin](/docs/core-sdk/extension/dynamic-workflow-plugin)（脚本化 Prompt + Skill 样板）
 

--- a/docs-site/docs/start-here/quickstart-java.md
+++ b/docs-site/docs/start-here/quickstart-java.md
@@ -194,3 +194,5 @@ openAiConfig.setApiHost("https://codex.trovebox.online/");
 - 想理解 `Chat` 细节：看 [Core SDK / Model Access / Chat](/docs/core-sdk/model-access/chat)
 - 想让模型调用本地函数：看 [First Tool Call](/docs/start-here/first-tool-call)
 - 想继续看完整能力：看 [Feature Map](/docs/start-here/feature-map)
+
+→ API Javadoc：[`AiService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/factory/AiService.html) · [`IChatService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/IChatService.html)


### PR DESCRIPTION
Final polish: 9 remaining minor gaps fixed + 11 javadoc.io deep-links added to key pages. All 53 audit gaps now resolved (0 outstanding).

🤔 Generated by Claude Code