### PR TITLE
docs(solutions): springboot-mysql-chat-memory 加跨实例恢复示例

### DIFF
--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/JdbcMemorySolutionDocTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/JdbcMemorySolutionDocTest.java
@@ -1,0 +1,106 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.memory.ChatMemoryItem;
+import io.github.lnyocly.ai4j.memory.JdbcChatMemory;
+import io.github.lnyocly.ai4j.memory.JdbcChatMemoryConfig;
+import io.github.lnyocly.ai4j.memory.MessageWindowChatMemoryPolicy;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Executable source of truth for the snippet in
+ * {@code docs/solutions/springboot-mysql-chat-memory.md}.
+ *
+ * <p>Proves the solution's core claim — the same session recovers across
+ * separate {@link JdbcChatMemory} instances — using an embedded H2 database
+ * (production uses MySQL with the same {@code jdbcUrl}). No key, no network.
+ */
+public class JdbcMemorySolutionDocTest {
+
+    private static String h2Url(String name) {
+        try {
+            Path dir = Files.createTempDirectory("ai4j-jdbc-doc-");
+            return "jdbc:h2:" + dir.resolve(name) + ";USER=sa;DB_CLOSE_DELAY=-1";
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ---- 这条方案的核心价值：同一会话跨实例恢复 ----
+
+    @Test
+    public void sameSessionRecoversAcrossInstances() {
+        String jdbcUrl = h2Url("recover");
+
+        // 第一个实例（如请求 A 所在 Pod）写入会话
+        JdbcChatMemory first = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl)
+                .sessionId("chat-1")
+                .build());
+        first.addSystem("You are helpful");
+        first.addUser("Hello");
+        first.addAssistant("Hi");
+
+        // 第二个实例（如请求 B 所在 Pod，或重启后）用同一个 sessionId 读回
+        JdbcChatMemory second = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl)
+                .sessionId("chat-1")
+                .build());
+
+        List<ChatMemoryItem> items = second.getItems();
+        Assert.assertEquals(3, items.size());
+        Assert.assertEquals("system", items.get(0).getRole());
+        Assert.assertEquals("Hello", items.get(1).getText());
+        Assert.assertEquals("Hi", items.get(2).getText());
+    }
+
+    // ---- 持久化 memory 同样支持窗口裁剪 ----
+
+    @Test
+    public void jdbcMemoryAppliesWindowPolicy() {
+        JdbcChatMemory memory = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(h2Url("policy"))
+                .sessionId("chat-2")
+                .policy(new MessageWindowChatMemoryPolicy(2))
+                .build());
+
+        memory.addSystem("system");
+        memory.addUser("u1");
+        memory.addAssistant("a1");
+        memory.addUser("u2");
+
+        List<ChatMemoryItem> items = memory.getItems();
+        Assert.assertEquals(3, items.size());
+        Assert.assertEquals("system", items.get(0).getRole());
+        Assert.assertEquals("u2", items.get(2).getText());
+    }
+
+    // ---- 不同 sessionId 互相隔离 ----
+
+    @Test
+    public void differentSessionsAreIsolated() {
+        String jdbcUrl = h2Url("isolation");
+
+        new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl).sessionId("alice").build())
+                .addUser("alice's message");
+
+        new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl).sessionId("bob").build())
+                .addUser("bob's message");
+
+        List<ChatMemoryItem> alice = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl).sessionId("alice").build()).getItems();
+        List<ChatMemoryItem> bob = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+                .jdbcUrl(jdbcUrl).sessionId("bob").build()).getItems();
+
+        Assert.assertEquals(1, alice.size());
+        Assert.assertEquals("alice's message", alice.get(0).getText());
+        Assert.assertEquals(1, bob.size());
+        Assert.assertEquals("bob's message", bob.get(0).getText());
+    }
+}

--- a/docs-site/docs/solutions/springboot-mysql-chat-memory.md
+++ b/docs-site/docs/solutions/springboot-mysql-chat-memory.md
@@ -33,6 +33,42 @@ tags: [integration]
 
 而不是完整 Agent 会话系统。
 
+:::tip 本页代码都是可跑通的
+下面的跨实例恢复示例来自
+[`JdbcMemorySolutionDocTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/JdbcMemorySolutionDocTest.java)，
+用内嵌 H2 验证（生产换 MySQL 只改 `jdbcUrl`）。无需密钥、在普通 CI 里跑。
+:::
+
+## 2.1 这条方案的核心：同一会话跨实例恢复
+
+```java
+// 生产：jdbcUrl = "jdbc:mysql://host:3306/db"
+JdbcChatMemoryConfig config = JdbcChatMemoryConfig.builder()
+        .jdbcUrl(jdbcUrl)
+        .sessionId(sessionId)        // ← 关键：稳定的会话标识
+        .build();
+
+// 第一个实例（如请求 A 所在 Pod）写入会话
+JdbcChatMemory first = new JdbcChatMemory(config);
+first.addSystem("You are helpful");
+first.addUser("Hello");
+first.addAssistant("Hi");
+
+// 第二个实例（请求 B 所在 Pod，或服务重启后）用同一个 sessionId 读回
+JdbcChatMemory second = new JdbcChatMemory(config);
+List<ChatMemoryItem> items = second.getItems();   // [system, user, assistant] 完整恢复
+```
+
+持久化 memory 同样支持窗口裁剪——避免会话无限膨胀：
+
+```java
+JdbcChatMemory memory = new JdbcChatMemory(JdbcChatMemoryConfig.builder()
+        .jdbcUrl(jdbcUrl)
+        .sessionId(sessionId)
+        .policy(new MessageWindowChatMemoryPolicy(20))   // 保留最近 20 条非 system
+        .build());
+```
+
 ## 3. 这条方案的优点
 
 - 对 Spring Boot 项目最直接


### PR DESCRIPTION
该方案页承诺'同一会话跨实例恢复'但全是架构文字。补端到端示例（两个独立 JdbcChatMemory 实例同 sessionId 写入/读回 + 持久化窗口裁剪），来自 `JdbcMemorySolutionDocTest`（3 用例，H2 验证，无需密钥）。为 solutions/ 建立'方案页也带可跑通示例'的基线。docs 构建零警告，ai4j 全量绿。