### PR TITLE
fix(subagent): FALLBACK_TO_PRIMARY 在真实 wiring 下不再泄漏路由错误

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/subagent/SubAgentToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/subagent/SubAgentToolExecutor.java
@@ -185,6 +185,36 @@ public class SubAgentToolExecutor implements ToolExecutor {
         return filtered == null ? call : filtered;
     }
 
+    /**
+     * Runs the FALLBACK_TO_PRIMARY path against the delegate executor.
+     *
+     * <p>Under real {@code AgentBuilder} wiring the delegate is a {@code ToolUtilExecutor}
+     * whose allowed-tool set was captured before subagents were merged, so it cannot serve
+     * the subagent tool name and raises an {@link IllegalArgumentException} ("Tool not
+     * allowed" / "No tool executor found"). That is not a real failure of the primary
+     * handler — it just means no primary handler exists for this tool. We translate it into
+     * a {@link PrimaryFallbackUnavailableException} so the caller surfaces a clean,
+     * intentional "handoff unavailable" message rather than the internal routing error.
+     */
+    private String executePrimaryFallback(AgentToolCall call) throws Exception {
+        try {
+            return delegate.execute(call);
+        } catch (IllegalArgumentException routingError) {
+            String message = "Handoff to subagent tool " + call.getName()
+                    + " was denied and no primary tool executor is available to serve it: "
+                    + safeMessage(routingError);
+            throw new PrimaryFallbackUnavailableException(message, routingError);
+        }
+    }
+
+    /** Signals that FALLBACK_TO_PRIMARY had no executor able to serve the subagent tool. */
+    static final class PrimaryFallbackUnavailableException extends Exception {
+        private static final long serialVersionUID = 1L;
+        PrimaryFallbackUnavailableException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
     private String executeOnce(AgentToolCall call, int depth, String toolName) throws Exception {
         long timeoutMillis = policy.getTimeoutMillis();
         if (timeoutMillis <= 0L) {
@@ -217,7 +247,7 @@ public class SubAgentToolExecutor implements ToolExecutor {
                             String deniedReason) throws Exception {
         if (policy.getOnDenied() == HandoffFailureAction.FALLBACK_TO_PRIMARY && delegate != null) {
             try {
-                String output = delegate.execute(call);
+                String output = executePrimaryFallback(call);
                 emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
                         handoffId,
                         call,
@@ -232,6 +262,24 @@ public class SubAgentToolExecutor implements ToolExecutor {
                         System.currentTimeMillis() - startedAt
                 ));
                 return output;
+            } catch (PrimaryFallbackUnavailableException ex) {
+                // The primary executor cannot serve the subagent tool name (the usual case
+                // under real AgentBuilder wiring). Surface an intentional, clear unavailable
+                // message instead of leaking the internal routing error to the model.
+                emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
+                        handoffId,
+                        call,
+                        definition,
+                        toolName,
+                        depth,
+                        "denied",
+                        ex.getMessage(),
+                        ex.getMessage(),
+                        deniedReason,
+                        Integer.valueOf(0),
+                        System.currentTimeMillis() - startedAt
+                ));
+                return ex.getMessage();
             } catch (Exception ex) {
                 emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
                         handoffId,
@@ -275,7 +323,7 @@ public class SubAgentToolExecutor implements ToolExecutor {
                            int attempts) throws Exception {
         if (policy.getOnError() == HandoffFailureAction.FALLBACK_TO_PRIMARY && delegate != null) {
             try {
-                String output = delegate.execute(call);
+                String output = executePrimaryFallback(call);
                 emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
                         handoffId,
                         call,
@@ -290,6 +338,21 @@ public class SubAgentToolExecutor implements ToolExecutor {
                         System.currentTimeMillis() - startedAt
                 ));
                 return output;
+            } catch (PrimaryFallbackUnavailableException ex) {
+                emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
+                        handoffId,
+                        call,
+                        definition,
+                        toolName,
+                        depth,
+                        "failed",
+                        ex.getMessage(),
+                        null,
+                        safeMessage(error),
+                        Integer.valueOf(attempts),
+                        System.currentTimeMillis() - startedAt
+                ));
+                return ex.getMessage();
             } catch (Exception ex) {
                 emitHandoffEvent(AgentEventType.HANDOFF_END, buildHandoffPayload(
                         handoffId,

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/subagent/HandoffFallbackRealWiringTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/subagent/HandoffFallbackRealWiringTest.java
@@ -1,0 +1,103 @@
+package io.github.lnyocly.ai4j.agent.subagent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.subagent.HandoffFailureAction;
+import io.github.lnyocly.ai4j.agent.subagent.HandoffPolicy;
+import io.github.lnyocly.ai4j.agent.subagent.SubAgentDefinition;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+
+/**
+ * FALLBACK_TO_PRIMARY under real AgentBuilder wiring.
+ *
+ * <p>The delegate passed to SubAgentToolExecutor is a ToolUtilExecutor whose
+ * allowedToolNames was captured before subagents were merged, so it cannot serve
+ * the subagent tool name. Before the fix this surfaced a misleading
+ * "Tool not allowed: delegate_xxx" error to the model. After the fix it surfaces
+ * a clean, intentional "handoff denied / no primary handler" message.
+ */
+public class HandoffFallbackRealWiringTest {
+
+    @Test
+    public void fallbackToPrimaryYieldsCleanUnavailableNotRoutingError() throws Exception {
+        ScriptedClient subClient = new ScriptedClient();
+        Agent sub = Agents.react().modelClient(subClient).model("sub").build();
+        SubAgentDefinition def = SubAgentDefinition.builder()
+                .name("worker").description("d").toolName("delegate_worker").agent(sub).build();
+
+        // A real base tool so the default ToolUtilExecutor is non-null (otherwise the
+        // delegate is null and fallback degrades cleanly, masking the real path).
+        io.github.lnyocly.ai4j.platform.openai.tool.Tool baseTool =
+                new io.github.lnyocly.ai4j.platform.openai.tool.Tool(
+                        "function",
+                        new io.github.lnyocly.ai4j.platform.openai.tool.Tool.Function(
+                                "lookup", "base tool", null));
+
+        ScriptedClient parentClient = new ScriptedClient();
+        parentClient.enqueue(toolCall("c1", "delegate_worker", "{}"));
+        parentClient.enqueue(text("parent-handled"));
+
+        Agent parent = Agents.react()
+                .modelClient(parentClient)
+                .model("parent")
+                .toolRegistry(new io.github.lnyocly.ai4j.agent.tool.StaticToolRegistry(
+                        Collections.singletonList((Object) baseTool)))
+                .subAgent(def)
+                .handoffPolicy(HandoffPolicy.builder()
+                        .allowedTools(Collections.singleton("delegate_other"))
+                        .onDenied(HandoffFailureAction.FALLBACK_TO_PRIMARY)
+                        .build())
+                .build();
+
+        AgentResult result = parent.run(AgentRequest.builder().input("go").build());
+        String toolOutput = result.getToolResults().get(0).getOutput();
+
+        // The fix: a denied handoff with no usable primary handler must report an intentional
+        // "handoff unavailable" message (not surface as a TOOL_ERROR wrapping the internal
+        // "Tool not allowed" routing failure).
+        Assert.assertFalse("fallback must not surface as a TOOL_ERROR: " + toolOutput,
+                toolOutput.startsWith("TOOL_ERROR:"));
+        Assert.assertTrue("fallback should explain the handoff is unavailable: " + toolOutput,
+                toolOutput.contains("was denied") && toolOutput.contains("no primary tool executor"));
+    }
+
+    private static AgentModelResult text(String t) {
+        return AgentModelResult.builder().outputText(t)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<AgentToolCall>()).build();
+    }
+
+    private static AgentModelResult toolCall(String id, String name, String args) {
+        return AgentModelResult.builder()
+                .toolCalls(Arrays.asList(AgentToolCall.builder()
+                        .callId(id).name(name).arguments(args).type("function_call").build()))
+                .memoryItems(new ArrayList<Object>()).build();
+    }
+
+    static class ScriptedClient implements AgentModelClient {
+        final Deque<AgentModelResult> q = new ArrayDeque<>();
+        void enqueue(AgentModelResult r) { q.addLast(r); }
+        @Override public AgentModelResult create(AgentPrompt p) {
+            AgentModelResult r = q.pollFirst();
+            if (r == null) throw new IllegalStateException("exhausted");
+            return r;
+        }
+        @Override public AgentModelResult createStream(AgentPrompt p, AgentModelStreamListener l) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Closes #238

## 问题
`HandoffFailureAction.FALLBACK_TO_PRIMARY` 在 `AgentBuilder` 真实 wiring 下，delegate（`ToolUtilExecutor`）不认识 subagent 工具名 → 抛 `Tool not allowed` → 被转成误导性 `TOOL_ERROR` 返给模型。

## 根因
delegate 的 `allowedToolNames` 在 subagent 合并进 registry **之前**捕获（AgentBuilder:547），不含 subagent 名。既有测试用 lambda delegate（`call -> "fallback-ok"`）绕过了真实执行器，所以漏了。

## 修复
新增 `executePrimaryFallback(call)`：捕获 delegate 抛的 `IllegalArgumentException`，转成 `PrimaryFallbackUnavailableException`。`onDenied`/`onError` 捕获后返回清晰的"handoff unavailable"消息，让父模型据此决策。

- delegate 真能服务该工具的路径（自定义 toolExecutor）行为不变
- 默认 ToolUtilExecutor 路径不再泄漏 `Tool not allowed`

## 验证
- 新增 `HandoffFallbackRealWiringTest`：通过 `AgentBuilder` 真实构建复现，断言不再出 `TOOL_ERROR` 且消息说明 unavailable（修复前 red，修复后 green）
- 既有 12 个 handoff/subagent 测试（含 4 个 lambda-based fallback）全绿
- ai4j-agent 全量绿

## 关于并发审计
issue 调查时跑了一个多维度审计 workflow，报了多条"并发 bug"（maxDepth 并行绕过、task board 竞态、message bus 竞态等）。逐条写复现测试后确认**这些是误判**——board/bus/stateStore 全 synchronized，depth 在子 agent 运行线程上正确设置。本 PR 只修经实测确认的 FALLBACK_TO_PRIMARY 一条。