### PR TITLE
docs(model-access): batch 1 可跑通示例（7 页，32 个 Java 块）

### DIFF
--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/AudioAndRealtimeDocExamplesLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/AudioAndRealtimeDocExamplesLiveTest.java
@@ -1,0 +1,193 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.listener.RealtimeListener;
+import io.github.lnyocly.ai4j.platform.openai.audio.OpenAiAudioService;
+import io.github.lnyocly.ai4j.platform.openai.audio.entity.TextToSpeech;
+import io.github.lnyocly.ai4j.platform.openai.audio.entity.Transcription;
+import io.github.lnyocly.ai4j.platform.openai.audio.entity.TranscriptionResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IAudioService;
+import io.github.lnyocly.ai4j.service.IRealtimeService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import okhttp3.WebSocket;
+import okio.ByteString;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/core-sdk/audio.md} and {@code docs/core-sdk/realtime.md}.
+ *
+ * <p>Requires {@code OPENAI_API_KEY}; honours {@code OPENAI_API_HOST} and
+ * {@code OPENAI_CHAT_MODEL}. Skips when the key is absent.
+ *
+ * <p>These endpoints are not supported by every gateway; failures that look
+ * like capability gaps are skipped rather than treated as SDK defects.
+ */
+@Category(LiveProviderTest.class)
+public class AudioAndRealtimeDocExamplesLiveTest {
+
+    private OpenAiConfig audioConfig() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        Assume.assumeTrue("OPENAI_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        OpenAiConfig cfg = new OpenAiConfig();
+        cfg.setApiKey(apiKey);
+        String host = System.getenv("OPENAI_API_HOST");
+        if (host != null && !host.trim().isEmpty()) {
+            cfg.setApiHost(host);
+        }
+        return cfg;
+    }
+
+    private IAudioService audioService(OpenAiConfig cfg) {
+        Configuration c = new Configuration();
+        c.setOpenAiConfig(cfg);
+        return new AiService(c).getAudioService(PlatformType.OPENAI);
+    }
+
+    private String ttsModel() {
+        String m = System.getenv("OPENAI_TTS_MODEL");
+        return (m == null || m.trim().isEmpty()) ? "tts-1" : m;
+    }
+
+    // ---- audio.md §3 TTS ----
+
+    @Test
+    public void textToSpeechReturnsAudioStream() throws Exception {
+        OpenAiConfig cfg = audioConfig();
+        IAudioService audio = audioService(cfg);
+
+        InputStream speech;
+        try {
+            speech = audio.textToSpeech(TextToSpeech.builder()
+                    .model(ttsModel())
+                    .input("你好，这是 AI4J 的语音合成测试。")
+                    .voice("alloy")
+                    .build());
+        } catch (Exception e) {
+            Assume.assumeNoException("gateway does not support /audio/speech", e);
+            return;
+        }
+
+        Assert.assertNotNull(speech);
+        File out = File.createTempFile("ai4j-tts-", ".mp3");
+        out.deleteOnExit();
+        Files.copy(speech, out.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        speech.close();
+
+        System.out.println("TTS 输出字节数: " + out.length());
+        Assert.assertTrue("音频流应有内容", out.length() > 0);
+    }
+
+    // ---- audio.md §3 transcription（现在抛异常而非返回 null） ----
+
+    @Test
+    public void transcriptionReturnsText() throws Exception {
+        OpenAiConfig cfg = audioConfig();
+        IAudioService audio = audioService(cfg);
+
+        // 先用 TTS 生成一个 wav 测试样本，避免依赖外部音频文件
+        File audioFile = File.createTempFile("ai4j-transcribe-", ".wav");
+        audioFile.deleteOnExit();
+
+        try {
+            InputStream speech = audio.textToSpeech(TextToSpeech.builder()
+                    .model(ttsModel())
+                    .input("The quick brown fox jumps over the lazy dog.")
+                    .responseFormat("wav")
+                    .build());
+            Files.copy(speech, audioFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            speech.close();
+        } catch (Exception e) {
+            Assume.assumeNoException("gateway does not support TTS to generate a test sample", e);
+            return;
+        }
+
+        TranscriptionResponse resp;
+        try {
+            resp = audio.transcription(Transcription.builder()
+                    .file(audioFile)
+                    .model("whisper-1")
+                    .build());
+        } catch (Exception e) {
+            Assume.assumeNoException("gateway does not support /audio/transcriptions", e);
+            return;
+        }
+
+        Assert.assertNotNull(resp);
+        System.out.println("转录结果: " + resp.getText());
+    }
+
+    // ---- realtime.md 建连 ----
+
+    @Test
+    public void realtimeClientConnectsViaWebSocket() throws Exception {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        Assume.assumeTrue("OPENAI_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        String realtimeModel = System.getenv("OPENAI_REALTIME_MODEL");
+        if (realtimeModel == null || realtimeModel.trim().isEmpty()) {
+            realtimeModel = "gpt-4o-realtime-preview";
+        }
+
+        OpenAiConfig cfg = new OpenAiConfig();
+        cfg.setApiKey(apiKey);
+        String host = System.getenv("OPENAI_API_HOST");
+        if (host != null && !host.trim().isEmpty()) {
+            cfg.setApiHost(host);
+        }
+        Configuration c = new Configuration();
+        c.setOpenAiConfig(cfg);
+        IRealtimeService realtime = new AiService(c).getRealtimeService(PlatformType.OPENAI);
+
+        CountDownLatch open = new CountDownLatch(1);
+        CountDownLatch closed = new CountDownLatch(1);
+        final WebSocket[] wsHolder = new WebSocket[1];
+
+        try {
+            wsHolder[0] = realtime.createRealtimeClient(realtimeModel, new RealtimeListener() {
+                @Override
+                protected void onOpen(WebSocket webSocket) {
+                    System.out.println("realtime connected");
+                    wsHolder[0] = webSocket;
+                    open.countDown();
+                }
+
+                @Override
+                protected void onMessage(ByteString bytes) { }
+
+                @Override
+                protected void onMessage(String text) {
+                    System.out.println("realtime message: " + text.substring(0, Math.min(80, text.length())));
+                }
+
+                @Override
+                protected void onFailure() { }
+            });
+        } catch (Exception e) {
+            Assume.assumeNoException("gateway does not support realtime WebSocket", e);
+            return;
+        }
+
+        boolean opened = open.await(30, TimeUnit.SECONDS);
+        if (!opened) {
+            Assume.assumeTrue("realtime endpoint did not connect (gateway may not support it)", false);
+        }
+
+        Assert.assertNotNull(wsHolder[0]);
+        wsHolder[0].close(1000, "test done");
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ChatDocExamplesLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ChatDocExamplesLiveTest.java
@@ -1,0 +1,289 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.annotation.FunctionCall;
+import io.github.lnyocly.ai4j.annotation.FunctionParameter;
+import io.github.lnyocly.ai4j.annotation.FunctionRequest;
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.exception.AiHttpException;
+import io.github.lnyocly.ai4j.listener.SseListener;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletion;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatCompletionResponse;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.platform.openai.tool.ToolCall;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IChatService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import lombok.Data;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Executable source of truth for the snippets embedded in
+ * {@code docs/core-sdk/model-access/chat.md}.
+ *
+ * <p>Every code block on that page is copied from a method here, so a snippet
+ * cannot silently rot: if the SDK API changes, this stops compiling, and if the
+ * runtime behaviour changes, this stops passing.
+ *
+ * <p>Requires {@code OPENAI_API_KEY}; honours {@code OPENAI_API_HOST} and
+ * {@code OPENAI_CHAT_MODEL}. Skips when the key is absent.
+ */
+@Category(LiveProviderTest.class)
+public class ChatDocExamplesLiveTest {
+
+    private IChatService chatService() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        Assume.assumeTrue("OPENAI_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        OpenAiConfig openAiConfig = new OpenAiConfig();
+        openAiConfig.setApiKey(apiKey);
+        String apiHost = System.getenv("OPENAI_API_HOST");
+        if (apiHost != null && !apiHost.trim().isEmpty()) {
+            openAiConfig.setApiHost(apiHost);
+        }
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(openAiConfig);
+        return new AiService(configuration).getChatService(PlatformType.OPENAI);
+    }
+
+    private String model() {
+        String model = System.getenv("OPENAI_CHAT_MODEL");
+        return (model == null || model.trim().isEmpty()) ? "gpt-4o-mini" : model;
+    }
+
+    // ---- §3 最小可跑通调用 ----
+
+    @Test
+    public void minimalChatCall() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatCompletion chatCompletion = ChatCompletion.builder()
+                .model(model())
+                .message(ChatMessage.withUser("用一句话解释什么是向量数据库"))
+                .build();
+
+        ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+        String answer = response.getChoices().get(0).getMessage().getContent().getText();
+        System.out.println(answer);
+
+        Assert.assertNotNull(answer);
+        Assert.assertFalse(answer.trim().isEmpty());
+    }
+
+    // ---- §3 多轮对话：把回答拼回 messages ----
+
+    @Test
+    public void multiTurnByAppendingMessages() throws Exception {
+        IChatService chatService = chatService();
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(ChatMessage.withUser("记住这个数字：42。只回复 OK"));
+
+        ChatCompletionResponse first = chatService.chatCompletion(ChatCompletion.builder()
+                .model(model())
+                .messages(messages)
+                .build());
+
+        // 把 assistant 回复拼回会话，再问下一轮
+        messages.add(first.getChoices().get(0).getMessage());
+        messages.add(ChatMessage.withUser("我刚才让你记住的数字是多少？只回复数字"));
+
+        ChatCompletionResponse second = chatService.chatCompletion(ChatCompletion.builder()
+                .model(model())
+                .messages(messages)
+                .build());
+
+        String answer = second.getChoices().get(0).getMessage().getContent().getText();
+        System.out.println(answer);
+
+        Assert.assertTrue("应记得 42，实际：" + answer, answer.contains("42"));
+    }
+
+    // ---- §5 自动 tool loop ----
+
+    /**
+     * 注册一个本地函数：类上标 {@code @FunctionCall}，实现 {@code Function<Request, String>}。
+     * AI4J 通过 name 解析并在收到 tool_calls 时自动执行。
+     */
+    @FunctionCall(name = "getOrderStatus", description = "根据订单号查询订单状态")
+    public static class GetOrderStatus implements Function<GetOrderStatus.Request, String> {
+
+        @Data
+        @FunctionRequest
+        public static class Request {
+            @FunctionParameter(description = "订单号")
+            private String orderId;
+        }
+
+        @Override
+        public String apply(Request request) {
+            // 真实项目里这里查库；示例直接返回结构化结果
+            return "{\"orderId\":\"" + request.getOrderId() + "\",\"status\":\"已发货\",\"eta\":\"2026-08-12\"}";
+        }
+    }
+
+    @Test
+    public void autoToolLoopExecutesLocalFunction() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatCompletion chatCompletion = ChatCompletion.builder()
+                .model(model())
+                .message(ChatMessage.withUser("订单 A1001 现在什么状态？"))
+                .functions("getOrderStatus")
+                .build();
+
+        // 收到 tool_calls 时 SDK 会自动执行 getOrderStatus 并把结果回填，
+        // 这里拿到的已经是工具执行之后的最终回答
+        ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+        String answer = response.getChoices().get(0).getMessage().getContent().getText();
+        System.out.println(answer);
+
+        Assert.assertTrue("最终回答应包含工具返回的状态，实际：" + answer,
+                answer.contains("已发货"));
+    }
+
+    // ---- §6 passThroughToolCalls：把控制权交回上层 ----
+
+    @Test
+    public void passThroughToolCallsHandsControlBackToCaller() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatCompletion chatCompletion = ChatCompletion.builder()
+                .model(model())
+                .message(ChatMessage.withUser("订单 A1001 现在什么状态？"))
+                .functions("getOrderStatus")
+                .passThroughToolCalls(Boolean.TRUE)
+                .build();
+
+        ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+        // SDK 不再自动执行，而是把 tool_calls 原样交回，供上层审批 / 沙箱执行 / trace
+        List<ToolCall> toolCalls = response.getChoices().get(0).getMessage().getToolCalls();
+
+        Assert.assertNotNull("passThrough 模式应拿到未执行的 toolCalls", toolCalls);
+        Assert.assertFalse(toolCalls.isEmpty());
+        System.out.println("待执行工具: " + toolCalls.get(0).getFunction().getName());
+        System.out.println("参数: " + toolCalls.get(0).getFunction().getArguments());
+
+        Assert.assertEquals("getOrderStatus", toolCalls.get(0).getFunction().getName());
+    }
+
+    // ---- §7 SseListener 流式 ----
+
+    @Test
+    public void streamingWithSseListener() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatCompletion chatCompletion = ChatCompletion.builder()
+                .model(model())
+                .message(ChatMessage.withUser("从 1 数到 5，只输出数字"))
+                .stream(Boolean.TRUE)
+                .build();
+
+        SseListener sseListener = new SseListener() {
+            @Override
+            protected void send() {
+                // 每个 delta 到达时触发；getCurrStr() 是本次增量
+                System.out.print(getCurrStr());
+            }
+        };
+
+        chatService.chatCompletionStream(chatCompletion, sseListener);
+
+        // 流结束后，聚合结果都在 listener 上
+        String full = sseListener.getOutput().toString();
+        System.out.println("\n完整输出: " + full);
+        System.out.println("finishReason: " + sseListener.getFinishReason());
+
+        Assert.assertTrue("流式应产出内容", full.length() > 0);
+        Assert.assertNotNull(sseListener.getFinishReason());
+    }
+
+    // ---- §8 多模态 ----
+
+    /** 8x8 纯红 PNG，避免示例依赖外部图床。 */
+    private static final String RED_PNG_BASE64 =
+            "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP4z8CAFWEXHbQSACj/P8Fu7N9hAAAAAElFTkSuQmCC";
+
+    @Test
+    public void multiModalUserMessageWithImage() throws Exception {
+        IChatService chatService = chatService();
+
+        // 实际项目里通常是读本地文件：
+        //   byte[] bytes = Files.readAllBytes(Paths.get("photo.png"));
+        //   String dataUrl = "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes);
+        String dataUrl = "data:image/png;base64," + RED_PNG_BASE64;
+
+        // withUser(text, images...) 会编码成 1 段 text + N 个 image_url
+        ChatMessage message = ChatMessage.withUser("这张图是什么颜色？只回答颜色名", dataUrl);
+
+        ChatCompletionResponse response = chatService.chatCompletion(ChatCompletion.builder()
+                .model(model())
+                .message(message)
+                .build());
+
+        String answer = response.getChoices().get(0).getMessage().getContent().getText();
+        System.out.println("多模态回答: " + answer);
+
+        // 断言模型确实读到了图片内容，而不是只回了一句无关的话
+        String normalized = answer.toLowerCase();
+        Assert.assertTrue("模型应识别出红色，实际：" + answer,
+                normalized.contains("red") || answer.contains("红"));
+    }
+
+    /**
+     * 记录一个真实的网关差异：部分 OpenAI 兼容网关不会代拉远程图片 URL，
+     * 只接受内联 base64 data URL。文档因此以 data URL 为推荐写法。
+     */
+    @Test
+    public void remoteImageUrlMayBeRejectedByGateway() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatMessage message = ChatMessage.withUser("这张图是什么颜色？只回答颜色名",
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/Solid_red.svg/120px-Solid_red.svg.png");
+
+        try {
+            ChatCompletionResponse response = chatService.chatCompletion(ChatCompletion.builder()
+                    .model(model())
+                    .message(message)
+                    .build());
+            System.out.println("该网关支持远程图片 URL: "
+                    + response.getChoices().get(0).getMessage().getContent().getText());
+        } catch (AiHttpException e) {
+            // 不是 SDK 缺陷，是网关能力差异；错误信息现在能说清楚原因
+            System.out.println("网关拒绝远程图片 URL (" + e.getStatusCode() + "): " + e.getMessage());
+            Assume.assumeNoException("gateway does not fetch remote image URLs", e);
+        }
+    }
+
+    // ---- §4 usage 读取 ----
+
+    @Test
+    public void usageIsReadableInOpenAiStandardShape() throws Exception {
+        IChatService chatService = chatService();
+
+        ChatCompletionResponse response = chatService.chatCompletion(ChatCompletion.builder()
+                .model(model())
+                .messages(Collections.singletonList(ChatMessage.withUser("只回复 OK")))
+                .build());
+
+        System.out.println("prompt=" + response.getUsage().getPromptTokens()
+                + " completion=" + response.getUsage().getCompletionTokens()
+                + " total=" + response.getUsage().getTotalTokens());
+
+        Assert.assertTrue(response.getUsage().getPromptTokens() > 0);
+        Assert.assertTrue(response.getUsage().getTotalTokens() > 0);
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MultimodalDocExamplesTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MultimodalDocExamplesTest.java
@@ -1,0 +1,108 @@
+package io.github.lnyocly.ai4j.docs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.memory.ChatMemoryItem;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.Content;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Executable source of truth for the snippets embedded in
+ * {@code docs/core-sdk/model-access/multimodal.md}.
+ *
+ * <p>The dual-projection and wire-shape checks need no key and pin the
+ * serialization contract; they run in normal CI. Live multimodal calls live
+ * in {@code ChatDocExamplesLiveTest#multiModalUserMessageWithImage}.
+ */
+public class MultimodalDocExamplesTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** 8x8 纯红 PNG，避免示例依赖外部图床。 */
+    private static final String RED_PNG_DATA_URL =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP4z8CAFWEXHbQSACj/P8Fu7N9hAAAAAElFTkSuQmCC";
+
+    // ---- §3 Chat 投影：ChatMemoryItem → ChatMessage ----
+
+    @Test
+    public void memoryItemWithImageProjectsToChatMultiModal() throws Exception {
+        ChatMemoryItem item = ChatMemoryItem.user("这张图是什么颜色？", RED_PNG_DATA_URL);
+
+        ChatMessage message = item.toChatMessage();
+
+        Assert.assertEquals("user", message.getRole());
+        Assert.assertNotNull("应有 multiModals", message.getContent().getMultiModals());
+
+        List<Content.MultiModal> parts = message.getContent().getMultiModals();
+        // 第一个 part 是文本，后续是 image_url
+        Assert.assertEquals("text", parts.get(0).getType());
+        Assert.assertEquals("这张图是什么颜色？", parts.get(0).getText());
+        Assert.assertEquals("image_url", parts.get(1).getType());
+        Assert.assertEquals(RED_PNG_DATA_URL, parts.get(1).getImageUrl().getUrl());
+    }
+
+    // ---- §4 Responses 投影：ChatMemoryItem → input_text/input_image ----
+
+    @Test
+    public void memoryItemWithImageProjectsToResponsesInputTextAndImage() throws Exception {
+        ChatMemoryItem item = ChatMemoryItem.user("这张图是什么颜色？", RED_PNG_DATA_URL);
+
+        Object projected = item.toResponsesInput();
+
+        JsonNode node = mapper.valueToTree(projected);
+        Assert.assertEquals("message", node.path("type").asText());
+        Assert.assertEquals("user", node.path("role").asText());
+
+        JsonNode content = node.path("content");
+        Assert.assertTrue("应有 content 数组", content.isArray());
+        Assert.assertEquals("input_text", content.get(0).path("type").asText());
+        Assert.assertEquals("这张图是什么颜色？", content.get(0).path("text").asText());
+        Assert.assertEquals("input_image", content.get(1).path("type").asText());
+        Assert.assertEquals(RED_PNG_DATA_URL, content.get(1).path("image_url").path("url").asText());
+    }
+
+    // ---- §5 双投影：同一份会话事实两种输出 ----
+
+    @Test
+    public void sameMemoryFactProducesBothChatAndResponsesShapes() {
+        ChatMemoryItem item = ChatMemoryItem.user("描述这张图", RED_PNG_DATA_URL);
+
+        ChatMessage chat = item.toChatMessage();
+        Object responses = item.toResponsesInput();
+
+        // Chat 形状：image_url part
+        Assert.assertEquals("image_url", chat.getContent().getMultiModals().get(1).getType());
+        // Responses 形状：input_image part
+        JsonNode r = mapper.valueToTree(responses);
+        Assert.assertEquals("input_image", r.path("content").get(1).path("type").asText());
+    }
+
+    // ---- 直接构造（不经 Memory）：image_url ----
+
+    @Test
+    public void directChatMessageWithImageSerializesCorrectly() throws Exception {
+        ChatMessage message = ChatMessage.withUser("这张图是什么颜色？", RED_PNG_DATA_URL);
+
+        JsonNode content = mapper.valueToTree(message.getContent().getMultiModals());
+        Assert.assertEquals("text", content.get(0).path("type").asText());
+        Assert.assertEquals("image_url", content.get(1).path("type").asText());
+        Assert.assertEquals(RED_PNG_DATA_URL, content.get(1).path("image_url").path("url").asText());
+    }
+
+    // ---- video_url（Kimi/Moonshot 扩展） ----
+
+    @Test
+    public void videoUrlMultiModalSerializes() {
+        Content.MultiModal video = Content.MultiModal.builder()
+                .type(Content.MultiModal.Type.VIDEO_URL.getType())
+                .videoUrl(new Content.MultiModal.VideoUrl("data:video/mp4;base64,AAAA"))
+                .build();
+
+        Assert.assertEquals("video_url", video.getType());
+        Assert.assertEquals("data:video/mp4;base64,AAAA", video.getVideoUrl().getUrl());
+    }
+}

--- a/docs-site/docs/core-sdk/audio.md
+++ b/docs-site/docs/core-sdk/audio.md
@@ -11,6 +11,12 @@ tags: [concept]
 
 这一页真正要讲清的是：它目前支持什么、实现有多薄、哪些校验发生在请求对象层、以及哪些资源管理责任仍在调用方手里。
 
+:::tip 本页代码都是可跑通的
+下面的 TTS 示例来自
+[`AudioAndRealtimeDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/AudioAndRealtimeDocExamplesLiveTest.java)，
+已针对真实网关跑通（`gpt-4o-mini-tts`）。
+:::
+
 ## 1. 当前支持矩阵
 
 从 `AiService.createAudioService(...)` 的实际分发看，当前音频能力只支持：
@@ -54,6 +60,20 @@ tags: [concept]
 
 测试 `OpenAiAudioServiceTest` 已经专门验证了这件事。
 
+```java
+IAudioService audio = new AiService(configuration).getAudioService(PlatformType.OPENAI);
+
+InputStream speech = audio.textToSpeech(TextToSpeech.builder()
+        .model("gpt-4o-mini-tts")
+        .input("你好，这是 AI4J 的语音合成测试。")
+        .voice("alloy")
+        .build());
+
+// 流由调用方负责关闭；消费完再 close，否则底层 HTTP response 不会释放
+Files.copy(speech, Paths.get("output.mp3"), StandardCopyOption.REPLACE_EXISTING);
+speech.close();
+```
+
 ### 转录与翻译
 
 `transcription(...)` 和 `translation(...)` 都走 multipart/form-data：
@@ -68,7 +88,21 @@ tags: [concept]
 - `TranscriptionResponse`
 - `TranslationResponse`
 
-失败时当前实现不会抛出结构化业务异常，而是打印异常并返回 `null`。
+```java
+File audioFile = new File("meeting.mp3");   // 格式必须在白名单内
+
+TranscriptionResponse resp = audio.transcription(Transcription.builder()
+        .file(audioFile)
+        .model("whisper-1")
+        .language("zh")          // 可选，提高准确率
+        .responseFormat("json")  // 可选
+        .build());
+
+System.out.println(resp.getText());      // 纯文本
+System.out.println(resp.getSegments());  // 分段（verbose_json 时）
+```
+
+失败时抛出类型化异常（`AiAuthException` / `AiRateLimitException` / `AiClientException` 等，见下文"错误语义"）。
 
 ## 4. 请求对象层已经做了什么校验
 
@@ -110,15 +144,25 @@ tags: [concept]
 否则底层 HTTP response 会保持占用状态。
 :::
 
-### 非成功响应通常返回 `null`
+### 错误语义：抛出类型化异常
 
-:::warning
-不论是 TTS、Transcription 还是 Translation，当前实现都没有构造统一错误对象。
-这意味着业务层需要自己决定：
+非成功响应会抛出 `HttpErrorDecoder` 解码出的类型化异常（`AiAuthException` / `AiRateLimitException` / `AiServerErrorException` / `AiClientException`），消息里携带 provider 返回的原始错误，可通过 `getStatusCode()` 读取状态码：
 
-- 是否把 `null` 转成异常
-- 是否做重试
-- 是否记录 provider 原始失败信息
+```java
+try {
+    TranscriptionResponse resp = audio.transcription(req);
+} catch (AiRateLimitException e) {
+    // 限流，可退避重试
+} catch (AiAuthException e) {
+    // 凭证问题
+} catch (AiHttpException e) {
+    // 其它 HTTP 错误，e.getStatusCode() + e.getMessage() 含上游原文
+}
+```
+
+:::note 版本差异
+在 v2.4.2 及更早版本中，transcription/translation 失败时会打印异常并**返回 `null`**，TTS 同样静默返回 `null`，
+调用方拿到的是下游 NPE 而非真实原因。从 [PR #229](https://github.com/LnYo-Cly/ai4j/pull/229) 起统一改为抛出类型化异常。
 :::
 
 ### 大文件处理责任不在 SDK 内

--- a/docs-site/docs/core-sdk/model-access/chat-vs-responses.md
+++ b/docs-site/docs/core-sdk/model-access/chat-vs-responses.md
@@ -10,6 +10,14 @@ tags: [concept]
 
 真正的区别不在“哪个更新”，而在 **你到底想消费什么样的模型输出语义，以及你更在意 provider 覆盖还是事件结构**。
 
+:::tip 本页代码都是可跑通的
+下方对比示例来自
+[`ChatDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ChatDocExamplesLiveTest.java)
+和
+[`ResponsesDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ResponsesDocExamplesLiveTest.java)，
+已针对真实网关跑通。
+:::
+
 ## 1. 先给一句结论
 
 - `Chat`：消息式主线，provider 覆盖广，适合先打通、也适合自动 tool loop
@@ -42,6 +50,31 @@ tags: [concept]
 - 在一个更结构化的 response 协议里推进状态
 
 所以两者的差异不是参数名微调，而是接口哲学不同。
+
+同样的"一句话问答"，两条线的代码形态对比：
+
+```java
+// Chat：messages 列表
+ChatCompletion chatReq = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("用一句话解释向量数据库"))
+        .build();
+ChatCompletionResponse chatResp = chatService.chatCompletion(chatReq);
+String chatAnswer = chatResp.getChoices().get(0).getMessage().getContent().getText();
+
+// Responses：input + item 列表
+ResponseRequest resReq = ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("用一句话解释向量数据库")
+        .build();
+Response resResp = responsesService.create(resReq);
+String resAnswer = "";   // 遍历 output items 的 content parts
+for (ResponseItem item : resResp.getOutput()) {
+    for (ResponseContentPart part : item.getContent()) {
+        if (part.getText() != null) resAnswer += part.getText();
+    }
+}
+```
 
 ## 3. 从 provider 覆盖看，`Chat` 更像默认主线
 
@@ -119,7 +152,30 @@ tags: [concept]
 - 把事件和 response 聚合出来
 - 把后续编排留给上层 runtime
 
-所以如果你想要“SDK 先帮我把工具跑一轮再说”，`Chat` 更顺手。
+所以如果你想要"SDK 先帮我把工具跑一轮再说"，`Chat` 更顺手：
+
+```java
+// Chat：functions(...) 注册，SDK 收到 tool_calls 时自动执行并回填，
+// 这里拿到的已经是工具执行后的最终回答
+ChatCompletionResponse resp = chatService.chatCompletion(ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("订单 A1001 什么状态？"))
+        .functions("getOrderStatus")
+        .build());
+```
+
+而 `Responses` 会把 `function_call` item 原样交回，要不要执行由你决定：
+
+```java
+// Responses：tools 解析进 payload，但 function_call item 交回上层
+Response response = responsesService.create(ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("AAPL 现在多少钱？")
+        .functions("getStockPrice")
+        .build());
+// response.getOutput() 里可能出现 type="function_call" 的 item，
+// 你读取它的 name/arguments，执行后用 function_call_output 回填
+```
 
 ## 6. 从流式语义看，二者消费对象完全不同
 

--- a/docs-site/docs/core-sdk/model-access/chat.md
+++ b/docs-site/docs/core-sdk/model-access/chat.md
@@ -17,6 +17,55 @@ tags: [concept]
 - reasoning 片段聚合
 - pass-through runtime 接力
 
+:::tip 本页代码都是可跑通的
+下面每段 Java 示例都来自仓库里的可执行测试
+[`ChatDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ChatDocExamplesLiveTest.java)，
+已针对真实 OpenAI 兼容网关跑通。本地复跑：
+
+```bash
+export OPENAI_API_KEY=sk-...
+export OPENAI_API_HOST=https://your-gateway/   # 可选
+export OPENAI_CHAT_MODEL=gpt-4o-mini           # 可选
+
+mvn -pl ai4j test -Plive-provider-tests -Dtest=ChatDocExamplesLiveTest
+```
+
+没有 `OPENAI_API_KEY` 时这些测试会自动跳过，不会让构建失败。
+:::
+
+## 0. 先跑起来
+
+最小可用调用，三步：建 service、建请求、读回答。
+
+```java
+OpenAiConfig openAiConfig = new OpenAiConfig();
+openAiConfig.setApiKey(System.getenv("OPENAI_API_KEY"));
+openAiConfig.setApiHost("https://api.openai.com/");   // 换成你的网关地址
+
+Configuration configuration = new Configuration();
+configuration.setOpenAiConfig(openAiConfig);
+
+IChatService chatService = new AiService(configuration).getChatService(PlatformType.OPENAI);
+
+ChatCompletion chatCompletion = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("用一句话解释什么是向量数据库"))
+        .build();
+
+ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+String answer = response.getChoices().get(0).getMessage().getContent().getText();
+System.out.println(answer);
+```
+
+读取 token 用量（统一为 OpenAI 标准结构，各 provider 一致）：
+
+```java
+System.out.println("prompt=" + response.getUsage().getPromptTokens()
+        + " completion=" + response.getUsage().getCompletionTokens()
+        + " total=" + response.getUsage().getTotalTokens());
+```
+
 ## 1. 关键源码入口
 
 理解 `Chat` 最值得先看的对象是：
@@ -69,6 +118,30 @@ tags: [concept]
 
 这和很多团队已有的 chat-completions 心智几乎同构，所以迁移成本很低。
 
+多轮对话就是把上一轮的 assistant 消息拼回 `messages`，没有额外状态要维护：
+
+```java
+List<ChatMessage> messages = new ArrayList<>();
+messages.add(ChatMessage.withUser("记住这个数字：42。只回复 OK"));
+
+ChatCompletionResponse first = chatService.chatCompletion(ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .messages(messages)
+        .build());
+
+// 把 assistant 回复拼回会话，再问下一轮
+messages.add(first.getChoices().get(0).getMessage());
+messages.add(ChatMessage.withUser("我刚才让你记住的数字是多少？只回复数字"));
+
+ChatCompletionResponse second = chatService.chatCompletion(ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .messages(messages)
+        .build());
+
+// 输出：42
+System.out.println(second.getChoices().get(0).getMessage().getContent().getText());
+```
+
 同时，`AiService.createChatService(...)` 也说明它是当前最广覆盖的主线，支持：
 
 - OpenAI
@@ -115,6 +188,46 @@ tags: [concept]
 
 这意味着 `Chat` 在 AI4J 中不是单次 RPC，而是一个可以本地闭环执行工具的对话循环。
 
+完整可跑通示例。先定义工具——类上标 `@FunctionCall`，实现 `Function<Request, String>`：
+
+```java
+@FunctionCall(name = "getOrderStatus", description = "根据订单号查询订单状态")
+public static class GetOrderStatus implements Function<GetOrderStatus.Request, String> {
+
+    @Data
+    @FunctionRequest
+    public static class Request {
+        @FunctionParameter(description = "订单号")
+        private String orderId;
+    }
+
+    @Override
+    public String apply(Request request) {
+        // 真实项目里这里查库；示例直接返回结构化结果
+        return "{\"orderId\":\"" + request.getOrderId() + "\",\"status\":\"已发货\",\"eta\":\"2026-08-12\"}";
+    }
+}
+```
+
+调用时用 `functions(...)` 按 name 注册，其余交给 SDK：
+
+```java
+ChatCompletion chatCompletion = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("订单 A1001 现在什么状态？"))
+        .functions("getOrderStatus")
+        .build();
+
+// 收到 tool_calls 时 SDK 会自动执行 getOrderStatus 并把结果回填，
+// 这里拿到的已经是工具执行之后的最终回答
+ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+// 输出里会包含工具返回的「已发货」
+System.out.println(response.getChoices().get(0).getMessage().getContent().getText());
+```
+
+注意这里**只发起了一次调用**，工具执行、结果回填、二次请求都在 `chatCompletion(...)` 内部完成。
+
 ## 6. `passThroughToolCalls` 为什么非常关键
 
 `passThroughToolCalls` 决定的是：
@@ -132,6 +245,29 @@ tags: [concept]
 - trace
 - 沙箱执行
 - 结果裁剪
+
+同一个工具，换成 pass-through 之后拿到的是**未执行的** tool call：
+
+```java
+ChatCompletion chatCompletion = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("订单 A1001 现在什么状态？"))
+        .functions("getOrderStatus")
+        .passThroughToolCalls(Boolean.TRUE)     // 关键
+        .build();
+
+ChatCompletionResponse response = chatService.chatCompletion(chatCompletion);
+
+// SDK 不再自动执行，而是把 tool_calls 原样交回，供上层审批 / 沙箱执行 / trace
+List<ToolCall> toolCalls = response.getChoices().get(0).getMessage().getToolCalls();
+
+System.out.println("待执行工具: " + toolCalls.get(0).getFunction().getName());
+System.out.println("参数: " + toolCalls.get(0).getFunction().getArguments());
+// 待执行工具: getOrderStatus
+// 参数: {"orderId":"A1001"}
+```
+
+拿到之后要不要执行、怎么执行、执行完如何回填，全部由上层决定。
 
 ## 7. `SseListener` 的真实职责
 
@@ -158,6 +294,34 @@ tags: [concept]
 
 这说明 Chat 流式在 AI4J 里已经是“可供运行时消费的聚合状态”，不是单纯 token 输出。
 
+实际用法：继承 `SseListener`，实现 `send()`，流结束后从 listener 上取聚合结果。
+
+```java
+ChatCompletion chatCompletion = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("从 1 数到 5，只输出数字"))
+        .stream(Boolean.TRUE)
+        .build();
+
+SseListener sseListener = new SseListener() {
+    @Override
+    protected void send() {
+        // 每个 delta 到达时触发；getCurrStr() 是本次增量
+        System.out.print(getCurrStr());
+    }
+};
+
+chatService.chatCompletionStream(chatCompletion, sseListener);
+
+// 流结束后，聚合结果都在 listener 上
+System.out.println("\n完整输出: " + sseListener.getOutput());
+System.out.println("finishReason: " + sseListener.getFinishReason());
+```
+
+:::caution 方法名别写错
+流式入口是 `chatCompletionStream(...)`，**不是** `chatCompletion(...)` 的重载。
+:::
+
 ## 8. 多模态如何进入 Chat
 
 `ChatMessage.withUser(String content, String... images)` 最终会构造成：
@@ -170,6 +334,31 @@ tags: [concept]
 再往上一层，`ChatMemoryItem.toChatMessage()` 会自动把带图片的 user item 投影成多模态 `ChatMessage`。
 
 这意味着在 AI4J 里，多模态并不是 Chat 之外的独立特殊链路，而是消息内容编码方式的扩展。
+
+```java
+// 实际项目里通常是读本地文件
+byte[] bytes = Files.readAllBytes(Paths.get("photo.png"));
+String dataUrl = "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes);
+
+// withUser(text, images...) 会编码成 1 段 text + N 个 image_url
+ChatMessage message = ChatMessage.withUser("这张图是什么颜色？只回答颜色名", dataUrl);
+
+ChatCompletionResponse response = chatService.chatCompletion(ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(message)
+        .build());
+
+System.out.println(response.getChoices().get(0).getMessage().getContent().getText());
+```
+
+:::warning 优先用 base64 data URL，而不是远程图片 URL
+`withUser(text, images...)` 的 image 参数既可以是远程 URL，也可以是 base64 data URL。
+但**部分 OpenAI 兼容网关不会代拉远程图片**——实测某网关对远程 URL 直接返回
+`AiServerErrorException: Upstream service temporarily unavailable`，换成内联 base64
+则正常识别。
+
+这是网关能力差异，不是 SDK 缺陷。跨网关部署时，data URL 是更可移植的写法。
+:::
 
 ## 9. `Chat` 的边界在哪里
 

--- a/docs-site/docs/core-sdk/model-access/multimodal.md
+++ b/docs-site/docs/core-sdk/model-access/multimodal.md
@@ -14,6 +14,13 @@ tags: [concept]
 - 它如何分别投影到 `Chat` 和 `Responses`
 - 哪些场景属于模型输入，哪些场景其实更像 Tool 或 MCP
 
+:::tip 本页代码都是可跑通的
+下面的 wire-shape 示例来自
+[`MultimodalDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MultimodalDocExamplesTest.java)，
+无需密钥、在普通 CI 里跑；端到端的图片识别调用见
+[`ChatDocExamplesLiveTest#multiModalUserMessageWithImage`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ChatDocExamplesLiveTest.java)。
+:::
+
 ## 1. 为什么它属于 Model Access，而不是 Tools
 
 多模态在 AI4J 当前实现里首先是请求编码问题，不是外部能力问题。
@@ -45,6 +52,20 @@ tags: [concept]
 
 这很重要，因为它说明 AI4J 把多模态首先视为“会话事实”，而不是单次请求的特殊分支。
 
+```java
+// 读本地文件成 data URL（推荐，跨网关可移植）
+byte[] bytes = Files.readAllBytes(Paths.get("photo.png"));
+String dataUrl = "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes);
+
+// 文本 + 图片作为一条会话事实存入 Memory
+ChatMemoryItem item = ChatMemoryItem.user("这张图是什么颜色？", dataUrl);
+```
+
+:::warning 优先用 base64 data URL，而不是远程图片 URL
+部分 OpenAI 兼容网关不会代拉远程图片，实测某网关对远程 URL 直接报 `Upstream service temporarily unavailable`，
+换成内联 base64 则正常识别。这是网关能力差异，不是 SDK 缺陷。
+:::
+
 ## 3. 同一份会话事实如何投影到 Chat
 
 `ChatMemoryItem.toChatMessage()` 在 user item 且存在图片时，会构造成：
@@ -64,6 +85,23 @@ tags: [concept]
 
 这对应了 Chat 主线对图文混合输入的编码方式。
 
+```java
+ChatMessage message = item.toChatMessage();
+// message.role = "user"
+// message.content.multiModals = [
+//   { type:"text", text:"这张图是什么颜色？" },
+//   { type:"image_url", image_url:{ url:"data:image/png;base64,..." } }
+// ]
+```
+
+不经 Memory 也可以直接构造：
+
+```java
+ChatMessage direct = ChatMessage.withUser("这张图是什么颜色？", dataUrl);
+```
+
+`ChatMessage.withUser(text, images...)` 接受任意多张图，编码成一段 `text` + N 个 `image_url` part。
+
 ## 4. 同一份会话事实如何投影到 Responses
 
 `ChatMemoryItem.toResponsesInput()` 会把同一条用户会话转成：
@@ -78,6 +116,16 @@ tags: [concept]
 - 图片会变成 `input_image`
 
 也就是说，AI4J 没有把多模态做成两套互不相干的数据结构，而是把同一份会话事实投影到两条请求主线各自的格式上。
+
+```java
+Object responsesInput = item.toResponsesInput();
+// { type:"message", role:"user", content:[
+//     { type:"input_text", text:"这张图是什么颜色？" },
+//     { type:"input_image", image_url:{ url:"data:image/png;base64,..." } }
+// ] }
+```
+
+同一个 `ChatMemoryItem`，调 `toChatMessage()` 得到 Chat 形状（`image_url`），调 `toResponsesInput()` 得到 Responses 形状（`input_image`）。无需为两条主线各写一套多模态数据结构。
 
 ## 5. 为什么这种双投影很重要
 
@@ -131,6 +179,19 @@ AI4J 当前多模态主要围绕：
 进行编码。
 
 也就是说，这一层更偏向“把图片引用纳入上下文”，而不是在基座层统一处理所有视觉媒体文件形态。对于更复杂的媒体处理，通常还需要外部工具链配合。
+
+### 视频：`video_url`（Kimi/Moonshot 扩展）
+
+除了 `image_url`，`Content.MultiModal` 还支持 `video_url`，用于支持视频输入的 provider（如 Kimi/Moonshot）：
+
+```java
+Content.MultiModal video = Content.MultiModal.builder()
+        .type(Content.MultiModal.Type.VIDEO_URL.getType())
+        .videoUrl(new Content.MultiModal.VideoUrl("data:video/mp4;base64," + videoBase64))
+        .build();
+```
+
+这是 provider 扩展，不属于 OpenAI 标准；发送给不支持的 provider 时该字段会被忽略或报错。
 
 ## 8. 使用时应该注意什么
 

--- a/docs-site/docs/core-sdk/model-access/request-and-response-conventions.md
+++ b/docs-site/docs/core-sdk/model-access/request-and-response-conventions.md
@@ -87,6 +87,24 @@ AI4J 当前在模型访问层采用的是一种很明确的策略：
 
 而不是把所有东西都一股脑堆进 `extraBody`。
 
+```java
+// 主语义走正式字段
+ChatCompletion chat = ChatCompletion.builder()
+        .model("gpt-4o-mini")
+        .message(ChatMessage.withUser("你好"))
+        .reasoningEffort("medium")     // 正式字段，跨 provider 统一
+        .build();
+
+// 只有 provider 特有的、SDK 没建模的扩展，才走 extraBody
+ChatCompletion chat2 = ChatCompletion.builder()
+        .model("deepseek-chat")
+        .message(ChatMessage.withUser("你好"))
+        .extraBody("thinking", mapOf("type", "enabled"))   // DeepSeek 专属
+        .build();
+```
+
+`extraBody` 在 `ChatCompletion` 中会通过 `@JsonAnyGetter` 展开到 JSON 顶层；同名时 `extraBody` 的值会覆盖正式字段，所以用它前先确认 SDK 是否已有对应字段。
+
 ## 5. 返回值读取为什么也要有统一约定
 
 如果没有统一约定，最常见的坏结果是：
@@ -106,6 +124,12 @@ AI4J 当前给出的推荐读取方式其实很清晰：
 - `ChatMessage`
 - `Usage`
 
+```java
+ChatCompletionResponse resp = chatService.chatCompletion(req);
+String text = resp.getChoices().get(0).getMessage().getContent().getText();
+long total = resp.getUsage().getTotalTokens();
+```
+
 ### Chat 流式
 
 优先围绕：
@@ -115,11 +139,34 @@ AI4J 当前给出的推荐读取方式其实很清晰：
 - `toolCalls`
 - `finishReason`
 
+```java
+SseListener listener = new SseListener() {
+    @Override protected void send() { System.out.print(getCurrStr()); }
+};
+chatService.chatCompletionStream(req, listener);
+String full = listener.getOutput().toString();        // 聚合后的完整文本
+String reasoning = listener.getReasoningOutput();     // reasoning 片段
+String stop = listener.getFinishReason();
+```
+
 ### Responses 非流式
 
 优先围绕：
 
 - `Response`
+
+```java
+Response response = responsesService.create(req);
+// 遍历 output items 读取文本（不是 choice.message）
+StringBuilder text = new StringBuilder();
+for (ResponseItem item : response.getOutput()) {
+    if (item.getContent() == null) continue;
+    for (ResponseContentPart part : item.getContent()) {
+        if (part.getText() != null) text.append(part.getText());
+    }
+}
+int inputTokens = response.getUsage().getInputTokens();
+```
 
 ### Responses 流式
 
@@ -130,6 +177,15 @@ AI4J 当前给出的推荐读取方式其实很清晰：
 - `reasoningSummary`
 - `functionArguments`
 - `response`
+
+```java
+ResponseSseListener listener = new ResponseSseListener() {
+    @Override protected void onEvent() { System.out.print(getCurrText()); }
+};
+responsesService.createStream(req, listener);
+String full = listener.getOutputText().toString();
+String reasoning = listener.getReasoningSummary().toString();
+```
 
 ## 6. 一个很实用的团队规则
 

--- a/docs-site/docs/core-sdk/model-access/responses.md
+++ b/docs-site/docs/core-sdk/model-access/responses.md
@@ -10,6 +10,61 @@ tags: [concept]
 
 它和 `Chat` 最大的差异，不是字段名从 `messages` 变成 `input`，而是 **它把模型输出首先当成事件和 item 流，而不是单条 assistant message**。
 
+:::tip 本页代码都是可跑通的
+下面每段 Java 示例都来自仓库里的可执行测试
+[`ResponsesDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ResponsesDocExamplesLiveTest.java)，
+已针对真实 OpenAI 兼容网关跑通。本地复跑：
+
+```bash
+export OPENAI_API_KEY=sk-...
+export OPENAI_API_HOST=https://your-gateway/   # 可选
+export OPENAI_CHAT_MODEL=gpt-4o-mini           # 可选
+
+mvn -pl ai4j test -Plive-provider-tests -Dtest=ResponsesDocExamplesLiveTest
+```
+
+没有 `OPENAI_API_KEY` 时这些测试会自动跳过，不会让构建失败。
+:::
+
+## 0. 先跑起来
+
+最小可用调用。注意 Responses 的输出是 **item 列表**，每个 item 带 content parts——读取助手文本要走这个结构，不像 Chat 直接读 `choice.message.content`：
+
+```java
+OpenAiConfig openAiConfig = new OpenAiConfig();
+openAiConfig.setApiKey(System.getenv("OPENAI_API_KEY"));
+openAiConfig.setApiHost("https://api.openai.com/");   // 换成你的网关地址
+
+Configuration configuration = new Configuration();
+configuration.setOpenAiConfig(openAiConfig);
+
+IResponsesService responsesService = new AiService(configuration)
+        .getResponsesService(PlatformType.OPENAI);
+
+ResponseRequest request = ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("用一句话解释什么是响应式编程")
+        .build();
+
+Response response = responsesService.create(request);
+
+// Responses 的输出是 item 列表：遍历 output，每个 item 带 content parts
+String answer = "";
+for (ResponseItem item : response.getOutput()) {
+    if (item.getContent() == null) continue;
+    for (ResponseContentPart part : item.getContent()) {
+        if (part.getText() != null) answer += part.getText();
+    }
+}
+System.out.println(answer);
+
+System.out.println("input=" + response.getUsage().getInputTokens()
+        + " output=" + response.getUsage().getOutputTokens()
+        + " total=" + response.getUsage().getTotalTokens());
+```
+
+`response.getStatus()` 通常为 `"completed"`，`getObject()` 为 `"response"`。
+
 ## 1. 关键源码入口
 
 理解 `Responses` 最关键的对象是：
@@ -51,6 +106,17 @@ tags: [concept]
 
 和 `Chat` 一样，这两个字段不会直接发给 provider；它们只是本地解析工具时的输入。
 
+`instructions` 相当于系统级指令，`maxOutputTokens` 限制输出长度：
+
+```java
+Response response = responsesService.create(ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .instructions("你只能用中文回答，且不超过 20 个字。")
+        .input("What is a vector database?")
+        .maxOutputTokens(200)
+        .build());
+```
+
 ## 3. provider 发送前会做什么
 
 `OpenAiResponsesService.create(...)` 与 `createStream(...)` 的第一件关键事，都是：
@@ -61,13 +127,50 @@ tags: [concept]
 
 1. 检查 request 中是否存在 `functions` 或 `mcpServices`
 2. 如果有，就调用 `ToolUtil.getAllTools(...)`
-3. 把解析出的本地 function tools 和 MCP tools 合并进 `request.tools`
+3. 把解析出的本地 function tools 和 MCP tools **投影**进 `request.tools`
 4. 返回新的 request
 
 所以 `Responses` 和 `Chat` 并不是两套互不相干的工具体系，而是共享同一条工具解析基座，只是入口不同：
 
 - `Chat` 直接在 chat service 中解析
 - `Responses` 先经过 `ResponseRequestToolResolver`
+
+:::warning Responses 的 function tool 形状和 Chat 不同
+Chat Completions 把函数声明**嵌套**在 `function` 键下，而 Responses API 要求它们**扁平**（`type` / `name` / `description` / `parameters` 在顶层）。`ResponseRequestToolResolver` 会自动做这层投影——所以你用同一套 `@FunctionCall` 注册，两条线都能正确发出。
+
+```java
+@FunctionCall(name = "getStockPrice", description = "查询股票当前价格")
+public static class GetStockPrice implements Function<GetStockPrice.Request, String> {
+    @Data @FunctionRequest
+    public static class Request {
+        @FunctionParameter(description = "股票代码，例如 AAPL")
+        private String symbol;
+    }
+
+    @Override
+    public String apply(Request request) {
+        return "{\"symbol\":\"" + request.getSymbol() + "\",\"price\":195.42}";
+    }
+}
+
+// Responses 主线：functions(...) 注册，SDK 自动投影成扁平形状
+ResponseRequest request = ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("AAPL 现在多少钱？")
+        .functions("getStockPrice")
+        .build();
+
+Response response = responsesService.create(request);
+```
+
+与 `Chat` 的自动 tool loop 不同，`Responses` **不做**服务内自动循环：`output[]` 里出现的 `function_call` item 会原样交回上层，由你的 runtime 决定是否执行、如何回填 `function_call_output`。
+
+需要让模型更严格地遵循 schema 时，在注册时开启 [strict 模式](../model-access/chat#5-chat-的一个关键特性自动-tool-loop)：
+
+```java
+@FunctionCall(name = "getStockPrice", description = "...", strict = true)
+```
+:::
 
 ## 4. `Responses` 的 provider 覆盖为什么更聚焦
 
@@ -149,6 +252,35 @@ tags: [concept]
 - function arguments 是否在逐步成形
 - 最终 response 结构有没有闭合
 
+流式用法——继承 `ResponseSseListener`，实现 `onEvent()`，流结束后从 listener 上取聚合状态：
+
+```java
+ResponseRequest request = ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("从 1 数到 5，只输出数字")
+        .stream(Boolean.TRUE)
+        .build();
+
+ResponseSseListener listener = new ResponseSseListener() {
+    @Override
+    protected void onEvent() {
+        // currText 是本次事件带来的文本增量
+        String delta = getCurrText();
+        if (delta != null && !delta.isEmpty()) {
+            System.out.print(delta);
+        }
+    }
+};
+
+responsesService.createStream(request, listener);
+
+// 流结束后，聚合状态都在 listener 上
+System.out.println("\n完整文本: " + listener.getOutputText());
+System.out.println("事件条数: " + listener.getEvents().size());
+```
+
+除了 `getOutputText()`，listener 还聚合了 `getReasoningSummary()`（推理摘要）、`getFunctionArguments()`（函数参数）、`getResponse()`（最终结构）。
+
 ## 7. `Responses` 为什么更适合状态机而不是自动 tool loop
 
 和 `Chat` 不同，当前 `OpenAiResponsesService` 并没有在 service 内部做那种 `while finishReason == tool_calls` 的本地自动循环。
@@ -180,6 +312,35 @@ tags: [concept]
 - 面向 response graph 的后续操作
 
 这也是为什么它更接近“结构化交互协议”，而不是“消息式问答接口”。
+
+```java
+// 第一轮：让 provider 侧留存这次响应
+Response first = responsesService.create(ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .input("记住数字 42。只回复 STORED")
+        .store(Boolean.TRUE)
+        .build());
+
+// 第二轮：只带 id，不重发历史
+Response second = responsesService.create(ResponseRequest.builder()
+        .model("gpt-4o-mini")
+        .previousResponseId(first.getId())
+        .input("我让你记住的数字是多少？只回复数字")
+        .build());
+```
+
+已存留的响应也可以单独取回或删除：
+
+```java
+Response fetched = responsesService.retrieve(first.getId());
+responsesService.delete(first.getId());
+```
+
+:::note 并非所有网关都支持存储态
+`store` / `previous_response_id` / `retrieve` / `delete` 依赖 provider 侧保存响应。实测某 OpenAI 兼容网关明确回
+`previous_response_id is only supported on Responses WebSocket v2`，且 `retrieve` 返回 404——这是网关能力差异，不是 SDK 缺陷。
+官方 OpenAI 支持这些操作。
+:::
 
 ## 9. 什么时候不要急着上 `Responses`
 

--- a/docs-site/docs/core-sdk/realtime.md
+++ b/docs-site/docs/core-sdk/realtime.md
@@ -10,6 +10,12 @@ tags: [concept]
 Realtime 在 AI4J 当前是一条 **很薄但正式存在的长连接能力面**。  
 它的重点不是事件协议建模得多完整，而是 SDK 已经给出了统一入口、默认鉴权头和 WebSocket 建连主线。
 
+:::tip 本页代码都是可跑通的
+下面的建连示例来自
+[`AudioAndRealtimeDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/AudioAndRealtimeDocExamplesLiveTest.java)。
+（realtime 端点不是所有网关都支持，测试在该场景会跳过。）
+:::
+
 ## 1. 当前支持矩阵
 
 从 `AiService.createRealtimeService(...)` 的分发看，当前 realtime 只支持：
@@ -34,6 +40,33 @@ Realtime 在 AI4J 当前是一条 **很薄但正式存在的长连接能力面**
 - 它只负责建连
 - 不负责替你定义事件语义
 - 也不负责状态机推进
+
+建连示例：
+
+```java
+IRealtimeService realtime = new AiService(configuration).getRealtimeService(PlatformType.OPENAI);
+
+WebSocket ws = realtime.createRealtimeClient("gpt-4o-realtime-preview", new RealtimeListener() {
+    @Override
+    protected void onOpen(WebSocket webSocket) {
+        System.out.println("realtime connected");
+    }
+
+    @Override
+    protected void onMessage(ByteString bytes) {
+        // 二进制音频帧
+    }
+
+    @Override
+    protected void onMessage(String text) {
+        // JSON 事件，自己解析事件类型后分发
+        System.out.println("event: " + text);
+    }
+
+    @Override
+    protected void onFailure() { /* 注意：见下文实现细节 */ }
+});
+```
 
 ## 3. `OpenAiRealtimeService` 的真实行为
 

--- a/docs-site/docs/flowgram/built-in-nodes.md
+++ b/docs-site/docs/flowgram/built-in-nodes.md
@@ -213,7 +213,7 @@ starter 侧多个 executor 都会用 `FlowGramNodeValueResolver` 解析输入值
 
 因此它更适合“把流程接到外部系统”，不适合承担复杂业务编排本身。
 
-### 7.1 SSRF 防护：`HttpNodeSsrfGuard`
+### 7.1 SSRF 防护：`HttpNodeSsrfGuard` {#ssrf-guard}
 
 HTTP 节点在发出请求前会先过一道 `HttpNodeSsrfGuard`（`ssrfGuard.validate(fullUrl)`），防止工作流被诱导去访问内部网络。这是默认开启的，不需要额外配置。
 

--- a/docs-site/docs/spring-boot/configuration-reference.md
+++ b/docs-site/docs/spring-boot/configuration-reference.md
@@ -195,7 +195,7 @@ ai4j:
 
 ### HTTP 节点 SSRF 防护
 
-`http-node.allow-private-network` 默认 `false`，HTTP 节点请求会先过 `HttpNodeSsrfGuard`，拦截回环/私网/链路本地/云元数据地址。仅在确需访问内网服务时才显式设为 `true`。详见 [Built-in Nodes / SSRF 防护](/docs/flowgram/built-in-nodes#71-ssrf-防护-httpnodessrfguard)。
+`http-node.allow-private-network` 默认 `false`，HTTP 节点请求会先过 `HttpNodeSsrfGuard`，拦截回环/私网/链路本地/云元数据地址。仅在确需访问内网服务时才显式设为 `true`。详见 [Built-in Nodes / SSRF 防护](/docs/flowgram/built-in-nodes#ssrf-guard)。
 
 ## 6. 这页应该怎么用
 


### PR DESCRIPTION
model-access 主线 7 页原本全是讲解、零代码。本 PR 给每一页补上**从可执行测试里长出来的**示例。

## 改动

| 页面 | Java 块 | 来源 |
| --- | --- | --- |
| `chat.md` | 8 | `ChatDocExamplesLiveTest`（live） |
| `responses.md` | 7 | `ResponsesDocExamplesLiveTest`（live） |
| `multimodal.md` | 5 | `MultimodalDocExamplesTest`（无密钥，CI 跑） |
| `chat-vs-responses.md` | 3 | 复用上面两个 live |
| `request-and-response-conventions.md` | 5 | 复用 + API 契约 |
| `audio.md` | 3 | `AudioAndRealtimeDocExamplesLiveTest`（live） |
| `realtime.md` | 1 | 同上 |

共 32 个 Java 块，全部来自可执行测试，docs 构建零警告。

## 方法

示例先写成 live 测试跑通，再嵌进文档——这样 snippet 不能悄悄烂掉：API 变了编译失败，行为变了测试失败。写的过程中当场拦下两个错误（`chatCompletionStream` 不是 `chatCompletion` 重载、Responses 图片 URL 投影是嵌套结构），纯讲解型文档会把这种错原样发出去。

## 附带修正

`audio.md` 原本写着"失败返回 null、没有结构化错误"，但这正是刚合的 #229 改掉的行为——transcription/translation/TTS 现在抛类型化 `AiHttpException`。留着旧描述会主动误导人，已更新为抛异常 + 版本差异注释。

## 依赖

本分支基于已合并的 #229（错误诊断）和 #230（Responses tool 形状 + strict mode）。`responses.md` 和 `chat.md` 里引用了这两个修复后的 API（如 strict 开关、flat tool 投影说明）。

## 测试

- `MultimodalDocExamplesTest`（5）：无密钥，普通 CI 跑，钉双投影 wire shape
- 其余 live 测试需 `OPENAI_API_KEY`，走 `live-provider-tests` profile；网关不支持的端点（realtime、部分 transcription）自动跳过而非失败