### PR TITLE
fix(exception): 非 Chat 服务丢弃 provider 错误信息

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/exception/HttpErrorDecoder.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/exception/HttpErrorDecoder.java
@@ -13,6 +13,9 @@ public final class HttpErrorDecoder {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    /** Upper bound on raw-body text kept in an exception message. */
+    private static final int MAX_RAW_BODY_CHARS = 500;
+
     private HttpErrorDecoder() {
     }
 
@@ -30,6 +33,12 @@ public final class HttpErrorDecoder {
         } catch (Exception ignored) {
         }
         String message = extractMessage(body);
+        if (message == null || message.isEmpty()) {
+            // Not a recognised JSON error shape: keep the raw body rather than
+            // discard it, otherwise gateway/proxy failures (HTML or plain-text
+            // error pages) leave the caller with nothing to debug.
+            message = rawBodySnippet(body);
+        }
         if (message == null || message.isEmpty()) {
             String httpMsg = response.message();
             message = (httpMsg != null && !httpMsg.isEmpty())
@@ -112,5 +121,18 @@ public final class HttpErrorDecoder {
 
     private static boolean isNotBlank(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private static String rawBodySnippet(String body) {
+        if (body == null) {
+            return null;
+        }
+        String trimmed = body.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed.length() <= MAX_RAW_BODY_CHARS
+                ? trimmed
+                : trimmed.substring(0, MAX_RAW_BODY_CHARS) + "... (truncated)";
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/dashscope/response/DashScopeResponsesService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/dashscope/response/DashScopeResponsesService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.dashscope.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.DashScopeConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ResponseSseListener;
 import io.github.lnyocly.ai4j.listener.StreamExecutionSupport;
 import io.github.lnyocly.ai4j.platform.openai.chat.entity.StreamOptions;
@@ -63,8 +63,8 @@ public class DashScopeResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), Response.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("DashScope Responses request failed");
     }
 
     @Override
@@ -121,8 +121,8 @@ public class DashScopeResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), Response.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("DashScope Responses retrieve failed");
     }
 
     @Override
@@ -146,8 +146,8 @@ public class DashScopeResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), ResponseDeleteResponse.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("DashScope Responses delete failed");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/image/DoubaoImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/image/DoubaoImageService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.doubao.image;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.DoubaoConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ImageSseListener;
 import io.github.lnyocly.ai4j.platform.doubao.image.entity.DoubaoImageGenerationRequest;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
@@ -81,9 +81,8 @@ public class DoubaoImageService implements IImageService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), ImageGenerationResponse.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-
-        throw new CommonException("豆包图片生成请求失败");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/rerank/DoubaoRerankService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/rerank/DoubaoRerankService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.DoubaoConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.network.UrlUtils;
 import io.github.lnyocly.ai4j.rerank.entity.RerankDocument;
 import io.github.lnyocly.ai4j.rerank.entity.RerankRequest;
@@ -90,8 +90,8 @@ public class DoubaoRerankService implements IRerankService {
             if (response.isSuccessful() && response.body() != null) {
                 return parseResponse(objectMapper.readTree(response.body().string()), request);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("Doubao rerank request failed");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/response/DoubaoResponsesService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/response/DoubaoResponsesService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.doubao.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.DoubaoConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ResponseSseListener;
 import io.github.lnyocly.ai4j.listener.StreamExecutionSupport;
 import io.github.lnyocly.ai4j.platform.openai.response.ResponseEventParser;
@@ -62,8 +62,8 @@ public class DoubaoResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), Response.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("Doubao Responses request failed");
     }
 
     @Override
@@ -118,8 +118,8 @@ public class DoubaoResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), Response.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("Doubao Responses retrieve failed");
     }
 
     @Override
@@ -143,8 +143,8 @@ public class DoubaoResponsesService implements IResponsesService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), ResponseDeleteResponse.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("Doubao Responses delete failed");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioService.java
@@ -3,6 +3,9 @@ package io.github.lnyocly.ai4j.platform.openai.audio;
 import com.alibaba.fastjson2.JSON;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
+import io.github.lnyocly.ai4j.exception.Ai4jException;
+import io.github.lnyocly.ai4j.exception.AiClientException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.platform.openai.audio.entity.TextToSpeech;
 import io.github.lnyocly.ai4j.platform.openai.audio.entity.Transcription;
 import io.github.lnyocly.ai4j.platform.openai.audio.entity.TranscriptionResponse;
@@ -62,19 +65,21 @@ public class OpenAiAudioService implements IAudioService {
         try {
             response = okHttpClient.newCall(request).execute();
             if (!response.isSuccessful()) {
-                throw new IOException("Unexpected code " + response);
+                throw HttpErrorDecoder.decode(response);
             }
 
             ResponseBody responseBody = response.body();
-            if (responseBody != null) {
-                return new ResponseInputStream(response, responseBody.byteStream());
+            if (responseBody == null) {
+                throw new AiClientException(response.code(), "OpenAI speech response had no body");
             }
+            InputStream stream = new ResponseInputStream(response, responseBody.byteStream());
+            response = null; // ownership transferred to the returned stream
+            return stream;
         } catch (IOException e) {
+            throw new Ai4jException("OpenAI speech request failed: " + e.getMessage(), e);
+        } finally {
             closeQuietly(response);
-            e.printStackTrace();
         }
-        closeQuietly(response);
-        return null;
     }
 
     @Override
@@ -156,10 +161,10 @@ public class OpenAiAudioService implements IAudioService {
             if (response.isSuccessful() && response.body() != null) {
                 return JSON.parseObject(response.body().string(), responseType);
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+            throw HttpErrorDecoder.decode(response);
+        } catch (IOException e) {
+            throw new Ai4jException("OpenAI audio request failed: " + e.getMessage(), e);
         }
-        return null;
     }
 
     private String resolveBaseUrl(String baseUrl) {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.openai.image;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ImageSseListener;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGenerationResponse;
@@ -66,9 +66,8 @@ public class OpenAiImageService implements IImageService {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), ImageGenerationResponse.class);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-
-        throw new CommonException("OpenAI 图片生成请求失败");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/response/OpenAiResponsesService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/response/OpenAiResponsesService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.openai.response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ResponseSseListener;
 import io.github.lnyocly.ai4j.listener.StreamExecutionSupport;
 import io.github.lnyocly.ai4j.platform.openai.chat.entity.StreamOptions;
@@ -81,7 +81,7 @@ public class OpenAiResponsesService implements IResponsesService {
         request = ResponseRequestToolResolver.resolve(request);
 
         Request httpRequest = buildJsonPostRequest(url, key, serializeRequest(request));
-        return executeJsonRequest(httpRequest, Response.class, "OpenAI Responses request failed");
+        return executeJsonRequest(httpRequest, Response.class);
     }
 
     @Override
@@ -122,7 +122,7 @@ public class OpenAiResponsesService implements IResponsesService {
         Request httpRequest = authorizedRequestBuilder(url, key)
                 .get()
                 .build();
-        return executeJsonRequest(httpRequest, Response.class, "OpenAI Responses retrieve failed");
+        return executeJsonRequest(httpRequest, Response.class);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class OpenAiResponsesService implements IResponsesService {
         Request httpRequest = authorizedRequestBuilder(url, key)
                 .delete()
                 .build();
-        return executeJsonRequest(httpRequest, ResponseDeleteResponse.class, "OpenAI Responses delete failed");
+        return executeJsonRequest(httpRequest, ResponseDeleteResponse.class);
     }
 
     @Override
@@ -170,13 +170,14 @@ public class OpenAiResponsesService implements IResponsesService {
                 .url(url);
     }
 
-    private <T> T executeJsonRequest(Request request, Class<T> responseType, String failureMessage) throws Exception {
+    private <T> T executeJsonRequest(Request request, Class<T> responseType) throws Exception {
         try (okhttp3.Response response = okHttpClient.newCall(request).execute()) {
             if (response.isSuccessful() && response.body() != null) {
                 return objectMapper.readValue(response.body().string(), responseType);
             }
+            // Decode inside the try: once the response closes, the provider's error body is gone.
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException(failureMessage);
     }
 
     private Map<String, Object> buildOpenAiPayload(ResponseRequest request) {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.network.UrlUtils;
 import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
 import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
@@ -101,9 +101,11 @@ public class OpenAiVideoService implements IVideoService {
                 .build();
         Response response = okHttpClient.newCall(request).execute();
         if (!response.isSuccessful() || response.body() == null) {
-            String message = errorMessage(response);
-            response.close();
-            throw new CommonException(message);
+            try {
+                throw HttpErrorDecoder.decode(response);
+            } finally {
+                response.close();
+            }
         }
         return new ResponseInputStream(response, response.body().byteStream());
     }
@@ -145,7 +147,7 @@ public class OpenAiVideoService implements IVideoService {
                 videoResponse.setRaw(mapper.readValue(body, new TypeReference<Map<String, Object>>() { }));
                 return videoResponse;
             }
-            throw new CommonException(errorMessage(response));
+            throw HttpErrorDecoder.decode(response);
         }
     }
 
@@ -165,12 +167,6 @@ public class OpenAiVideoService implements IVideoService {
 
     private String encodePathSegment(String value) throws IOException {
         return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
-    }
-
-    private String errorMessage(Response response) throws IOException {
-        ResponseBody body = response.body();
-        String detail = body == null ? "" : body.string();
-        return "OpenAI video request failed: HTTP " + response.code() + (detail.length() == 0 ? "" : " - " + detail);
     }
 
     private static final class ResponseInputStream extends FilterInputStream {

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/standard/rerank/StandardRerankService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/standard/rerank/StandardRerankService.java
@@ -3,7 +3,7 @@ package io.github.lnyocly.ai4j.platform.standard.rerank;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.network.UrlUtils;
 import io.github.lnyocly.ai4j.rerank.entity.RerankDocument;
 import io.github.lnyocly.ai4j.rerank.entity.RerankRequest;
@@ -72,8 +72,8 @@ public class StandardRerankService implements IRerankService {
                 JsonNode root = objectMapper.readTree(response.body().string());
                 return toResponse(root, request);
             }
+            throw HttpErrorDecoder.decode(response);
         }
-        throw new CommonException("Standard rerank request failed");
     }
 
     @Override

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/suno/music/SunoMusicService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/suno/music/SunoMusicService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.lnyocly.ai4j.config.SunoConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.network.UrlUtils;
 import io.github.lnyocly.ai4j.platform.suno.music.entity.SunoFetchResponse;
 import io.github.lnyocly.ai4j.platform.suno.music.entity.SunoLyricsRequest;
@@ -128,13 +128,7 @@ public class SunoMusicService implements IMusicService {
                 }
                 return parsed;
             }
-            throw new CommonException(errorMessage(response));
+            throw HttpErrorDecoder.decode(response);
         }
-    }
-
-    private String errorMessage(Response response) throws IOException {
-        ResponseBody body = response.body();
-        String detail = body == null ? "" : body.string();
-        return "Suno request failed: HTTP " + response.code() + (detail.length() == 0 ? "" : " - " + detail);
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/websearch/ChatWithWebSearchEnhance.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/websearch/ChatWithWebSearchEnhance.java
@@ -2,6 +2,8 @@ package io.github.lnyocly.ai4j.websearch;
 
 import com.alibaba.fastjson2.JSON;
 import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.Ai4jException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.SseListener;
 import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletion;
 import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletionResponse;
@@ -100,12 +102,14 @@ public class ChatWithWebSearchEnhance implements IChatService {
 
 
             }else{
-                throw new CommonException("SearXNG request failed");
+                throw HttpErrorDecoder.decode(execute);
             }
 
 
+        } catch (Ai4jException e) {
+            throw e;
         } catch (Exception e) {
-            throw new CommonException("SearXNG request failed");
+            throw new CommonException("SearXNG request failed: " + e.getMessage());
         }
 
 

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/exception/NonChatServiceHttpErrorTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/exception/NonChatServiceHttpErrorTest.java
@@ -1,0 +1,227 @@
+package io.github.lnyocly.ai4j.exception;
+
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.platform.openai.audio.OpenAiAudioService;
+import io.github.lnyocly.ai4j.platform.openai.audio.entity.Transcription;
+import io.github.lnyocly.ai4j.platform.openai.image.OpenAiImageService;
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
+import io.github.lnyocly.ai4j.platform.openai.response.OpenAiResponsesService;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
+import io.github.lnyocly.ai4j.platform.standard.rerank.StandardRerankService;
+import io.github.lnyocly.ai4j.rerank.entity.RerankRequest;
+import io.github.lnyocly.ai4j.service.Configuration;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Offline regression tests for issue #228: non-chat services used to discard the
+ * provider's error body and throw a hardcoded generic message, leaving callers
+ * with nothing to debug.
+ *
+ * <p>Every service here must now route HTTP failures through
+ * {@link HttpErrorDecoder}, matching what the {@code *ChatService} family
+ * already does.
+ */
+public class NonChatServiceHttpErrorTest {
+
+    /** The exact failure reported in issue #228, observed live against a gateway. */
+    private static final String GATEWAY_MESSAGE =
+            "previous_response_id is only supported on Responses WebSocket v2";
+
+    // ---- OpenAI Responses (the originally reported service) ----
+
+    @Test
+    public void responsesCreate_propagatesProviderMessageInsteadOfGenericText() {
+        OpenAiResponsesService service = responsesService(400,
+                "{\"error\":{\"message\":\"" + GATEWAY_MESSAGE + "\"}}");
+
+        try {
+            service.create(ResponseRequest.builder().model("gpt-4o-mini").input("hi").build());
+            Assert.fail("Expected AiClientException");
+        } catch (AiClientException e) {
+            Assert.assertEquals(400, e.getStatusCode());
+            Assert.assertTrue("provider message must survive, got: " + e.getMessage(),
+                    e.getMessage().contains(GATEWAY_MESSAGE));
+        } catch (Exception e) {
+            Assert.fail("Expected AiClientException, got " + e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void responsesCreate_401_isTypedAsAuthFailure() {
+        OpenAiResponsesService service = responsesService(401,
+                "{\"error\":{\"message\":\"Invalid API key\"}}");
+
+        try {
+            service.create(ResponseRequest.builder().model("gpt-4o-mini").input("hi").build());
+            Assert.fail("Expected AiAuthException");
+        } catch (AiAuthException e) {
+            Assert.assertEquals(401, e.getStatusCode());
+            Assert.assertTrue(e.getMessage().contains("Invalid API key"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiAuthException, got " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void responsesRetrieve_alsoDecodesTheErrorBody() {
+        OpenAiResponsesService service = responsesService(429,
+                "{\"error\":{\"message\":\"Rate limit exceeded\"}}");
+
+        try {
+            service.retrieve("resp_123");
+            Assert.fail("Expected AiRateLimitException");
+        } catch (AiRateLimitException e) {
+            Assert.assertEquals(429, e.getStatusCode());
+            Assert.assertTrue(e.getMessage().contains("Rate limit exceeded"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiRateLimitException, got " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void responsesDelete_alsoDecodesTheErrorBody() {
+        OpenAiResponsesService service = responsesService(404,
+                "{\"error\":{\"message\":\"No such response\"}}");
+
+        try {
+            service.delete("resp_missing");
+            Assert.fail("Expected AiClientException");
+        } catch (AiClientException e) {
+            Assert.assertTrue(e.getMessage().contains("No such response"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiClientException, got " + e.getClass().getName());
+        }
+    }
+
+    /**
+     * Gateways and reverse proxies fail with HTML or plain text, not the OpenAI
+     * error envelope. That body is often the only clue, so it must not be dropped.
+     */
+    @Test
+    public void nonJsonErrorBodyIsPreservedRatherThanReducedToStatusLine() {
+        OpenAiResponsesService service = responsesService(502,
+                "<html><body>Bad Gateway: upstream connect timeout</body></html>");
+
+        try {
+            service.create(ResponseRequest.builder().model("gpt-4o-mini").input("hi").build());
+            Assert.fail("Expected AiServerErrorException");
+        } catch (AiServerErrorException e) {
+            Assert.assertEquals(502, e.getStatusCode());
+            Assert.assertTrue("raw body must survive, got: " + e.getMessage(),
+                    e.getMessage().contains("upstream connect timeout"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiServerErrorException, got " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void oversizedErrorBodyIsTruncatedNotDumpedWhole() {
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 5000; i++) {
+            huge.append('x');
+        }
+        OpenAiResponsesService service = responsesService(500, huge.toString());
+
+        try {
+            service.create(ResponseRequest.builder().model("gpt-4o-mini").input("hi").build());
+            Assert.fail("Expected AiServerErrorException");
+        } catch (AiServerErrorException e) {
+            Assert.assertTrue("message should be bounded, was " + e.getMessage().length(),
+                    e.getMessage().length() < 700);
+            Assert.assertTrue(e.getMessage().contains("truncated"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiServerErrorException, got " + e.getClass().getName());
+        }
+    }
+
+    // ---- Audio: used to swallow the exception and return null ----
+
+    @Test
+    public void audioTranscription_throwsInsteadOfReturningNull() throws Exception {
+        File audio = File.createTempFile("ai4j-test-", ".mp3");
+        audio.deleteOnExit();
+
+        OpenAiAudioService service = new OpenAiAudioService(
+                configuration(400, "{\"error\":{\"message\":\"Audio file is too short\"}}"));
+
+        try {
+            Object result = service.transcription(
+                    Transcription.builder().file(audio).model("whisper-1").build());
+            Assert.fail("Should have thrown instead of returning " + result);
+        } catch (AiClientException e) {
+            Assert.assertEquals(400, e.getStatusCode());
+            Assert.assertTrue(e.getMessage().contains("Audio file is too short"));
+        }
+    }
+
+    // ---- Image and rerank: same generic-message defect ----
+
+    @Test
+    public void imageGeneration_propagatesProviderMessage() {
+        OpenAiImageService service = new OpenAiImageService(
+                configuration(400, "{\"error\":{\"message\":\"Your prompt was rejected\"}}"));
+
+        try {
+            service.generate(ImageGeneration.builder().model("dall-e-3").prompt("a cat").build());
+            Assert.fail("Expected AiClientException");
+        } catch (AiClientException e) {
+            Assert.assertTrue(e.getMessage().contains("Your prompt was rejected"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiClientException, got " + e.getClass().getName());
+        }
+    }
+
+    @Test
+    public void rerank_propagatesProviderMessage() {
+        StandardRerankService service = new StandardRerankService(
+                stubClient(400, "{\"error\":{\"message\":\"Unknown rerank model\"}}"),
+                "https://unit.test/", "test-key", "/v1/rerank");
+
+        try {
+            service.rerank(RerankRequest.builder().model("bad-model").query("q").build());
+            Assert.fail("Expected AiClientException");
+        } catch (AiClientException e) {
+            Assert.assertTrue(e.getMessage().contains("Unknown rerank model"));
+        } catch (Exception e) {
+            Assert.fail("Expected AiClientException, got " + e.getClass().getName());
+        }
+    }
+
+    // ---- helpers ----
+
+    private OpenAiResponsesService responsesService(int statusCode, String errorBody) {
+        return new OpenAiResponsesService(configuration(statusCode, errorBody));
+    }
+
+    private Configuration configuration(int statusCode, String errorBody) {
+        OpenAiConfig config = new OpenAiConfig();
+        config.setApiKey("test-key");
+        config.setApiHost("https://unit.test/");
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(config);
+        configuration.setOkHttpClient(stubClient(statusCode, errorBody));
+        return configuration;
+    }
+
+    /** Short-circuits the call so no network is required. */
+    private OkHttpClient stubClient(final int statusCode, final String errorBody) {
+        return new OkHttpClient.Builder()
+                .addInterceptor(chain -> new Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(statusCode)
+                        .message("Error")
+                        .body(ResponseBody.create(errorBody, MediaType.get("application/json")))
+                        .build())
+                .build();
+    }
+}

--- a/docs-site/docs/core-sdk/search-and-rag/online-search.md
+++ b/docs-site/docs/core-sdk/search-and-rag/online-search.md
@@ -175,19 +175,31 @@ chatCompletion.getMessages().get(chatLen - 1)
 
 ## 7. 当前失败路径是什么样的
 
-`performWebSearch(...)` 的失败处理相对保守：
+`performWebSearch(...)` 的失败按类型区分：
 
 - 没配置 `SearXNG url`，直接抛 `CommonException`
-- 请求失败，抛 `CommonException("SearXNG request failed")`
-- 解析或网络异常，也统一抛这个错误
+- 上游返回非 2xx，抛 `HttpErrorDecoder` 解码出的类型化异常（`AiAuthException` / `AiRateLimitException` / `AiServerErrorException` / `AiClientException`），**携带上游返回的原始错误信息**，并可通过 `getStatusCode()` 读取状态码
+- 解析或网络异常，抛 `CommonException`，消息中附带底层异常的 `getMessage()`
 
-这带来的好处是接口表面简单；代价是错误被压平了。  
-排障时你往往还得自己补日志，否则很难区分：
+因此排障时可以直接区分：
 
-- 网络错误
-- 上游返回异常
-- JSON 解析失败
-- 配置错误
+```java
+try {
+    String results = enhance.performWebSearch(query);
+} catch (AiRateLimitException e) {
+    // 上游限流，可退避重试
+} catch (AiAuthException e) {
+    // 凭证问题
+} catch (AiHttpException e) {
+    // 其它上游 HTTP 错误，e.getStatusCode() + e.getMessage() 已含上游原文
+} catch (CommonException e) {
+    // 配置缺失、网络或解析失败
+}
+```
+
+:::note 版本差异
+在 v2.4.2 及更早版本中，上述所有情况都会被压平成同一句 `CommonException("SearXNG request failed")`，无法区分。详见 [issue #228](https://github.com/LnYo-Cly/ai4j/issues/228)。
+:::
 
 ## 8. 这一层最真实的安全与质量边界
 


### PR DESCRIPTION
Closes #228

## 问题

非 Chat 类服务在 HTTP 失败时丢弃 provider 返回的真实错误，只抛一句写死的通用文案。实测（TroveBox 网关）：

| | 消息 |
| --- | --- |
| 网关实际返回 | `previous_response_id is only supported on Responses WebSocket v2` |
| 修复前 SDK 抛出 | `CommonException: OpenAI Responses request failed` |
| 修复后 SDK 抛出 | `AiClientException(400): previous_response_id is only supported on Responses WebSocket v2` |

最后一行是**真机实测输出**，非构造。

## 机械成因

`throw` 写在 try-with-resources **外面**——执行到它时 response 已关闭，body 读不出来，所以只能写死文案：

```java
try (Response response = ...) {
    if (response.isSuccessful() && response.body() != null) { return ...; }
}                                                    // <-- 已关闭
throw new CommonException("OpenAI Responses request failed");   // <-- body 不可读
```

把 `throw` 移进 try 内，即可复用 SDK **已有的** `HttpErrorDecoder`（11 个 `*ChatService` 早已在用）。没有引入任何新抽象。

## 改动范围

| 服务 | 改动 |
| --- | --- |
| OpenAI / Doubao / DashScope Responses | 通用文案 → `HttpErrorDecoder`（各 3 个入口） |
| OpenAI / Doubao Image | 同上 |
| Standard / Doubao Rerank | 同上 |
| Suno Music、OpenAI Video | 删掉各自手写的 `errorMessage()`，改用 decoder（顺带获得类型化） |
| SearXNG Online Search | 类型化 + 保留底层异常 message |
| **OpenAI Audio** | **原先吞异常 + 返回 null**，改为抛出 |

### OpenAiAudioService 是最严重的一处

原实现 `catch (Exception e) { e.printStackTrace(); } return null;` —— 转录/翻译失败时静默返回 null，用户在下游拿到一个毫无线索的 NPE。现改为抛出，与 `OpenAiChatServiceHttpErrorTest#chatCompletion_doesNotReturnNullOnNon2xx` 已确立的约定一致。

### HttpErrorDecoder 增强

非 JSON 错误体（网关/反代返回的 HTML 或纯文本）此前会被压成 `"502 Bad Gateway"`，正文丢失。现保留正文并限长 500 字符。这同时保证 Suno/Video 改用 decoder 后**不丢失**它们原本手工拼接的信息。

## 验证

- 新增 `NonChatServiceHttpErrorTest`，9 个用例，无需密钥（拦截器打桩）
- **回退 `src/main` 后 9/9 全部失败；带上修复 9/9 通过** —— 确认测试确实锁住了该缺陷
- `ai4j` 模块全量 280 用例通过，含既有 `ErrorInterceptorTest` / `HttpErrorDecoderTest`
- 全模块 `test-compile` 通过
- 真机 live 复现确认（见上表）

## 兼容性

`CommonException` 与 `AiHttpException` 同为 `Ai4jException`（`RuntimeException`）子类：

- `catch (Ai4jException | Exception)` → 不受影响
- 在这些失败路径上**专门** `catch (CommonException)` 的代码 → 需调整

Chat 系列此前已完成同样切换，本次是把剩余服务对齐既有约定。文档 `online-search.md` 第 7 节原本记录并吐槽了旧的"错误被压平"行为，已同步更新并标注版本差异。