### PR TITLE
docs(agent): 通讯与并行模型——subagent RPC + teams 共享状态协作

### DIFF
--- a/docs-site/docs/agent/agent-teams.md
+++ b/docs-site/docs/agent/agent-teams.md
@@ -19,6 +19,15 @@ tags: [concept]
 
 如果只看表面 API，`AgentTeam.run("...")` 很像“高级版多 Agent demo”；但从源码看，它更像一个轻量 orchestration runtime。
 
+:::tip 成员间通讯模型
+与 [SubAgent 的工具调用 RPC](/docs/agent/subagent-handoff-policy#0-通讯与并行模型先建立正确心智) 不同，Teams 成员之间**不是工具调用关系**，而是通过两个共享组件协作：
+
+- **任务板（TaskBoard）**：planner 拆任务 → 成员 `claim_task` 抢占 → 执行 → 编排器自动 `markCompleted`。是分工的源头。
+- **消息总线（MessageBus）**：成员用 `team_send_message`（点对点）/ `team_broadcast` 发消息；**下个成员执行前**，编排器把 `historyFor(member)` 注入它的 prompt（拉模型，详见 §7.2）。
+
+成员间是**协作式**（共享状态），不是层级式（父调子）。同一轮多个 ready task 可并行（§5），board/bus 全 `synchronized` 保证线程安全。
+:::
+
 ## 1. 先抓住 3 个关键设计决策
 
 理解 Agent Teams，最重要的不是先背类名，而是先抓住 3 个设计决策。

--- a/docs-site/docs/agent/subagent-handoff-policy.md
+++ b/docs-site/docs/agent/subagent-handoff-policy.md
@@ -16,6 +16,37 @@ SubAgent 的核心，不是“主 Agent 调另一个 Agent”，而是把另一�
 
 因此 SubAgent 的本质不是“多 Agent 聊天”，而是“带 handoff policy 的工具委派”。
 
+## 0. 通讯与并行模型（先建立正确心智）
+
+理解 SubAgent 最关键的一点：**通讯就是工具调用，是同步请求-响应，不是消息流。**
+
+```text
+父 agent 模型 ──tool_call(delegate_xxx, {task})──► SubAgentToolExecutor
+                                                       │ 起子 agent，跑完整个 ReAct loop
+                                                       ▼
+父 agent  ◄──── tool_result（子 agent 的 outputText）────┘
+```
+
+子 agent 拿到 task 输入后**独立跑完**，执行期间无法和父 agent 交互。父 agent 只在子 agent 返回后看到 `outputText`——**看不到子的 reasoning 或中间 tool 调用**（这与 Claude Code subagent 一致，是刻意的 context 经济设计）。
+
+### 并行多个 subagent：靠父模型一轮发多个 tool_call
+
+SDK 不主动 fan-out。"父 agent 同时跑多个子 agent"的真相是：
+
+1. 父模型在**一轮**里发出多个 tool_call（如同时调 `delegate_research` 和 `delegate_write`）
+2. 若 `parallelToolCalls=true`，runtime 用线程池**并行执行这一轮的所有 tool_call**
+3. 但这是一道 **fork-join barrier**：父必须等本轮全部 tool_call 结束才进下一轮
+
+所以并行的触发权在**模型的行为**（一轮发几个 call）+ `parallelToolCalls` 开关，不是 SDK 帮你调度。
+
+:::note 与 Claude Code 的差距
+Claude Code 的 background agent 是 **async**——父派子后可以继续干别的，子完成后异步回流。AI4J 的 SubAgent 是**同步阻塞**：父在 fork-join barrier 上等全部子返回。对短任务（读文件、grep）无感；对长耗时研究型子 agent，父会被阻塞。这是 roadmap 上待补的能力。
+:::
+
+### 嵌套 handoff 与 depth
+
+子 agent 也能挂自己的 subagent（嵌套 handoff）。`HandoffContext` 用 ThreadLocal 在**子 agent 运行的线程上**记录递归深度——不是靠继承父线程，而是在子 agent 启动时（`HandoffContext.runWithDepth`）在该线程 set。所以**并行嵌套 handoff 的 depth 计数正确**，`maxDepth` 在并行下不会失效。
+
 ## 1. 先抓住 3 个关键设计决策
 
 ### 1.1 SubAgent 先是 tool surface，后才是协作能力
@@ -461,6 +492,11 @@ delegate.execute(call)
 - 你的原始 `delegate` 必须真的能处理这个同名工具调用
 
 否则 fallback 配了也没有意义。
+
+:::note 默认 wiring 下主执行器通常不认识 subagent 工具名
+在默认 `AgentBuilder` wiring 下，主执行器（`ToolUtilExecutor`）的白名单在 subagent 合并进 registry 之前就捕获了，不含 subagent 工具名。所以 `FALLBACK_TO_PRIMARY` 在默认配置下，主执行器**无法**服务该 call——此时它返回一条清晰的「handoff unavailable」消息（而非把 call 当普通工具硬转）。
+要让 fallback 真正执行别的东西，需要自定义 `toolExecutor` 来服务该工具名。详见 [issue #238](https://github.com/LnYo-Cly/ai4j/issues/238)。
+:::
 
 ```java
 // 被拒绝后不抛异常，而是把工具调用交回主执行链


### PR DESCRIPTION
回应「agent 交互通讯原理是否讲清」。两个页面的通讯模型原本散在各节，缺顶层正确心智。

## subagent-handoff-policy.md（新增 §0）
- 通讯 = 工具调用，同步请求-响应，非消息流；父只看子 outputText 不看中间步骤（对齐 Claude Code）
- 并行多个 subagent = 父模型一轮多 tool_call + parallelToolCalls，runtime 并行执行本轮，但是 **fork-join barrier**
- 诚实标注与 Claude Code 的差距：同步阻塞，非 async background（roadmap）
- 嵌套 handoff 的 depth 在子运行线程上正确 set（并行下 maxDepth 不失效）
- §11 补 FALLBACK_TO_PRIMARY 在默认 wiring 下的真实行为（issue #238，已修复）

## agent-teams.md（顶部 callout）
与 subagent 对照：成员间是**协作式**（共享任务板 + 消息总线），非工具调用。任务板 = 分工源头（claim / 编排器自动 complete）；消息总线 = 拉模型（执行前注入 historyFor）。

## 依据
基于实测验证的通讯原理 + 多 agent 审计结论。审计 workflow 报的并发 bug 多数经实测为误判（board/bus/stateStore 全 synchronized），已在 issue #239 PR 描述里说明。本 PR 只描述经实测确认的机制。

docs 构建零警告。基于 main（含 #239 修复），通讯模型描述与修复后行为一致。