### PR TITLE
fix(responses): function tool 形状 + strict mode 支持

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/annotation/FunctionCall.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/annotation/FunctionCall.java
@@ -15,4 +15,16 @@ import java.lang.annotation.Target;
 public @interface FunctionCall {
     String name();
     String description();
+
+    /**
+     * 是否对该函数启用严格模式（strict mode）。OpenAI 官方建议开启。
+     *
+     * <p>开启后，{@link io.github.lnyocly.ai4j.platform.openai.tool.Tool.Function#getStrict()}
+     * 为 {@code true}，且参数 schema 会被自动调整为严格模式要求的形态：
+     * {@code additionalProperties=false}，所有字段列入 {@code required}，
+     * 原本可选的字段标记为可空（{@code ["string","null"]}）。
+     *
+     * <p>默认 {@code false}，保持与历史版本一致的行为。
+     */
+    boolean strict() default false;
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/tool/Tool.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/tool/Tool.java
@@ -1,5 +1,6 @@
 package io.github.lnyocly.ai4j.platform.openai.tool;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,6 +51,23 @@ public class Tool {
          */
         private Parameter parameters;
 
+        /**
+         * 是否启用严格模式。OpenAI 官方建议开启，开启后模型的函数调用会严格遵循
+         * schema，而不是尽力而为。
+         *
+         * <p>严格模式对 schema 有硬性要求：{@code additionalProperties} 必须为
+         * {@code false}，且 {@code properties} 中所有字段都必须出现在
+         * {@code required} 里；不满足时请求会被拒绝。使用
+         * {@link Parameter#enforceStrictSchema()} 可以把已有 schema 调整到位。
+         *
+         * <p>为 {@code null}（默认）时不会出现在请求体中，行为与历史版本一致。
+         */
+        private Boolean strict;
+
+        /** 兼容构造器：不带 strict（保持既有调用方签名不变）。 */
+        public Function(String name, String description, Parameter parameters) {
+            this(name, description, parameters, null);
+        }
 
 
         @Data
@@ -71,6 +89,53 @@ public class Tool {
              */
             private List<String> required;
 
+            /**
+             * 是否允许 schema 之外的额外属性。严格模式要求为 {@code false}。
+             *
+             * <p>为 {@code null}（默认）时不会出现在请求体中。
+             */
+            @JsonProperty("additionalProperties")
+            private Boolean additionalProperties;
+
+            /** 兼容构造器：不带 additionalProperties（保持既有调用方签名不变）。 */
+            public Parameter(String type, Map<String, Property> properties, List<String> required) {
+                this(type, properties, required, null);
+            }
+
+            /**
+             * 把当前 schema 调整为满足严格模式的形态：
+             *
+             * <ol>
+             *   <li>{@code additionalProperties} 置为 {@code false}</li>
+             *   <li>把 {@code properties} 中所有字段补进 {@code required}</li>
+             * </ol>
+             *
+             * <p>原本可选的字段会按官方要求改为可空类型（{@code ["string","null"]}），
+             * 因此语义仍然是"可以不传值"，只是表达方式从"不在 required 里"变成"值可以为 null"。
+             */
+            public Parameter enforceStrictSchema() {
+                this.additionalProperties = Boolean.FALSE;
+                if (properties == null || properties.isEmpty()) {
+                    if (required == null) {
+                        required = new java.util.ArrayList<String>();
+                    }
+                    return this;
+                }
+
+                List<String> alreadyRequired = required == null
+                        ? new java.util.ArrayList<String>()
+                        : new java.util.ArrayList<String>(required);
+
+                List<String> allNames = new java.util.ArrayList<String>();
+                for (Map.Entry<String, Property> entry : properties.entrySet()) {
+                    allNames.add(entry.getKey());
+                    if (!alreadyRequired.contains(entry.getKey()) && entry.getValue() != null) {
+                        entry.getValue().setNullable(true);
+                    }
+                }
+                this.required = allNames;
+                return this;
+            }
         }
 
         @Data
@@ -82,6 +147,7 @@ public class Tool {
             /**
              * 属性类型
              */
+            @JsonIgnore
             private String type;
 
             /**
@@ -99,6 +165,47 @@ public class Tool {
              * 数组元素类型定义（当type为array时使用）
              */
             private Property items;
+
+            /**
+             * 严格模式下的可选字段，需表达为可空类型（{@code ["string","null"]}）。
+             * 仅影响序列化，{@link #getType()} 仍返回原始类型字符串。
+             */
+            @JsonIgnore
+            private boolean nullable;
+
+            /** 兼容构造器：不带 nullable（保持既有调用方签名不变）。 */
+            public Property(String type, String description, List<String> enumValues, Property items) {
+                this(type, description, enumValues, items, false);
+            }
+
+            /**
+             * 序列化 {@code type}：普通情况输出字符串，可空时输出
+             * {@code ["<type>","null"]}——这是 OpenAI 严格模式表达可选字段的方式。
+             */
+            @JsonProperty("type")
+            public Object getSerializedType() {
+                if (type == null) {
+                    return null;
+                }
+                return nullable ? new String[]{type, "null"} : type;
+            }
+
+            /** 反序列化时同时接受字符串与数组两种形态。 */
+            @JsonProperty("type")
+            public void setSerializedType(Object value) {
+                if (value instanceof List) {
+                    List<?> values = (List<?>) value;
+                    for (Object candidate : values) {
+                        if (candidate != null && !"null".equals(candidate)) {
+                            this.type = String.valueOf(candidate);
+                        } else if ("null".equals(candidate)) {
+                            this.nullable = true;
+                        }
+                    }
+                } else if (value != null) {
+                    this.type = String.valueOf(value);
+                }
+            }
         }
 
     }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ResponseRequestToolResolver.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ResponseRequestToolResolver.java
@@ -4,7 +4,9 @@ import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
 import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class ResponseRequestToolResolver {
 
@@ -28,11 +30,47 @@ public final class ResponseRequestToolResolver {
 
         List<Tool> resolvedTools = ToolUtil.getAllTools(request.getFunctions(), request.getMcpServices());
         if (resolvedTools != null && !resolvedTools.isEmpty()) {
-            mergedTools.addAll(resolvedTools);
+            for (Tool tool : resolvedTools) {
+                mergedTools.add(toResponsesTool(tool));
+            }
         }
 
         return request.toBuilder()
                 .tools(mergedTools)
                 .build();
+    }
+
+    /**
+     * Converts a Chat Completions function tool into the shape the Responses API
+     * expects.
+     *
+     * <p>Chat Completions nests the declaration:
+     * {@code {"type":"function","function":{"name":...,"parameters":...}}}
+     * while the Responses API declares {@code type} / {@code name} /
+     * {@code description} / {@code parameters} at the top level — see the
+     * official function-calling guide, whose {@code responses.create} examples
+     * carry {@code name} unnested. The two mainlines share one tool registry, so
+     * the registered {@link Tool} has to be projected here rather than passed
+     * through.
+     *
+     * <p>Lenient gateways accept either form, but only the flat one matches the
+     * documented contract.
+     */
+    private static Object toResponsesTool(Tool tool) {
+        if (tool == null || tool.getFunction() == null) {
+            return tool;
+        }
+        Tool.Function function = tool.getFunction();
+
+        Map<String, Object> flat = new LinkedHashMap<String, Object>();
+        flat.put("type", tool.getType() == null ? "function" : tool.getType());
+        flat.put("name", function.getName());
+        if (function.getDescription() != null) {
+            flat.put("description", function.getDescription());
+        }
+        if (function.getParameters() != null) {
+            flat.put("parameters", function.getParameters());
+        }
+        return flat;
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ResponseRequestToolResolver.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ResponseRequestToolResolver.java
@@ -71,6 +71,9 @@ public final class ResponseRequestToolResolver {
         if (function.getParameters() != null) {
             flat.put("parameters", function.getParameters());
         }
+        if (function.getStrict() != null) {
+            flat.put("strict", function.getStrict());
+        }
         return flat;
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ToolUtil.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/tool/ToolUtil.java
@@ -803,6 +803,9 @@ public class ToolUtil {
                         function.setDescription(functionCall.description());
 
                         setFunctionParameters(function, functionClass);
+                        if (functionCall.strict()) {
+                            applyStrictMode(function);
+                        }
                         toolClassMap.put(functionName, functionClass);
                         return function;
                     }
@@ -927,6 +930,19 @@ public class ToolUtil {
             log.error("设置Function参数失败: {}", function.getName(), e);
             throw new RuntimeException("设置Function参数失败: " + function.getName(), e);
         }
+    }
+
+    /**
+     * 开启严格模式：调整 schema 以满足 OpenAI 的硬性要求
+     * （{@code additionalProperties=false}、所有字段列入 {@code required}、
+     * 可选字段标为可空），并把 {@code strict} 置为 {@code true}。
+     */
+    private static void applyStrictMode(Tool.Function function) {
+        Tool.Function.Parameter params = function.getParameters();
+        if (params != null) {
+            params.enforceStrictSchema();
+        }
+        function.setStrict(Boolean.TRUE);
     }
 
     /**

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ResponsesDocExamplesLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ResponsesDocExamplesLiveTest.java
@@ -1,0 +1,291 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.annotation.FunctionCall;
+import io.github.lnyocly.ai4j.annotation.FunctionParameter;
+import io.github.lnyocly.ai4j.annotation.FunctionRequest;
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.exception.AiHttpException;
+import io.github.lnyocly.ai4j.listener.ResponseSseListener;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.Response;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseContentPart;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseItem;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IResponsesService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import lombok.Data;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Executable source of truth for the snippets embedded in
+ * {@code docs/core-sdk/model-access/responses.md}.
+ *
+ * <p>Requires {@code OPENAI_API_KEY}; honours {@code OPENAI_API_HOST} and
+ * {@code OPENAI_CHAT_MODEL}. Skips when the key is absent.
+ */
+@Category(LiveProviderTest.class)
+public class ResponsesDocExamplesLiveTest {
+
+    private IResponsesService responsesService() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        Assume.assumeTrue("OPENAI_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        OpenAiConfig openAiConfig = new OpenAiConfig();
+        openAiConfig.setApiKey(apiKey);
+        String apiHost = System.getenv("OPENAI_API_HOST");
+        if (apiHost != null && !apiHost.trim().isEmpty()) {
+            openAiConfig.setApiHost(apiHost);
+        }
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(openAiConfig);
+        return new AiService(configuration).getResponsesService(PlatformType.OPENAI);
+    }
+
+    private String model() {
+        String model = System.getenv("OPENAI_CHAT_MODEL");
+        return (model == null || model.trim().isEmpty()) ? "gpt-4o-mini" : model;
+    }
+
+    // ---- §0 最小调用 + 读取输出 ----
+
+    /**
+     * Responses 的输出是 item 列表，每个 item 带 content parts。
+     * 这是读取助手文本必须走的结构。
+     */
+    private static String outputTextOf(Response response) {
+        StringBuilder text = new StringBuilder();
+        if (response == null || response.getOutput() == null) {
+            return "";
+        }
+        for (ResponseItem item : response.getOutput()) {
+            if (item == null || item.getContent() == null) {
+                continue;
+            }
+            for (ResponseContentPart part : item.getContent()) {
+                if (part != null && part.getText() != null) {
+                    text.append(part.getText());
+                }
+            }
+        }
+        return text.toString();
+    }
+
+    @Test
+    public void minimalCreateAndReadOutput() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        ResponseRequest request = ResponseRequest.builder()
+                .model(model())
+                .input("用一句话解释什么是响应式编程")
+                .build();
+
+        Response response = responsesService.create(request);
+
+        System.out.println("id     = " + response.getId());
+        System.out.println("status = " + response.getStatus());
+        System.out.println("输出   = " + outputTextOf(response));
+
+        Assert.assertEquals("response", response.getObject());
+        Assert.assertEquals("completed", response.getStatus());
+        Assert.assertFalse(outputTextOf(response).trim().isEmpty());
+    }
+
+    @Test
+    public void usageIsReportedWithInputOutputTokens() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        Response response = responsesService.create(ResponseRequest.builder()
+                .model(model())
+                .input("只回复 OK")
+                .build());
+
+        System.out.println("input=" + response.getUsage().getInputTokens()
+                + " output=" + response.getUsage().getOutputTokens()
+                + " total=" + response.getUsage().getTotalTokens());
+
+        Assert.assertNotNull(response.getUsage());
+        Assert.assertTrue(response.getUsage().getInputTokens() > 0);
+    }
+
+    // ---- §2 instructions 与 maxOutputTokens ----
+
+    @Test
+    public void instructionsActAsSystemLevelSteering() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        Response response = responsesService.create(ResponseRequest.builder()
+                .model(model())
+                .instructions("你只能用中文回答，且不超过 20 个字。")
+                .input("What is a vector database?")
+                .maxOutputTokens(200)
+                .build());
+
+        String text = outputTextOf(response);
+        System.out.println(text);
+
+        Assert.assertFalse(text.trim().isEmpty());
+    }
+
+    // ---- §3 工具解析：functions 与 Chat 共享同一基座 ----
+
+    @FunctionCall(name = "getStockPrice", description = "查询股票当前价格")
+    public static class GetStockPrice implements Function<GetStockPrice.Request, String> {
+
+        @Data
+        @FunctionRequest
+        public static class Request {
+            @FunctionParameter(description = "股票代码，例如 AAPL")
+            private String symbol;
+        }
+
+        @Override
+        public String apply(Request request) {
+            return "{\"symbol\":\"" + request.getSymbol() + "\",\"price\":195.42,\"currency\":\"USD\"}";
+        }
+    }
+
+    /**
+     * Responses 不做 Chat 那种服务内自动 tool loop：它把工具解析进 request，
+     * 把 function_call item 交回上层，由 runtime 决定怎么编排。
+     */
+    @Test
+    public void functionsAreResolvedIntoTheRequest() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        ResponseRequest request = ResponseRequest.builder()
+                .model(model())
+                .input("AAPL 现在多少钱？")
+                .functions("getStockPrice")
+                .build();
+
+        Response response;
+        try {
+            response = responsesService.create(request);
+        } catch (AiHttpException e) {
+            // 该网关的 /v1/responses 稳定性较差（502/503 间歇性），
+            // 工具形状本身由 ResponsesToolPayloadShapeTest 确定性地钉住。
+            Assume.assumeNoException("gateway unavailable (" + e.getStatusCode() + ")", e);
+            return;
+        }
+
+        // 输出 item 里可能出现 function_call，由上层决定是否执行
+        boolean sawFunctionCall = false;
+        if (response.getOutput() != null) {
+            for (ResponseItem item : response.getOutput()) {
+                if (item != null && "function_call".equals(item.getType())) {
+                    sawFunctionCall = true;
+                    System.out.println("待执行: " + item.getName() + " 参数: " + item.getArguments());
+                }
+            }
+        }
+        System.out.println("是否产生 function_call: " + sawFunctionCall);
+
+        Assert.assertNotNull("请求应成功返回", response.getId());
+    }
+
+    // ---- §6 流式：事件聚合而非单纯 token 输出 ----
+
+    @Test
+    public void streamAggregatesEventsAndText() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        ResponseRequest request = ResponseRequest.builder()
+                .model(model())
+                .input("从 1 数到 5，只输出数字")
+                .stream(Boolean.TRUE)
+                .build();
+
+        ResponseSseListener listener = new ResponseSseListener() {
+            @Override
+            protected void onEvent() {
+                // currText 是本次事件带来的文本增量
+                String delta = getCurrText();
+                if (delta != null && !delta.isEmpty()) {
+                    System.out.print(delta);
+                }
+            }
+        };
+
+        responsesService.createStream(request, listener);
+
+        // 流结束后，聚合状态都在 listener 上
+        System.out.println("\n完整文本: " + listener.getOutputText());
+        System.out.println("事件条数: " + listener.getEvents().size());
+
+        Assert.assertTrue("流式应产出文本", listener.getOutputText().length() > 0);
+        Assert.assertFalse("应收到事件", listener.getEvents().isEmpty());
+    }
+
+    // ---- §8 previousResponseId + store ----
+
+    /**
+     * previous_response_id 是 Responses 原生的续接方式：不用重发历史。
+     *
+     * <p>并非所有 OpenAI 兼容网关都在 HTTP 端点上实现它，因此这里把链式调用
+     * 的失败视为网关能力差异而跳过——第一次调用已经证明请求/响应契约可用。
+     */
+    @Test
+    public void previousResponseIdContinuesWithoutResendingHistory() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        Response first = responsesService.create(ResponseRequest.builder()
+                .model(model())
+                .input("记住数字 42。只回复 STORED")
+                .store(Boolean.TRUE)          // 让 provider 侧留存这次响应
+                .build());
+
+        System.out.println("first id = " + first.getId());
+
+        Response second;
+        try {
+            second = responsesService.create(ResponseRequest.builder()
+                    .model(model())
+                    .previousResponseId(first.getId())   // 只带 id，不重发历史
+                    .input("我让你记住的数字是多少？只回复数字")
+                    .build());
+        } catch (AiHttpException e) {
+            System.out.println("网关不支持 HTTP 端点的 previous_response_id ("
+                    + e.getStatusCode() + "): " + e.getMessage());
+            Assume.assumeNoException("gateway capability gap, not an SDK defect", e);
+            return;
+        }
+
+        String text = outputTextOf(second);
+        System.out.println("续接回答: " + text);
+        Assert.assertTrue("应记得 42，实际：" + text, text.contains("42"));
+    }
+
+    // ---- retrieve / delete ----
+
+    @Test
+    public void retrieveAndDeleteAStoredResponse() throws Exception {
+        IResponsesService responsesService = responsesService();
+
+        Response created = responsesService.create(ResponseRequest.builder()
+                .model(model())
+                .input("只回复 OK")
+                .store(Boolean.TRUE)
+                .build());
+
+        try {
+            Response fetched = responsesService.retrieve(created.getId());
+            System.out.println("retrieve status = " + fetched.getStatus());
+            Assert.assertEquals(created.getId(), fetched.getId());
+
+            responsesService.delete(created.getId());
+            System.out.println("deleted " + created.getId());
+        } catch (AiHttpException e) {
+            System.out.println("网关不支持 retrieve/delete (" + e.getStatusCode() + "): " + e.getMessage());
+            Assume.assumeNoException("gateway capability gap", e);
+        }
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/response/ResponseRequestToolResolverTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/response/ResponseRequestToolResolverTest.java
@@ -4,7 +4,6 @@ import io.github.lnyocly.ai4j.annotation.FunctionCall;
 import io.github.lnyocly.ai4j.annotation.FunctionParameter;
 import io.github.lnyocly.ai4j.annotation.FunctionRequest;
 import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
-import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
 import io.github.lnyocly.ai4j.tool.ResponseRequestToolResolver;
 import org.junit.Test;
 
@@ -14,11 +13,22 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ResponseRequestToolResolverTest {
 
+    /**
+     * Responses declares function tools flat ({@code type} / {@code name} /
+     * {@code description} / {@code parameters} at the top level), unlike Chat
+     * Completions which nests them under {@code function}. The resolver shares
+     * Chat's tool registry, so it must project rather than pass through.
+     *
+     * <p>Asserted on the resulting map, not on the Java type: an earlier version
+     * of this test checked {@code instanceof Tool}, which held while the
+     * serialized payload still carried the Chat-shaped nesting.
+     */
     @Test
     public void shouldResolveAnnotatedFunctionsIntoResponsesTools() {
         ResponseRequest request = ResponseRequest.builder()
@@ -31,9 +41,16 @@ public class ResponseRequestToolResolverTest {
 
         assertNotNull(resolved.getTools());
         assertEquals(1, resolved.getTools().size());
-        Tool tool = (Tool) resolved.getTools().get(0);
-        assertEquals("function", tool.getType());
-        assertEquals("responses_test_weather", tool.getFunction().getName());
+
+        Object tool = resolved.getTools().get(0);
+        assertTrue("Responses 工具应为扁平结构，实际类型: " + tool.getClass(), tool instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> flat = (Map<String, Object>) tool;
+        assertEquals("function", flat.get("type"));
+        assertEquals("responses_test_weather", flat.get("name"));
+        assertNotNull("parameters 应在顶层", flat.get("parameters"));
+        assertFalse("不应保留 Chat Completions 的 function 嵌套", flat.containsKey("function"));
     }
 
     @Test
@@ -52,8 +69,11 @@ public class ResponseRequestToolResolverTest {
 
         assertNotNull(resolved.getTools());
         assertEquals(2, resolved.getTools().size());
-        assertTrue(resolved.getTools().get(0) instanceof Map);
-        assertTrue(resolved.getTools().get(1) instanceof Tool);
+
+        // 调用方手写的内置工具原样保留
+        assertEquals("web_search_preview", ((Map<?, ?>) resolved.getTools().get(0)).get("type"));
+        // 注册表解析出的函数工具已投影成 Responses 扁平结构
+        assertEquals("responses_test_weather", ((Map<?, ?>) resolved.getTools().get(1)).get("name"));
     }
 
     @FunctionCall(name = "responses_test_weather", description = "test weather function for responses")

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/response/ResponsesToolPayloadShapeTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/response/ResponsesToolPayloadShapeTest.java
@@ -1,0 +1,151 @@
+package io.github.lnyocly.ai4j.platform.openai.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.annotation.FunctionCall;
+import io.github.lnyocly.ai4j.annotation.FunctionParameter;
+import io.github.lnyocly.ai4j.annotation.FunctionRequest;
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
+import io.github.lnyocly.ai4j.service.Configuration;
+import lombok.Data;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * The Responses API declares function tools <em>flat</em>:
+ *
+ * <pre>{"type":"function","name":"...","description":"...","parameters":{...}}</pre>
+ *
+ * per the official function-calling guide, while Chat Completions nests the same
+ * fields under a {@code function} key. Lenient gateways accept either, so a wrong
+ * shape can ship unnoticed — these tests pin the wire payload so the two
+ * mainlines cannot drift back into each other.
+ */
+public class ResponsesToolPayloadShapeTest {
+
+    @FunctionCall(name = "getStockPrice", description = "查询股票当前价格")
+    public static class GetStockPrice implements Function<GetStockPrice.Request, String> {
+
+        @Data
+        @FunctionRequest
+        public static class Request {
+            @FunctionParameter(description = "股票代码")
+            private String symbol;
+        }
+
+        @Override
+        public String apply(Request request) {
+            return "{}";
+        }
+    }
+
+    @Test
+    public void functionToolsAreSerializedInResponsesFlatShape() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        OpenAiResponsesService service = serviceCapturing(body);
+
+        service.create(ResponseRequest.builder()
+                .model("gpt-4o-mini")
+                .input("AAPL 现在多少钱？")
+                .functions("getStockPrice")
+                .build());
+
+        JsonNode tools = new ObjectMapper().readTree(body.get()).path("tools");
+        Assert.assertTrue("tools 应被解析进 payload", tools.isArray() && tools.size() > 0);
+
+        JsonNode tool = tools.get(0);
+        Assert.assertEquals("function", tool.path("type").asText());
+
+        Assert.assertTrue("Responses 要求 name 在顶层，实际 payload: " + tool,
+                tool.hasNonNull("name"));
+        Assert.assertEquals("getStockPrice", tool.path("name").asText());
+        Assert.assertTrue("parameters 应在顶层", tool.path("parameters").isObject());
+        Assert.assertTrue("properties 应保留参数定义",
+                tool.path("parameters").path("properties").has("symbol"));
+
+        Assert.assertFalse("不应出现 Chat Completions 的嵌套 function 包装，实际 payload: " + tool,
+                tool.has("function"));
+    }
+
+    /** 调用方手写的扁平 tool（Map/自定义对象）必须原样保留。 */
+    @Test
+    public void callerSuppliedFlatToolIsPassedThroughUnchanged() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        OpenAiResponsesService service = serviceCapturing(body);
+
+        java.util.Map<String, Object> flatTool = new java.util.LinkedHashMap<>();
+        flatTool.put("type", "function");
+        flatTool.put("name", "handWritten");
+        flatTool.put("parameters", java.util.Collections.singletonMap("type", "object"));
+
+        service.create(ResponseRequest.builder()
+                .model("gpt-4o-mini")
+                .input("hi")
+                .tools(java.util.Collections.<Object>singletonList(flatTool))
+                .build());
+
+        JsonNode tool = new ObjectMapper().readTree(body.get()).path("tools").get(0);
+        Assert.assertEquals("handWritten", tool.path("name").asText());
+        Assert.assertFalse(tool.has("function"));
+    }
+
+    /** 内置工具（web_search 等）没有 function 包装，不能被误改。 */
+    @Test
+    public void builtInToolTypesAreNotRewritten() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        OpenAiResponsesService service = serviceCapturing(body);
+
+        service.create(ResponseRequest.builder()
+                .model("gpt-4o-mini")
+                .input("hi")
+                .tools(java.util.Collections.<Object>singletonList(
+                        java.util.Collections.singletonMap("type", "web_search")))
+                .build());
+
+        JsonNode tool = new ObjectMapper().readTree(body.get()).path("tools").get(0);
+        Assert.assertEquals("web_search", tool.path("type").asText());
+        Assert.assertFalse(tool.has("name"));
+    }
+
+    // ---- helpers ----
+
+    private OpenAiResponsesService serviceCapturing(final AtomicReference<String> body) {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    Buffer buffer = new Buffer();
+                    if (chain.request().body() != null) {
+                        chain.request().body().writeTo(buffer);
+                    }
+                    body.set(buffer.readUtf8());
+                    return new Response.Builder()
+                            .request(chain.request())
+                            .protocol(Protocol.HTTP_1_1)
+                            .code(200)
+                            .message("OK")
+                            .body(ResponseBody.create(
+                                    "{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\"}",
+                                    MediaType.get("application/json")))
+                            .build();
+                })
+                .build();
+
+        OpenAiConfig config = new OpenAiConfig();
+        config.setApiKey("test-key");
+        config.setApiHost("https://unit.test/");
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(config);
+        configuration.setOkHttpClient(client);
+        return new OpenAiResponsesService(configuration);
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/tool/StrictModeToolSchemaTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/tool/StrictModeToolSchemaTest.java
@@ -1,0 +1,103 @@
+package io.github.lnyocly.ai4j.platform.openai.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.tool.ToolUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 严格模式（strict mode）对 schema 形态有硬性要求，OpenAI 官方建议开启。
+ * 这些测试钉住 SDK 生成的 schema 是否满足这些要求，避免"开了 strict 却被 API 拒绝"。
+ */
+public class StrictModeToolSchemaTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void enforceStrictSchema_setsAdditionalPropertiesFalseAndAllRequired() {
+        Map<String, Tool.Function.Property> props = new LinkedHashMap<String, Tool.Function.Property>();
+        props.put("city", new Tool.Function.Property("string", "city", null, null));
+        props.put("days", new Tool.Function.Property("integer", "days", null, null));
+
+        Tool.Function.Parameter param = new Tool.Function.Parameter("object", props,
+                java.util.Collections.singletonList("city"));
+
+        param.enforceStrictSchema();
+
+        Assert.assertEquals(Boolean.FALSE, param.getAdditionalProperties());
+        Assert.assertEquals("所有字段都应进 required",
+                2, param.getRequired().size());
+        Assert.assertTrue(param.getRequired().contains("city"));
+        Assert.assertTrue(param.getRequired().contains("days"));
+    }
+
+    @Test
+    public void enforceStrictSchema_marksOptionalFieldsAsNullable() {
+        Map<String, Tool.Function.Property> props = new LinkedHashMap<String, Tool.Function.Property>();
+        props.put("city", new Tool.Function.Property("string", null, null, null));
+        props.put("note", new Tool.Function.Property("string", null, null, null));
+
+        Tool.Function.Parameter param = new Tool.Function.Parameter("object", props,
+                java.util.Collections.singletonList("city"));
+
+        param.enforceStrictSchema();
+
+        Assert.assertFalse("原本必填的字段不变", props.get("city").isNullable());
+        Assert.assertTrue("原本可选的字段标为可空", props.get("note").isNullable());
+    }
+
+    @Test
+    public void nullableProperty_serializesAsTypeArray() throws Exception {
+        Tool.Function.Property prop = new Tool.Function.Property("string", null, null, null);
+        prop.setNullable(true);
+
+        String json = mapper.writeValueAsString(prop);
+
+        JsonNode node = mapper.readTree(json);
+        Assert.assertTrue("可空类型应序列化为 [\"string\",\"null\"]",
+                node.get("type").isArray());
+        Assert.assertEquals("string", node.get("type").get(0).asText());
+        Assert.assertEquals("null", node.get("type").get(1).asText());
+    }
+
+    @Test
+    public void nonNullableProperty_serializesAsPlainString() throws Exception {
+        Tool.Function.Property prop = new Tool.Function.Property("string", null, null, null);
+
+        String json = mapper.writeValueAsString(prop);
+
+        JsonNode node = mapper.readTree(json);
+        Assert.assertEquals("string", node.get("type").asText());
+    }
+
+    /**
+     * 回环：序列化后能反序列化还原，包括可空字段。
+     */
+    @Test
+    public void nullableProperty_roundTripsThroughDeserialization() throws Exception {
+        Tool.Function.Property prop = new Tool.Function.Property("integer", null, null, null);
+        prop.setNullable(true);
+
+        String json = mapper.writeValueAsString(prop);
+        Tool.Function.Property back = mapper.readValue(json, Tool.Function.Property.class);
+
+        Assert.assertEquals("integer", back.getType());
+        Assert.assertTrue(back.isNullable());
+    }
+
+    @Test
+    public void functionStrictFlag_isOmittedWhenNullAndPresentWhenTrue() throws Exception {
+        Tool.Function without = new Tool.Function();
+        without.setName("f");
+        Assert.assertFalse(mapper.writeValueAsString(without).contains("\"strict\""));
+
+        Tool.Function with = new Tool.Function();
+        with.setName("f");
+        with.setStrict(Boolean.TRUE);
+        Assert.assertTrue(mapper.writeValueAsString(with).contains("\"strict\":true"));
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/tool/StrictModeRegistrationTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/tool/StrictModeRegistrationTest.java
@@ -1,0 +1,84 @@
+package io.github.lnyocly.ai4j.tool;
+
+import io.github.lnyocly.ai4j.annotation.FunctionCall;
+import io.github.lnyocly.ai4j.annotation.FunctionParameter;
+import io.github.lnyocly.ai4j.annotation.FunctionRequest;
+import io.github.lnyocly.ai4j.platform.openai.tool.Tool;
+import io.github.lnyocly.ai4j.platform.openai.response.entity.ResponseRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * 验证 {@code @FunctionCall(strict = true)} 在两条主线上都产出合规的 schema：
+ *
+ * <ul>
+ *   <li>Chat 主线（直接走 {@code Tool}）：{@code strict=true} + schema 满足约束</li>
+ *   <li>Responses 主线（经 {@link ResponseRequestToolResolver} 投影）：
+ *       {@code strict} 和扁平字段一起进入 payload</li>
+ * </ul>
+ */
+public class StrictModeRegistrationTest {
+
+    @FunctionCall(name = "strict_test_lookup", description = "lookup", strict = true)
+    public static class StrictLookup implements Function<StrictLookup.Request, String> {
+        @Override
+        public String apply(Request request) {
+            return "{}";
+        }
+
+        @io.github.lnyocly.ai4j.annotation.FunctionRequest
+        public static class Request {
+            @FunctionParameter(description = "id", required = true)
+            private String id;
+            @FunctionParameter(description = "optional note", required = false)
+            private String note;
+        }
+    }
+
+    @Test
+    public void strictRegistrationProducesCompliantChatSchema() {
+        Tool.Function fn = ToolUtil.getFunctionEntity("strict_test_lookup");
+
+        Assert.assertNotNull(fn);
+        Assert.assertEquals("strict 应被开启", Boolean.TRUE, fn.getStrict());
+
+        Tool.Function.Parameter params = fn.getParameters();
+        Assert.assertEquals("additionalProperties 应为 false",
+                Boolean.FALSE, params.getAdditionalProperties());
+        Assert.assertTrue("必填字段应在 required",
+                params.getRequired().contains("id"));
+        Assert.assertTrue("可选字段也应进 required",
+                params.getRequired().contains("note"));
+
+        Map<String, Tool.Function.Property> props = params.getProperties();
+        Assert.assertFalse("必填字段不可空", props.get("id").isNullable());
+        Assert.assertTrue("可选字段应标为可空", props.get("note").isNullable());
+    }
+
+    @Test
+    public void responsesProjectionCarriesStrictFlag() {
+        ResponseRequest request = ResponseRequest.builder()
+                .model("gpt-4o-mini")
+                .input("hi")
+                .functions("strict_test_lookup")
+                .build();
+
+        ResponseRequest resolved = ResponseRequestToolResolver.resolve(request);
+
+        Assert.assertNotNull(resolved.getTools());
+        Assert.assertEquals(1, resolved.getTools().size());
+
+        Object tool = resolved.getTools().get(0);
+        Assert.assertTrue(tool instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> flat = (Map<String, Object>) tool;
+
+        Assert.assertEquals("function", flat.get("type"));
+        Assert.assertEquals("strict_test_lookup", flat.get("name"));
+        Assert.assertEquals("strict 应随扁平结构一起进入 Responses payload",
+                Boolean.TRUE, flat.get("strict"));
+    }
+}


### PR DESCRIPTION
两个相互关联的修复，都是写文档示例时 live 验证出来的。

## 1. Responses 的 function tool 发了错误的形状

三条请求协议声明工具的格式各不相同：

| 协议 | 形状 |
| --- | --- |
| Chat Completions | `{type, function:{name, description, parameters}}` — 嵌套 |
| **Responses** | `{type, name, description, parameters}` — **扁平** |
| Anthropic Messages | `{name, description, input_schema}` |

SDK 统一注册（`@FunctionCall` + `functions("...")`），各 provider 层各自投影。`AnthropicChatService.convertTools()` 投影正确，Chat 本身是原生形状，**只有 Responses 漏了这一步**——`ResponseRequestToolResolver` 把 Chat 形状的 `Tool` 原样塞进了 payload。

依据 OpenAI 官方 function-calling 文档（`responses.create` 的示例 `name` 在顶层），在 `ResponseRequestToolResolver` 加了投影：把注册表解析出的 `Tool` 转成扁平结构。覆盖 OpenAI/Doubao/DashScope 三个 provider 的同步与流式（6 个调用点都走同一个 resolver）。

**为什么不更早发现**：宽容的网关两种形状都接受。实测某网关对两种形状都返回 200 且都能触发 `function_call`，行为一致。所以这是规范符合性修复，风险在严格实现（官方 OpenAI / Azure），不是当前线上故障。

**为什么之前没测出来**：原 `ResponseRequestToolResolverTest` 断言的是 Java 内部类型（`instanceof Tool`），payload 错了它照样绿。已改成断言实际序列化的 map，并新增 `ResponsesToolPayloadShapeTest` 钉住三种情况（注册表函数投影为扁平、调用方手写扁平工具原样保留、`web_search` 等内置类型不被误改）。

## 2. 支持 strict mode

OpenAI 官方建议开启 strict mode。strict 对 schema 有四个硬性要求，只加标志位不满足它们请求会被直接拒绝，所以一并生成合规 schema：

- `additionalProperties = false`
- 所有字段列入 `required`
- 原本可选的字段（`@FunctionParameter(required = false)`）标记为可空（`["string","null"]`）
- `strict = true`

用法——在现有注册上加一个标志位，不加就完全不变（默认行为与历史版本一致）：

```java
@FunctionCall(name = "getOrder", description = "...", strict = true)
public static class GetOrder implements Function<Request, String> { ... }
```

**关键设计**：
- `Property.type` 保持 `String`（既有读者包括 MCP 的 `input_schema` 导出依赖它）；序列化经 `getSerializedType()`/`setSerializedType()` 路由，可空时发 `["type","null"]`，`getType()` 仍返回 `"string"`，回环验证通过。
- `strict` 是 OpenAI 概念，不渗到 Anthropic（它有自己的 `disable_parallel_tool_use`）。作用在 Chat（原生 `Tool` 直发）和 Responses（resolver 投影时带上）。
- 加字段处（`Function`/`Parameter`/`Property`）都补了兼容构造器，6+ 既有调用点零改动。

**真机验证**：生成的 Chat payload 完全符合文档要求并被网关接受。

## 测试

- `ResponseRequestToolResolverTest`（2，重写为断言 wire shape）
- `ResponsesToolPayloadShapeTest`（3，钉 wire payload）
- `StrictModeToolSchemaTest`（6，schema 机制与序列化）
- `StrictModeRegistrationTest`（2，`@FunctionCall(strict=true)` 在 Chat 与 Responses 两条线）

共 13 个，全绿，无需密钥。`ai4j` 模块全量离线测试通过。

## 文档影响

写文档示例时发现的这两个问题修好后，model-access 主线（尤其 Responses）的示例才能给出可跑通的工具调用代码。文档示例在另一条分支，本 PR 只含这两个 fix。