### PR TITLE
docs(model-access): messages.md 补 live 测试 + tool_use 示例

### DIFF
--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MessagesDocExamplesLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MessagesDocExamplesLiveTest.java
@@ -1,0 +1,192 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.config.AnthropicConfig;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.entity.AnthropicChatCompletion;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.entity.AnthropicChatCompletionResponse;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.entity.AnthropicContentBlock;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.entity.AnthropicMessage;
+import io.github.lnyocly.ai4j.platform.anthropic.chat.entity.AnthropicTool;
+import io.github.lnyocly.ai4j.platform.anthropic.stream.AnthropicStreamHandler;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IMessagesService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/core-sdk/model-access/messages.md}.
+ *
+ * <p>Validated against an Anthropic-compatible endpoint (MiniMax-M3).
+ * Requires {@code MINIMAX_API_KEY}; honours {@code MINIMAX_BASE_URL} and
+ * {@code MINIMAX_MODEL}. Skips when the key is absent.
+ */
+@Category(LiveProviderTest.class)
+public class MessagesDocExamplesLiveTest {
+
+    private IMessagesService messagesService() {
+        String apiKey = System.getenv("MINIMAX_API_KEY");
+        Assume.assumeTrue("MINIMAX_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        String baseUrl = System.getenv("MINIMAX_BASE_URL");
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            baseUrl = "https://api.minimaxi.com/anthropic/";
+        }
+
+        AnthropicConfig config = new AnthropicConfig();
+        config.setApiKey(apiKey);
+        config.setApiHost(baseUrl);
+
+        Configuration configuration = new Configuration();
+        configuration.setAnthropicConfig(config);
+        return new AiService(configuration).getMessagesService(PlatformType.ANTHROPIC);
+    }
+
+    private String model() {
+        String model = System.getenv("MINIMAX_MODEL");
+        return (model == null || model.trim().isEmpty()) ? "MiniMax-M3" : model;
+    }
+
+    private AnthropicChatCompletion request(String prompt) {
+        AnthropicMessage user = new AnthropicMessage();
+        user.setRole("user");
+        user.setContent(prompt);
+
+        AnthropicChatCompletion request = new AnthropicChatCompletion();
+        request.setModel(model());
+        request.setMessages(new ArrayList<AnthropicMessage>(Collections.singletonList(user)));
+        request.setMaxTokens(256);
+        return request;
+    }
+
+    /** 遍历 content blocks 读取助手文本（thinking / tool_use 之外的 text block）。 */
+    private static String textOf(AnthropicChatCompletionResponse response) {
+        StringBuilder text = new StringBuilder();
+        if (response != null && response.getContent() != null) {
+            for (AnthropicContentBlock block : response.getContent()) {
+                if (block != null && "text".equals(block.getType()) && block.getText() != null) {
+                    text.append(block.getText());
+                }
+            }
+        }
+        return text.toString();
+    }
+
+    // ---- §4 原生调用 + 读取 content / usage ----
+
+    @Test
+    public void messagesReturnsTextAndUsage() throws Exception {
+        IMessagesService service = messagesService();
+
+        AnthropicChatCompletionResponse response = service.messages(request("Reply with exactly: PONG"));
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals("message", response.getType());
+        Assert.assertEquals("assistant", response.getRole());
+
+        System.out.println("回答: " + textOf(response));
+        System.out.println("input=" + response.getUsage().getInputTokens()
+                + " output=" + response.getUsage().getOutputTokens());
+
+        Assert.assertTrue("应包含 PONG：" + textOf(response),
+                textOf(response).toUpperCase().contains("PONG"));
+        Assert.assertTrue(response.getUsage().getInputTokens() > 0);
+    }
+
+    // ---- §4 流式（原生事件回调） ----
+
+    @Test
+    public void messagesStreamDeliversDeltasAndStopReason() throws Exception {
+        IMessagesService service = messagesService();
+
+        AnthropicChatCompletion req = request("Count from 1 to 5, digits only.");
+        req.setStream(Boolean.TRUE);
+
+        final StringBuilder streamed = new StringBuilder();
+        final AtomicReference<String> stopReason = new AtomicReference<String>();
+        final CountDownLatch done = new CountDownLatch(1);
+
+        service.messagesStream(req, new AnthropicStreamHandler() {
+            @Override
+            public void onDeltaText(String delta) {
+                if (delta != null) streamed.append(delta);
+            }
+
+            @Override
+            public void onStopReason(String reason, long inputTokens, long outputTokens) {
+                stopReason.set(reason);
+            }
+
+            @Override
+            public void onComplete() {
+                done.countDown();
+            }
+        });
+
+        Assert.assertTrue("流应在 120s 内完成", done.await(120, TimeUnit.SECONDS));
+        Assert.assertTrue("应有流式文本", streamed.length() > 0);
+        Assert.assertNotNull("应有 stopReason", stopReason.get());
+        System.out.println("流式输出: " + streamed);
+        System.out.println("stopReason: " + stopReason.get());
+    }
+
+    // ---- tool_use：Messages 协议原生的工具调用 ----
+
+    /**
+     * tool_use 是 Messages 协议最该测的能力：模型必须 emit 一个
+     * type="tool_use" 的 content block，带 name / id / input（已解析对象）。
+     */
+    @Test
+    public void messagesSupportsToolUse() throws Exception {
+        IMessagesService service = messagesService();
+
+        Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        Map<String, Object> cityProperty = new LinkedHashMap<String, Object>();
+        cityProperty.put("type", "string");
+        cityProperty.put("description", "City name");
+        properties.put("city", cityProperty);
+
+        Map<String, Object> inputSchema = new LinkedHashMap<String, Object>();
+        inputSchema.put("type", "object");
+        inputSchema.put("properties", properties);
+        inputSchema.put("required", Collections.singletonList("city"));
+
+        AnthropicTool tool = new AnthropicTool();
+        tool.setName("get_weather");
+        tool.setDescription("Get the current weather for a city.");
+        tool.setInputSchema(inputSchema);
+
+        AnthropicChatCompletion req = request("What is the weather in Beijing? Use the get_weather tool.");
+        req.setTools(new ArrayList<AnthropicTool>(Collections.singletonList(tool)));
+
+        AnthropicChatCompletionResponse response = service.messages(req);
+
+        Assert.assertNotNull(response);
+        List<AnthropicContentBlock> blocks = response.getContent();
+
+        boolean sawToolUse = false;
+        for (AnthropicContentBlock block : blocks) {
+            if (block != null && "tool_use".equals(block.getType())) {
+                sawToolUse = true;
+                Assert.assertEquals("get_weather", block.getName());
+                Assert.assertNotNull("tool_use 应带 id", block.getId());
+                Assert.assertNotNull("tool_use 应带 input（已解析对象）", block.getInput());
+                System.out.println("tool_use: " + block.getName() + " input=" + block.getInput());
+            }
+        }
+        Assert.assertTrue("应产生 tool_use block；stopReason=" + response.getStopReason(), sawToolUse);
+    }
+}

--- a/docs-site/docs/core-sdk/model-access/chat.md
+++ b/docs-site/docs/core-sdk/model-access/chat.md
@@ -209,6 +209,8 @@ public static class GetOrderStatus implements Function<GetOrderStatus.Request, S
 }
 ```
 
+这里 `@FunctionCall` / `@FunctionRequest` / `@FunctionParameter` 三注解 + 反射会自动把 Java 类型生成 provider 的 JSON Schema（`String`→`string`、`enum`→`string+enum`、`Integer`→`integer`…），你不用手写 schema。`required`、复杂类型边界、`strict` 模式详见 [Annotation-based Tools](/docs/core-sdk/tools/annotation-based-tools)。
+
 调用时用 `functions(...)` 按 name 注册，其余交给 SDK：
 
 ```java

--- a/docs-site/docs/core-sdk/model-access/messages.md
+++ b/docs-site/docs/core-sdk/model-access/messages.md
@@ -12,6 +12,21 @@ tags: [concept]
 
 > 让本就说 Anthropic 方言的系统，**原生 in / 原生 out**地接入，零 OpenAI 格式转换、零字段丢失。
 
+:::tip 本页代码都是可跑通的
+下面的示例来自
+[`MessagesDocExamplesLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MessagesDocExamplesLiveTest.java)，
+已针对真实 Anthropic 兼容网关（MiniMax-M3）跑通。本地复跑：
+
+```bash
+export MINIMAX_API_KEY=sk-...
+export MINIMAX_MODEL=MiniMax-M3   # 可选
+
+mvn -pl ai4j test -Plive-provider-tests -Dtest=MessagesDocExamplesLiveTest
+```
+
+没有 `MINIMAX_API_KEY` 时自动跳过。
+:::
+
 ## 1. 三条主线，不是新旧关系
 
 | 主线 | 协议 | 接口 | 适合 |
@@ -72,8 +87,54 @@ request.setMessages(Collections.singletonList(user));
 request.setMaxTokens(128);
 
 AnthropicChatCompletionResponse response = messages.messages(request);
+
 // 原生 content blocks（text / thinking / tool_use）原样拿到
+// 遍历 content 读取助手文本（thinking / tool_use 之外的 text block）
+StringBuilder answer = new StringBuilder();
+for (AnthropicContentBlock block : response.getContent()) {
+    if ("text".equals(block.getType())) {
+        answer.append(block.getText());
+    }
+}
+System.out.println(answer);
+
+System.out.println("input=" + response.getUsage().getInputTokens()
+        + " output=" + response.getUsage().getOutputTokens());
 ```
+
+### tool_use（Messages 原生工具调用）
+
+```java
+Map<String, Object> inputSchema = new LinkedHashMap<>();
+inputSchema.put("type", "object");
+inputSchema.put("properties", Map.of("city",
+        Map.of("type", "string", "description", "City name")));
+inputSchema.put("required", List.of("city"));
+
+AnthropicTool tool = new AnthropicTool();
+tool.setName("get_weather");
+tool.setDescription("Get the current weather for a city.");
+tool.setInputSchema(inputSchema);
+
+AnthropicChatCompletion toolReq = request("What is the weather in Beijing? Use the get_weather tool.");
+toolReq.setTools(List.of(tool));
+
+AnthropicChatCompletionResponse resp = messages.messages(toolReq);
+
+// 模型会 emit 一个 type="tool_use" 的 content block，带 name / id / input（已解析对象）
+for (AnthropicContentBlock block : resp.getContent()) {
+    if ("tool_use".equals(block.getType())) {
+        System.out.println("待执行: " + block.getName() + " input=" + block.getInput());
+        System.out.println("call_id: " + block.getId());   // 回填 tool_result 时要用
+    }
+}
+```
+
+:::note tool_use 与 Chat 的工具格式不同
+Anthropic 的工具声明用 `input_schema`（不是 OpenAI 的 `parameters`），返回的 `input` 是**已解析的对象**（不是 JSON 字符串）；
+回填结果用 `role:"user"` 消息里的 `tool_result` block + `tool_use_id`（不是 OpenAI 的 `role:"tool"` + `tool_call_id`）。
+原生路径走的就是这套，零转换。
+:::
 
 ### 流式（原生事件回调）
 


### PR DESCRIPTION
`messages.md`（Anthropic 原生主线）有代码，但和 chat/responses 两条主线不对齐：没有 doc 名的 live 测试，§4 示例没展示如何读响应（content blocks / usage），也没覆盖 tool_use。

## 改动

- 新增 `MessagesDocExamplesLiveTest`（普通调用 + 流式 + tool_use），针对 MiniMax-M3 跑通，3/3 绿
- `messages.md`：
  - 加可跑通 tip 横幅，指向新测试
  - §4 补 content / usage 读取
  - 新增 tool_use 完整示例 + 格式差异 callout（Anthropic 用 `input_schema`、`input` 是已解析对象、回填用 `tool_result` + `tool_use_id`）

## 为什么 tool_use 值得专门测

它是 Messages 协议最该测的能力：模型必须 emit 一个 `type="tool_use"` 的 content block，带 `name` / `id` / `input`（已解析对象）。实测 MiniMax-M3 正确返回。

至此三条模型访问主线（Chat / Responses / Messages）都有了 doc 名的 live 测试和完整示例。

需要 `MINIMAX_API_KEY`，走 `live-provider-tests` profile；无 key 自动跳过。