### PR TITLE
docs(agent): subagent-handoff / teams / codeact 三个零代码页补可跑通示例

### DIFF
--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentTeamsDocExamplesTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentTeamsDocExamplesTest.java
@@ -1,0 +1,128 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.team.AgentTeam;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamMember;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamPlan;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamResult;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamTask;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/agent/agent-teams-api-reference.md}.
+ *
+ * <p>Inline scripted clients, zero network; runs in CI.
+ */
+public class AgentTeamsDocExamplesTest {
+
+    // ---- §1 buildAgent()：把 Team 包成普通 Agent ----
+
+    @Test
+    public void teamAsStandardAgentPlansAndSynthesizes() throws Exception {
+        ScriptedClient memberClient = new ScriptedClient();
+        memberClient.enqueue(text("requirements-collected"));
+
+        ScriptedClient synthClient = new ScriptedClient();
+        synthClient.enqueue(text("team-final-answer"));
+
+        Agent teamAgent = Agents.teamAgent(Agents.team()
+                .planner((objective, members, options) -> AgentTeamPlan.builder()
+                        .tasks(Arrays.asList(
+                                AgentTeamTask.builder()
+                                        .id("collect")
+                                        .memberId("researcher")
+                                        .task("Collect requirements")
+                                        .build()
+                        ))
+                        .build())
+                .synthesizerAgent(newAgent("synth", synthClient))
+                .member(AgentTeamMember.builder()
+                        .id("researcher")
+                        .name("Researcher")
+                        .agent(newAgent("member", memberClient))
+                        .build()));
+
+        AgentResult result = teamAgent.run(AgentRequest.builder().input("prepare plan").build());
+
+        Assert.assertEquals("team-final-answer", result.getOutputText());
+        Assert.assertTrue("应返回 AgentTeamResult", result.getRawResponse() instanceof AgentTeamResult);
+    }
+
+    // ---- §1 build()：直接拿 AgentTeam，能读任务板 ----
+
+    @Test
+    public void buildReturnsAgentTeamWithTaskBoard() throws Exception {
+        ScriptedClient memberClient = new ScriptedClient();
+        memberClient.enqueue(text("done"));
+        ScriptedClient synthClient = new ScriptedClient();
+        synthClient.enqueue(text("synthesized"));
+
+        AgentTeam team = Agents.team()
+                .planner((objective, members, options) -> AgentTeamPlan.builder()
+                        .tasks(Collections.singletonList(
+                                AgentTeamTask.builder()
+                                        .id("t1").memberId("worker").task("do work").build()))
+                        .build())
+                .synthesizerAgent(newAgent("synth", synthClient))
+                .member(AgentTeamMember.builder()
+                        .id("worker").name("Worker")
+                        .agent(newAgent("w", memberClient)).build())
+                .build();
+
+        AgentTeamResult result = team.run(AgentRequest.builder().input("go").build());
+
+        Assert.assertEquals("synthesized", result.getOutput());
+        // build() 返回的 AgentTeam 暴露任务状态、消息总线、持久化状态——这是选 build() 而非 buildAgent() 的理由
+        Assert.assertNotNull(team.snapshotState());
+        Assert.assertNotNull(team.listTaskStates());
+    }
+
+    // ---- helpers ----
+
+    private static Agent newAgent(String name, ScriptedClient client) {
+        return Agents.react().modelClient(client).model(name).build();
+    }
+
+    private static AgentModelResult text(String t) {
+        return AgentModelResult.builder()
+                .outputText(t)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<AgentToolCall>())
+                .build();
+    }
+
+    static final class ScriptedClient implements AgentModelClient {
+        final Deque<AgentModelResult> queue = new ConcurrentLinkedDeque<AgentModelResult>();
+
+        void enqueue(AgentModelResult r) { queue.addLast(r); }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            AgentModelResult r = queue.pollFirst();
+            if (r == null) throw new IllegalStateException("scripted client exhausted");
+            return r;
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/CodeActDocExamplesTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/CodeActDocExamplesTest.java
@@ -1,0 +1,125 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentOptions;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.codeact.CodeActOptions;
+import io.github.lnyocly.ai4j.agent.codeact.NashornCodeExecutor;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.script.ScriptEngineManager;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+
+/**
+ * Executable source of truth for the snippet in
+ * {@code docs/agent/codeact-runtime.md}.
+ *
+ * <p>Inline scripted client emits a code message then a final message,
+ * exercising the code→execute→finalize loop with zero network.
+ * Skips when Nashorn is unavailable (JDK 16+).
+ */
+public class CodeActDocExamplesTest {
+
+    @Test
+    public void codeActDirectOutputFromExecutedCode() throws Exception {
+        org.junit.Assume.assumeTrue("Nashorn required", isNashornAvailable());
+
+        // reAct=false：模型发一段代码，执行结果直接作为输出（无需二次收尾）
+        ScriptedClient client = new ScriptedClient();
+        client.enqueue(codeMessage("javascript", "return 17*3+5")); // 执行得 56
+
+        Agent agent = Agents.codeAct()
+                .modelClient(client)
+                .model("test-model")
+                .codeExecutor(new NashornCodeExecutor())
+                .systemPrompt("你是代码执行助手。输出 {type:code,language,code} 让执行器跑。")
+                .codeActOptions(CodeActOptions.builder().reAct(false).build())
+                .options(AgentOptions.builder().maxSteps(4).build())
+                .build();
+
+        AgentResult result = agent.run(AgentRequest.builder()
+                .input("请用 JavaScript 计算 17*3+5").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("执行结果应直接作为输出", "56", result.getOutputText().trim());
+    }
+
+    @Test
+    public void codeActReActModeFinalizesWithSecondCall() throws Exception {
+        org.junit.Assume.assumeTrue("Nashorn required", isNashornAvailable());
+
+        // reAct=true：第一轮发代码 → 执行 → 第二轮模型用 type=final 收尾
+        ScriptedClient client = new ScriptedClient();
+        client.enqueue(codeMessage("javascript", "return 88/11"));   // 执行得 8
+        client.enqueue(finalMessage("88 除以 11 等于 8"));
+
+        Agent agent = Agents.codeAct()
+                .modelClient(client)
+                .model("test-model")
+                .codeExecutor(new NashornCodeExecutor())
+                .systemPrompt("先输出代码，再用 type=final 收尾。")
+                .codeActOptions(CodeActOptions.builder().reAct(true).build())
+                .options(AgentOptions.builder().maxSteps(4).build())
+                .build();
+
+        AgentResult result = agent.run(AgentRequest.builder()
+                .input("用 JavaScript 计算 88 除以 11，再给出最终结果").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("reAct 模式应走到 final 收尾", "88 除以 11 等于 8", result.getOutputText());
+    }
+
+    private static boolean isNashornAvailable() {
+        try {
+            return new ScriptEngineManager().getEngineByName("nashorn") != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static AgentModelResult codeMessage(String language, String code) {
+        // CodeAct 协议：模型输出 JSON，type=code 触发执行器
+        String json = "{\"type\":\"code\",\"language\":\"" + language + "\",\"code\":\"" + code + "\"}";
+        return AgentModelResult.builder()
+                .outputText(json)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<>())
+                .build();
+    }
+
+    private static AgentModelResult finalMessage(String output) {
+        String json = "{\"type\":\"final\",\"output\":\"" + output + "\"}";
+        return AgentModelResult.builder()
+                .outputText(json)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<>())
+                .build();
+    }
+
+    static final class ScriptedClient implements AgentModelClient {
+        final Deque<AgentModelResult> queue = new ArrayDeque<AgentModelResult>();
+
+        void enqueue(AgentModelResult r) { queue.addLast(r); }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            AgentModelResult r = queue.pollFirst();
+            if (r == null) throw new IllegalStateException("scripted client exhausted");
+            return r;
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/SubAgentHandoffDocExamplesTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/SubAgentHandoffDocExamplesTest.java
@@ -1,0 +1,204 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.subagent.HandoffFailureAction;
+import io.github.lnyocly.ai4j.agent.subagent.HandoffPolicy;
+import io.github.lnyocly.ai4j.agent.subagent.SubAgentDefinition;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Executable source of truth for the snippets in
+ * {@code docs/agent/subagent-handoff-policy.md}.
+ *
+ * <p>Uses an inline scripted model client so the handoff wiring and
+ * HandoffPolicy behaviour are exercised with zero network. Runs in CI.
+ */
+public class SubAgentHandoffDocExamplesTest {
+
+    // ---- §3 把 SubAgent 装进 parent ----
+
+    @Test
+    public void subAgentRegisteredAsAToolAndDelegated() throws Exception {
+        ScriptedClient subClient = new ScriptedClient();
+        subClient.enqueue(text("review-ready"));
+        Agent reviewer = Agents.react().modelClient(subClient).model("reviewer").build();
+
+        SubAgentDefinition reviewerSub = SubAgentDefinition.builder()
+                .name("code-reviewer")
+                .description("Review code quality and risks")
+                .toolName("delegate_code_review")
+                .agent(reviewer)
+                .build();
+
+        ScriptedClient parentClient = new ScriptedClient();
+        parentClient.enqueue(toolCall("call_1", "delegate_code_review", "{\"task\":\"review auth\"}"));
+        parentClient.enqueue(text("final-answer"));
+
+        Agent parent = Agents.react()
+                .modelClient(parentClient)
+                .model("manager")
+                .subAgent(reviewerSub)
+                .build();
+
+        AgentResult result = parent.run(AgentRequest.builder().input("analyze").build());
+
+        Assert.assertEquals("final-answer", result.getOutputText());
+        Assert.assertEquals("subagent 的输出应回流给 parent", 1, result.getToolResults().size());
+        Assert.assertTrue(result.getToolResults().get(0).getOutput().contains("review-ready"));
+    }
+
+    // ---- §10/§11 HandoffPolicy：限制工具面 + 失败回退 ----
+
+    @Test
+    public void handoffPolicyAllowedToolsDeniesUnlistedToolByDefault() throws Exception {
+        ScriptedClient subClient = new ScriptedClient();
+        Agent sub = Agents.react().modelClient(subClient).model("sub").build();
+
+        SubAgentDefinition def = SubAgentDefinition.builder()
+                .name("worker").description("d").toolName("delegate_worker").agent(sub).build();
+
+        ScriptedClient parentClient = new ScriptedClient();
+        parentClient.enqueue(toolCall("c1", "delegate_worker", "{}"));
+        parentClient.enqueue(text("done"));
+
+        Agent parent = Agents.react()
+                .modelClient(parentClient)
+                .model("parent")
+                .subAgent(def)
+                .handoffPolicy(HandoffPolicy.builder()
+                        .allowedTools(Collections.singleton("delegate_other"))  // 不含 delegate_worker
+                        .build())
+                .build();
+
+        // 默认 onDenied=FAIL：delegate_worker 不在 allowedTools 里，handoff 被拒绝并抛异常
+        try {
+            parent.run(AgentRequest.builder().input("go").build());
+            Assert.fail("expected HandoffPolicy denial");
+        } catch (RuntimeException e) {
+            Assert.assertTrue("应说明被 allowedTools 拒绝: " + e.getMessage(),
+                    e.getMessage().contains("allowedTools"));
+        }
+    }
+
+    @Test
+    public void fallbackToPrimaryKeepsParentAliveWhenSubAgentDenied() throws Exception {
+        ScriptedClient subClient = new ScriptedClient();
+        Agent sub = Agents.react().modelClient(subClient).model("sub").build();
+
+        SubAgentDefinition def = SubAgentDefinition.builder()
+                .name("worker").description("d").toolName("delegate_worker").agent(sub).build();
+
+        ScriptedClient parentClient = new ScriptedClient();
+        parentClient.enqueue(toolCall("c1", "delegate_worker", "{}"));
+        parentClient.enqueue(text("parent-handled"));
+
+        Agent parent = Agents.react()
+                .modelClient(parentClient)
+                .model("parent")
+                .subAgent(def)
+                .handoffPolicy(HandoffPolicy.builder()
+                        .allowedTools(Collections.singleton("delegate_other"))
+                        .onDenied(HandoffFailureAction.FALLBACK_TO_PRIMARY)  // 拒绝后回退给主 agent
+                        .build())
+                .build();
+
+        AgentResult result = parent.run(AgentRequest.builder().input("go").build());
+        Assert.assertEquals("回退后 parent 自己完成", "parent-handled", result.getOutputText());
+    }
+
+    // ---- §10 maxDepth 防止递归 handoff ----
+
+    @Test
+    public void maxDepthBlocksRecursiveHandoff() throws Exception {
+        ScriptedClient leafClient = new ScriptedClient();
+        leafClient.enqueue(text("leaf-out"));
+        Agent leaf = Agents.react().modelClient(leafClient).model("leaf").build();
+        SubAgentDefinition leafDef = SubAgentDefinition.builder()
+                .name("leaf").description("d").toolName("delegate_leaf").agent(leaf).build();
+
+        // middle 想再 delegate 给 leaf，但 maxDepth=1 会挡住
+        ScriptedClient middleClient = new ScriptedClient();
+        middleClient.enqueue(toolCall("c1", "delegate_leaf", "{}"));
+        middleClient.enqueue(text("middle-out"));
+        Agent middle = Agents.react()
+                .modelClient(middleClient).model("middle")
+                .subAgent(leafDef)
+                .handoffPolicy(HandoffPolicy.builder().maxDepth(1).build())
+                .build();
+        SubAgentDefinition middleDef = SubAgentDefinition.builder()
+                .name("middle").description("d").toolName("delegate_middle").agent(middle).build();
+
+        ScriptedClient parentClient = new ScriptedClient();
+        parentClient.enqueue(toolCall("c1", "delegate_middle", "{}"));
+        parentClient.enqueue(text("parent-out"));
+
+        Agent parent = Agents.react()
+                .modelClient(parentClient).model("parent")
+                .subAgent(middleDef)
+                .handoffPolicy(HandoffPolicy.builder().maxDepth(1).build())
+                .build();
+
+        // parent→middle（depth 1）允许；middle→leaf（depth 2）超过 maxDepth 被拒绝
+        try {
+            parent.run(AgentRequest.builder().input("go").build());
+            Assert.fail("expected maxDepth denial");
+        } catch (RuntimeException e) {
+            Assert.assertTrue("应说明超过 maxDepth: " + e.getMessage(),
+                    e.getMessage().contains("maxDepth"));
+        }
+    }
+
+    // ---- 极简 scripted client（不依赖测试包里的 helper）----
+
+    private static AgentModelResult text(String t) {
+        return AgentModelResult.builder()
+                .outputText(t)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<AgentToolCall>())
+                .build();
+    }
+
+    private static AgentModelResult toolCall(String callId, String name, String args) {
+        return AgentModelResult.builder()
+                .toolCalls(Arrays.asList(AgentToolCall.builder()
+                        .callId(callId).name(name).arguments(args).type("function_call").build()))
+                .memoryItems(new ArrayList<Object>())
+                .build();
+    }
+
+    static final class ScriptedClient implements AgentModelClient {
+        final Deque<AgentModelResult> queue = new ConcurrentLinkedDeque<AgentModelResult>();
+        final List<AgentPrompt> prompts = new ArrayList<AgentPrompt>();
+
+        void enqueue(AgentModelResult r) { queue.addLast(r); }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            prompts.add(prompt);
+            AgentModelResult r = queue.pollFirst();
+            if (r == null) throw new IllegalStateException("scripted client exhausted");
+            return r;
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/docs-site/docs/agent/agent-teams-api-reference.md
+++ b/docs-site/docs/agent/agent-teams-api-reference.md
@@ -25,28 +25,63 @@ tags: [reference]
 - `ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeam.java`
 - `ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeamAgentRuntime.java`
 
+:::tip 本页代码都是可跑通的
+下面的装配示例来自
+[`AgentTeamsDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentTeamsDocExamplesTest.java)，
+内联 scripted model client，零网络、CI 跑。
+:::
+
 `AgentTeamBuilder` 有两个终点：
 
 ### 1.1 `build()`
 
-返回 `AgentTeam`。
+返回 `AgentTeam`。适合你要直接用 team-specific API（读任务板、消息总线、持久化状态）：
 
-适合：
+```java
+AgentTeam team = Agents.team()
+        .planner((objective, members, options) -> AgentTeamPlan.builder()
+                .tasks(Collections.singletonList(
+                        AgentTeamTask.builder()
+                                .id("t1").memberId("worker").task("do work").build()))
+                .build())
+        .synthesizerAgent(synthAgent)
+        .member(AgentTeamMember.builder()
+                .id("worker").name("Worker").agent(workerAgent).build())
+        .build();                              // ← 返回 AgentTeam
 
-- 你明确要使用 team-specific API
-- 你要读取任务板、消息总线、持久化状态
-- 你要接 `planApproval`、`hooks`、`stateStore`
+AgentTeamResult result = team.run(AgentRequest.builder().input("go").build());
+result.getOutput();                            // 汇总输出
+team.snapshotState();                          // 任务板 / 消息总线 / 持久化状态
+team.listTaskStates();
+```
 
 ### 1.2 `buildAgent()`
 
-返回一个普通 `Agent`，但 runtime 被替换成 `AgentTeamAgentRuntime`。
+返回一个普通 `Agent`，但 runtime 被替换成 `AgentTeamAgentRuntime`。适合你想让 Team 接进统一 `Agent` 调用面（session、listener）：
+
+```java
+Agent teamAgent = Agents.teamAgent(Agents.team()
+        .planner((objective, members, options) -> AgentTeamPlan.builder()
+                .tasks(Arrays.asList(
+                        AgentTeamTask.builder()
+                                .id("collect").memberId("researcher")
+                                .task("Collect requirements").build()))
+                .build())
+        .synthesizerAgent(synthAgent)
+        .member(AgentTeamMember.builder()
+                .id("researcher").name("Researcher").agent(researcherAgent).build()));
+
+AgentResult result = teamAgent.run(AgentRequest.builder().input("prepare plan").build());
+result.getOutputText();                        // 走统一 Agent 接口
+result.getRawResponse();                       // 实际是 AgentTeamResult
+```
 
 这个包装做了两件事：
 
 - 用模板 `AgentTeamBuilder` 每次复制并构建新的 `AgentTeam`
 - 给包装后的 `Agent` 配一份新的 `InMemoryAgentMemory`
 
-因此 `buildAgent()` 的意义不是“把 Team 变成另一个对象模型”，而是：
+因此 `buildAgent()` 的意义不是"把 Team 变成另一个对象模型"，而是：
 
 - 让 Team orchestration 可以挂进统一 `Agent` 接口
 - 让 Team 能和普通 Agent 一样接入 session、listener、通用调用面

--- a/docs-site/docs/agent/codeact-runtime.md
+++ b/docs-site/docs/agent/codeact-runtime.md
@@ -101,6 +101,42 @@ CodeAct 的价值，就是把这种任务从“模型直接推理”转换成“
 
 如果后者更重要，就该进入 CodeAct。
 
+:::tip 本页代码都是可跑通的
+下面的装配示例来自
+[`CodeActDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j-agent/src/test/java/io/github/lnyocly/agent/CodeActDocExamplesTest.java)，
+用内联 scripted client 验证 code→execute→finalize 协议，零网络。
+Nashorn 执行器仅 JDK 8/11 可用，更高 JDK 自动跳过。
+:::
+
+最小装配——`reAct=false`，模型发代码、执行器跑、结果直接作为输出：
+
+```java
+Agent agent = Agents.codeAct()
+        .modelClient(modelClient)
+        .model("gpt-4o-mini")
+        .codeExecutor(new NashornCodeExecutor())           // JDK 8/11 用 Nashorn；其它用 GraalVM/Python
+        .systemPrompt("你是代码执行助手。输出 {type:code,language,code} 让执行器跑。")
+        .codeActOptions(CodeActOptions.builder().reAct(false).build())
+        .options(AgentOptions.builder().maxSteps(4).build())
+        .build();
+
+AgentResult result = agent.run(AgentRequest.builder()
+        .input("请用 JavaScript 计算 17*3+5").build());
+// reAct=false：模型发 {"type":"code","language":"javascript","code":"return 17*3+5"}
+// → 执行得 56 → 直接作为输出，无需模型二次收尾
+```
+
+`reAct=true` 则是两段：先发代码执行，再发 `{"type":"final","output":"..."}` 由模型收尾——适合执行结果需要模型再解释或继续推理的场景。
+
+模型输出的 JSON 协议就两种：
+
+| type | 含义 |
+| --- | --- |
+| `code` | 触发执行器；`language` + `code` 桥接给 `CodeExecutor` |
+| `final` | 收尾；`output` 作为最终答案 |
+
+执行结果以 `CODE_RESULT: ...` / `CODE_ERROR: ...` 回灌进 memory，形成自修复闭环。
+
 ## 4. `runInternal()` 的真实生命周期
 
 从源码看，`CodeActRuntime.runInternal(...)` 可以拆成 6 个阶段。

--- a/docs-site/docs/agent/subagent-handoff-policy.md
+++ b/docs-site/docs/agent/subagent-handoff-policy.md
@@ -75,6 +75,37 @@ SubAgent 最适合的场景是：
 
 SubAgent 真正进入系统，是在 `AgentBuilder.build()` 里。
 
+:::tip 本页代码都是可跑通的
+下面的装配与 HandoffPolicy 示例来自
+[`SubAgentHandoffDocExamplesTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j-agent/src/test/java/io/github/lnyocly/agent/SubAgentHandoffDocExamplesTest.java)，
+用内联 scripted model client，零网络、在普通 CI 里跑。
+:::
+
+最小装配——把一个 reviewer agent 作为 subagent 挂进 parent：
+
+```java
+Agent reviewer = Agents.react()
+        .modelClient(reviewerClient)
+        .model("reviewer-model")
+        .build();
+
+SubAgentDefinition reviewerSubAgent = SubAgentDefinition.builder()
+        .name("code-reviewer")
+        .description("Review code quality and risks")
+        .toolName("delegate_code_review")   // 暴露给 parent 模型的工具名
+        .agent(reviewer)
+        .build();
+
+Agent parent = Agents.react()
+        .modelClient(parentClient)
+        .model("manager-model")
+        .subAgent(reviewerSubAgent)         // 一行挂入
+        .build();
+
+AgentResult result = parent.run(AgentRequest.builder().input("analyze").build());
+// parent 模型调 delegate_code_review → reviewer 执行 → 输出回流给 parent
+```
+
 核心装配顺序是：
 
 1. 先拿到 `baseToolRegistry`
@@ -391,6 +422,23 @@ int attempts = Math.max(1, policy.getMaxRetries() + 1);
 - 但默认不开放递归 handoff
 - 也默认不自动吞错或自动降级
 
+收紧工具面 + 防递归的典型配置：
+
+```java
+Agent parent = Agents.react()
+        .modelClient(parentClient)
+        .model("manager")
+        .subAgent(workerDef)
+        .handoffPolicy(HandoffPolicy.builder()
+                .allowedTools(Collections.singleton("delegate_worker"))  // 只允许这一个 handoff 工具
+                .maxDepth(1)          // 只允许一层，挡住 subagent 再 handoff
+                .maxRetries(1)        // 失败重试一次
+                .build())
+        .build();
+```
+
+不在 `allowedTools` 里的 handoff 工具会被拒绝；默认 `onDenied=FAIL` 直接抛异常，异常信息会写明被哪个策略挡住（`tool is not in allowedTools` / `handoff depth N exceeds maxDepth`）。
+
 ## 11. `FALLBACK_TO_PRIMARY` 的语义必须说清
 
 当 `onDenied` 或 `onError` 设成 `FALLBACK_TO_PRIMARY` 时，执行器会：
@@ -413,6 +461,20 @@ delegate.execute(call)
 - 你的原始 `delegate` 必须真的能处理这个同名工具调用
 
 否则 fallback 配了也没有意义。
+
+```java
+// 被拒绝后不抛异常，而是把工具调用交回主执行链
+Agent parent = Agents.react()
+        .modelClient(parentClient)
+        .model("manager")
+        .subAgent(workerDef)
+        .handoffPolicy(HandoffPolicy.builder()
+                .allowedTools(Collections.singleton("delegate_other"))  // 不含 delegate_worker
+                .onDenied(HandoffFailureAction.FALLBACK_TO_PRIMARY)
+                .build())
+        .build();
+// parent 调 delegate_worker → 被 allowedTools 拒绝 → 回退给主 agent 自己处理
+```
 
 ## 12. 一个很容易忽略的设计细节
 


### PR DESCRIPTION
agent/* 三个最严重的「功能页但零代码」补示例，全部来自可执行测试（内联 scripted model client，零网络，CI 跑）。

## subagent-handoff-policy.md（0 → 5 块）
486 行讲 handoff 全链路治理但实质零代码。补：
- §3 最小装配：reviewer 作为 subagent 挂进 parent，验证 delegate 工具回流
- §10 HandoffPolicy 收紧：allowedTools + maxDepth + maxRetries，验证拒绝路径
- §11 FALLBACK_TO_PRIMARY：被拒后回退主 agent
来自 \`SubAgentHandoffDocExamplesTest\`（4 用例）。

## agent-teams-api-reference.md（0 → 2 块）
452 行讲 builder 字段→运行链但零代码。补：
- build()：返回 AgentTeam，验证 run() → AgentTeamResult + snapshotState()
- buildAgent()：包成普通 Agent，走统一 AgentResult
来自 \`AgentTeamsDocExamplesTest\`（2 用例）。

## codeact-runtime.md（0 → 1 块）
411 行讲协议但零装配示例。补：
- §3 最小装配：codeAct() + NashornCodeExecutor + reAct=false，验证 code→execute→direct-output
- JSON 协议表（type=code/final）+ reAct 语义差异
来自 \`CodeActDocExamplesTest\`（2 用例，assumeTrue Nashorn，JDK17/21 跳过）。

ai4j-agent 全量绿；docs 构建零警告。这是 agent 文档 P0-P2（审计里协作线 + codeact 线最严重的缺口）。