### PR TITLE
docs(memory,skills): chat-memory + skill discovery 可跑通示例

### DIFF
--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MemoryDocExamplesTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MemoryDocExamplesTest.java
@@ -1,0 +1,137 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.memory.ChatMemory;
+import io.github.lnyocly.ai4j.memory.ChatMemoryItem;
+import io.github.lnyocly.ai4j.memory.ChatMemorySnapshot;
+import io.github.lnyocly.ai4j.memory.InMemoryChatMemory;
+import io.github.lnyocly.ai4j.memory.MessageWindowChatMemoryPolicy;
+import io.github.lnyocly.ai4j.platform.openai.chat.entity.ChatMessage;
+import io.github.lnyocly.ai4j.platform.openai.tool.ToolCall;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/core-sdk/memory/chat-memory.md}.
+ *
+ * <p>All checks are in-memory projections — no key, no network; runs in CI.
+ */
+public class MemoryDocExamplesTest {
+
+    private static final String RED_PNG_DATA_URL =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP4z8CAFWEXHbQSACj/P8Fu7N9hAAAAAElFTkSuQmCC";
+
+    // ---- §1 基本使用 + 投影 ----
+
+    @Test
+    public void memoryHoldsConversationFactsAndProjectsToChat() {
+        ChatMemory memory = new InMemoryChatMemory();
+
+        memory.addSystem("You are a helpful assistant.");
+        memory.addUser("记住数字 42");
+        memory.addAssistant("好的，记住了。");
+
+        Assert.assertEquals(3, memory.getItems().size());
+
+        // 投影到 Chat：ChatMessage 列表
+        List<ChatMessage> messages = memory.toChatMessages();
+        Assert.assertEquals("system", messages.get(0).getRole());
+        Assert.assertEquals("user", messages.get(1).getRole());
+        Assert.assertEquals("assistant", messages.get(2).getRole());
+    }
+
+    // ---- §3 同一份事实投影到 Chat 和 Responses ----
+
+    @Test
+    public void sameFactsProjectToBothChatAndResponses() {
+        ChatMemory memory = new InMemoryChatMemory();
+        memory.addUser("这张图是什么颜色？", RED_PNG_DATA_URL);
+
+        // Chat 投影：image_url
+        List<ChatMessage> chat = memory.toChatMessages();
+        Assert.assertEquals("image_url", chat.get(0).getContent().getMultiModals().get(1).getType());
+
+        // Responses 投影：input_image
+        Map<String, Object> responsesItem = (Map<String, Object>) memory.toResponsesInput().get(0);
+        Assert.assertEquals("input_image",
+                ((List<Map<String, Object>>) responsesItem.get("content")).get(1).get("type"));
+    }
+
+    // ---- §6 MessageWindowChatMemoryPolicy 保住 system ----
+
+    @Test
+    public void windowPolicyRetainsSystemAndTrimsWindow() {
+        InMemoryChatMemory memory = new InMemoryChatMemory(new MessageWindowChatMemoryPolicy(2));
+
+        memory.addSystem("system prompt");
+        memory.addUser("u1");
+        memory.addAssistant("a1");
+        memory.addUser("u2");
+
+        List<ChatMemoryItem> items = memory.getItems();
+        // system 被保住，窗口外更早的非 system 条目被裁掉
+        Assert.assertEquals(3, items.size());
+        Assert.assertEquals("system", items.get(0).getRole());
+        Assert.assertEquals("u2", items.get(2).getText());
+    }
+
+    // ---- §7 快照与恢复 ----
+
+    @Test
+    public void snapshotFreezesAndRestoreResumes() {
+        InMemoryChatMemory memory = new InMemoryChatMemory();
+        memory.addUser("第一轮");
+        memory.addAssistant("回复一");
+
+        ChatMemorySnapshot snapshot = memory.snapshot();
+
+        memory.addUser("第二轮");
+        Assert.assertEquals(3, memory.getItems().size());
+
+        // 恢复到快照点：临时分支试验、回放
+        memory.restore(snapshot);
+        Assert.assertEquals("恢复后应回到快照时的条目数", 2, memory.getItems().size());
+    }
+
+    // ---- §8 工具结果如何进入 memory ----
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void toolCallAndOutputRecordedAsAFactChain() {
+        InMemoryChatMemory memory = new InMemoryChatMemory();
+
+        ToolCall toolCall = new ToolCall(
+                "call_1", "function",
+                new ToolCall.Function("queryWeather", "{\"city\":\"Beijing\"}"));
+
+        memory.addAssistant("让我查一下", Collections.singletonList(toolCall));
+        memory.addToolOutput("call_1", "{\"weather\":\"sunny\"}");
+
+        // Chat 投影：assistant(toolCalls) + tool 消息
+        List<ChatMessage> chat = memory.toChatMessages();
+        Assert.assertEquals("tool", chat.get(1).getRole());
+
+        // Responses 投影：message(tool_calls) + function_call_output
+        List<Object> responses = memory.toResponsesInput();
+        Map<String, Object> toolOutput = (Map<String, Object>) responses.get(1);
+        Assert.assertEquals("function_call_output", toolOutput.get("type"));
+        Assert.assertEquals("call_1", toolOutput.get("call_id"));
+    }
+
+    // ---- §4 InMemory add 复制条目 ----
+
+    @Test
+    public void addCopiesItemToAvoidSharedMutation() {
+        InMemoryChatMemory memory = new InMemoryChatMemory();
+        ChatMemoryItem item = ChatMemoryItem.user("hello");
+        memory.add(item);
+
+        // 修改原对象不影响 memory 里的条目
+        item.setText("changed");
+        Assert.assertEquals("hello", memory.getItems().get(0).getText());
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/SkillsDocExamplesTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/SkillsDocExamplesTest.java
@@ -1,0 +1,102 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.skill.SkillDescriptor;
+import io.github.lnyocly.ai4j.skill.Skills;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/core-sdk/skills/overview.md} and {@code discovery-and-loading.md}.
+ *
+ * <p>Creates a temp workspace with a SKILL.md, runs discovery end to end.
+ * No key, no network; runs in CI.
+ */
+public class SkillsDocExamplesTest {
+
+    // ---- §7 发现 + 目录 ----
+
+    @Test
+    public void discoverFindsSkillFromWorkspace() throws Exception {
+        Path workspace = createWorkspaceWithSkill();
+
+        Skills.DiscoveryResult result = Skills.discoverDefault(workspace);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("应发现 skill", result.getSkills().isEmpty());
+
+        SkillDescriptor skill = result.getSkills().get(0);
+        Assert.assertEquals("code-review", skill.getName());
+        Assert.assertTrue(skill.getDescription().contains("code review"));
+        Assert.assertTrue("应记录 skill 文件路径", skill.getSkillFilePath().endsWith("SKILL.md"));
+        Assert.assertFalse("应给出只读根", result.getAllowedReadRoots().isEmpty());
+    }
+
+    // ---- §6.3 暴露层：buildAvailableSkillsPrompt 只给目录不给正文 ----
+
+    @Test
+    public void availableSkillsPromptListsNamesNotFullBody() throws Exception {
+        Path workspace = createWorkspaceWithSkill();
+        Skills.DiscoveryResult result = Skills.discoverDefault(workspace);
+
+        String prompt = Skills.buildAvailableSkillsPrompt(result.getSkills());
+
+        System.out.println(prompt);
+        Assert.assertTrue("目录应含 skill 名", prompt.contains("code-review"));
+        Assert.assertTrue("应提示读取 SKILL.md", prompt.contains("SKILL.md"));
+        // 正文里的步骤细节不应出现在目录里
+        Assert.assertFalse("正文不应泄漏进目录", prompt.contains("1. Read the diff"));
+    }
+
+    // ---- §6.4 createToolContext 产出只读根 ----
+
+    @Test
+    public void createToolContextExposesAllowedReadRoots() throws Exception {
+        Path workspace = createWorkspaceWithSkill();
+
+        io.github.lnyocly.ai4j.tool.BuiltInToolContext ctx =
+                Skills.createToolContext(workspace);
+
+        Assert.assertNotNull(ctx.getAllowedReadRoots());
+        Assert.assertFalse("只读根应包含 skill 目录", ctx.getAllowedReadRoots().isEmpty());
+    }
+
+    // ---- appendAvailableSkillsPrompt 把目录拼到既有 prompt 上 ----
+
+    @Test
+    public void appendAvailableSkillsPromptMergesIntoBasePrompt() throws Exception {
+        Path workspace = createWorkspaceWithSkill();
+        Skills.DiscoveryResult result = Skills.discoverDefault(workspace);
+
+        String merged = Skills.appendAvailableSkillsPrompt(
+                "You are a coding agent.", result.getSkills());
+
+        Assert.assertTrue("应保留原 prompt", merged.contains("You are a coding agent."));
+        Assert.assertTrue("应追加 skill 目录", merged.contains("code-review"));
+    }
+
+    // ---- helpers ----
+
+    private Path createWorkspaceWithSkill() throws Exception {
+        Path workspace = Files.createTempDirectory("ai4j-skill-test-");
+        Path skillDir = workspace.resolve(".ai4j/skills/code-review");
+        Files.createDirectories(skillDir);
+        Files.write(skillDir.resolve("SKILL.md"),
+                ("---\n"
+                        + "name: code-review\n"
+                        + "description: How to do a thorough code review\n"
+                        + "---\n"
+                        + "# Code Review\n\n"
+                        + "Steps:\n"
+                        + "1. Read the diff carefully.\n"
+                        + "2. Check naming and structure.\n"
+                        + "3. Verify tests cover the change.\n"
+                ).getBytes(StandardCharsets.UTF_8));
+        return workspace;
+    }
+}

--- a/docs-site/docs/core-sdk/memory/chat-memory.md
+++ b/docs-site/docs/core-sdk/memory/chat-memory.md
@@ -9,7 +9,26 @@ tags: [concept]
 `ChatMemory` 是 AI4J 基座里一个非常核心、但容易被低估的对象。  
 它真正做的不是“帮你存一份 messages”，而是 **把多轮会话事实组织成可投影、可裁剪、可快照、可恢复的统一上下文抽象**。
 
+:::tip 本页代码都是可跑通的
+下面的示例来自
+[`MemoryDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/MemoryDocExamplesTest.java)，
+无需密钥、在普通 CI 里跑。
+:::
+
 ## 1. 先看真实契约
+
+最小用法——记录会话事实，投影成请求消息：
+
+```java
+ChatMemory memory = new InMemoryChatMemory();
+
+memory.addSystem("You are a helpful assistant.");
+memory.addUser("记住数字 42");
+memory.addAssistant("好的，记住了。");
+
+// 投影到 Chat：ChatMessage 列表
+List<ChatMessage> messages = memory.toChatMessages();   // [system, user, assistant]
+```
 
 `ChatMemory.java` 当前定义的核心能力包括：
 
@@ -65,6 +84,16 @@ tags: [concept]
 
 同一份历史不需要被业务层维护两套结构，这正是 `ChatMemory` 的价值所在。
 
+```java
+ChatMemory memory = new InMemoryChatMemory();
+memory.addUser("这张图是什么颜色？", dataUrl);
+
+// Chat 投影：text + image_url
+memory.toChatMessages();
+// Responses 投影：input_text + input_image
+memory.toResponsesInput();
+```
+
 ## 4. `InMemoryChatMemory` 的真实行为
 
 默认实现是：
@@ -112,13 +141,26 @@ tags: [concept]
 
 ### `MessageWindowChatMemoryPolicy`
 
-这不是“简单保留最后 N 条数组元素”。
+这不是"简单保留最后 N 条数组元素"。
 
 它会：
 
 - 从尾部开始统计最近的非 system 消息
 - 尽量保留 `system` 项
 - 丢弃超出窗口的较早非 system 条目
+
+```java
+// 保留最近 2 条非 system 消息，但 system 总是被保住
+ChatMemory memory = new InMemoryChatMemory(new MessageWindowChatMemoryPolicy(2));
+
+memory.addSystem("system prompt");
+memory.addUser("u1");
+memory.addAssistant("a1");
+memory.addUser("u2");
+
+memory.getItems();
+// → [system, assistant("a1"), user("u2")]   // u1 被裁掉，system 保留
+```
 
 测试里已经验证了这一点：即使窗口裁剪发生，`system` 消息仍会被保住。
 
@@ -150,8 +192,21 @@ tags: [concept]
 - 手动 checkpoint
 - 持久化恢复
 
-这里的 `ChatMemorySnapshot` 只是复制 `ChatMemoryItem` 列表，不承担额外语义。  
-它的价值在于把“当下会话状态”稳定冻结下来。
+这里的 `ChatMemorySnapshot` 只是复制 `ChatMemoryItem` 列表，不承担额外语义。
+它的价值在于把"当下会话状态"稳定冻结下来。
+
+```java
+InMemoryChatMemory memory = new InMemoryChatMemory();
+memory.addUser("第一轮");
+memory.addAssistant("回复一");
+
+ChatMemorySnapshot snapshot = memory.snapshot();   // 冻结当前状态
+
+memory.addUser("第二轮");                           // 继续推进
+// ... 做一次试验性分支 ...
+
+memory.restore(snapshot);                            // 回到快照点，丢弃试验
+```
 
 ## 8. 多模态和工具结果如何进入 memory
 
@@ -171,6 +226,21 @@ assistant 的 tool calls 和 tool outputs 是分开记录的：
 
 - assistant 曾请求过什么工具
 - 那个工具返回了什么
+
+```java
+ChatMemory memory = new InMemoryChatMemory();
+
+ToolCall toolCall = new ToolCall(
+        "call_1", "function",
+        new ToolCall.Function("queryWeather", "{\"city\":\"Beijing\"}"));
+
+memory.addAssistant("让我查一下", Collections.singletonList(toolCall));
+memory.addToolOutput("call_1", "{\"weather\":\"sunny\"}");
+
+// 下一轮请求时，模型能看到完整的 [assistant tool_call → tool output] 链
+memory.toChatMessages();   // Chat: assistant(toolCalls) + role:"tool"
+memory.toResponsesInput(); // Responses: message(tool_calls) + function_call_output
+```
 
 ## 9. 使用这层时最常见的误区
 

--- a/docs-site/docs/core-sdk/skills/discovery-and-loading.md
+++ b/docs-site/docs/core-sdk/skills/discovery-and-loading.md
@@ -15,7 +15,25 @@ tags: [concept]
 - 为什么不应该一开始读取全部正文
 - 这些技能文件怎样进入安全读取边界
 
+:::tip 本页代码都是可跑通的
+下面的发现示例来自
+[`SkillsDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/SkillsDocExamplesTest.java)，
+它建一个临时工作区放 SKILL.md，跑通完整发现链。无需密钥、在普通 CI 里跑。
+:::
+
 ## 1. 主入口就在 `Skills.java`
+
+一次完整发现：
+
+```java
+// 工作区下放：<workspace>/.ai4j/skills/code-review/SKILL.md
+Skills.DiscoveryResult result = Skills.discoverDefault(workspaceRoot);
+
+List<SkillDescriptor> skills = result.getSkills();          // 发现到的技能
+List<String> readRoots = result.getAllowedReadRoots();       // 只读根（联动进安全边界）
+```
+
+每个 `SkillDescriptor` 带 `name` / `description` / `skillFilePath` / `source` / `disableModelInvocation`。
 
 这套机制几乎都集中在：
 

--- a/docs-site/docs/core-sdk/skills/overview.md
+++ b/docs-site/docs/core-sdk/skills/overview.md
@@ -16,6 +16,12 @@ tags: [concept]
 
 这就是为什么 `Skill` 应该被放在基座层，而不是只当成 `Coding Agent` 的产品特性。
 
+:::tip 本页代码都是可跑通的
+下面的发现/目录生成示例来自
+[`SkillsDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/SkillsDocExamplesTest.java)，
+无需密钥、在普通 CI 里跑。
+:::
+
 ## 1. `Skill` 在架构里的真实位置
 
 从源码看，skill 主线在：
@@ -161,7 +167,20 @@ skill 不负责：
 4. 模型根据任务匹配选择是否读取某个 `SKILL.md`
 5. 读取后按 skill 指南执行
 
-这套流程和“把所有 SOP 一开始全部喂给模型”是完全不同的设计。
+这套流程和"把所有 SOP 一开始全部喂给模型"是完全不同的设计。
+
+```java
+Skills.DiscoveryResult result = Skills.discoverDefault(workspaceRoot);
+
+// 只生成技能目录（name + description），不含正文
+String skillCatalog = Skills.buildAvailableSkillsPrompt(result.getSkills());
+
+// 把目录拼到既有 system prompt 上
+String systemPrompt = Skills.appendAvailableSkillsPrompt(
+        "You are a coding agent.", result.getSkills());
+```
+
+目录里只有 `name` / `description` 和"读取 SKILL.md"的提示；正文（具体步骤、约束）不会泄漏进目录——模型匹配后再决定读取哪个 skill。
 
 ## 8. 哪些场景最适合 Skill
 


### PR DESCRIPTION
两个概念重、零代码的区域补示例。

## chat-memory.md（5 块）
- 基本使用 + Chat 投影
- 双投影：同一份事实 → Chat `image_url` / Responses `input_image`
- `MessageWindowChatMemoryPolicy` 保住 system、裁掉窗口外非 system
- `snapshot()` / `restore()` 分支试验/回放
- 工具事实链：`addAssistant(toolCalls)` + `addToolOutput` → Chat `role:"tool"` / Responses `function_call_output`

来自 `MemoryDocExamplesTest`（6 用例，无密钥，CI 跑）。

## skills（overview + discovery-and-loading，各 1 块）
完整发现链：`discoverDefault` → `buildAvailableSkillsPrompt`（只给目录不给正文）→ `appendAvailableSkillsPrompt` 拼到 system prompt。

来自 `SkillsDocExamplesTest`（4 用例，无密钥）：建临时工作区放 SKILL.md，跑通发现、目录生成、只读根产出。强调目录只暴露 `name`/`description`，正文不泄漏。

## 测试
全部无密钥，普通 CI 跑；ai4j 模块全绿；docs 构建零警告。