### PR TITLE
feat(team): 成员 reactive receive（team_read_messages，对齐 Claude Code）

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeam.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeam.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -42,6 +43,13 @@ public class AgentTeam implements AgentTeamControl {
 
     private final Object memberLock = new Object();
     private final Object runtimeLock = new Object();
+
+    /**
+     * Per-member set of message ids already returned by {@code team_read_messages}, powering
+     * reactive receive: each call returns only messages addressed to the member that it has not
+     * seen yet.
+     */
+    private final Map<String, Set<String>> memberDeliveredIds = new java.util.concurrent.ConcurrentHashMap<String, Set<String>>();
 
     private volatile AgentTeamTaskBoard activeBoard;
     private volatile List<AgentTeamTaskState> lastTaskStates = Collections.emptyList();
@@ -250,6 +258,43 @@ public class AgentTeam implements AgentTeamControl {
             validateKnownMemberId(normalizedMemberId, true, "memberId");
         }
         return messageBus.historyFor(normalizedMemberId, limit);
+    }
+
+    /**
+     * Reactive receive: returns messages addressed to {@code memberId} that the member has not
+     * yet read, and marks them read. A subsequent call reports only messages that arrived in
+     * between.
+     *
+     * <p>Aligns AI4J teams with the "teammates can challenge each other mid-task" capability
+     * Claude Code's per-agent mailbox provides, without copying its file-based IPC — the shared
+     * message log stays the source of truth, and a per-member delivered-id set gives each member
+     * its own "unread" view. Tracked by message id rather than timestamp so two messages sent in
+     * the same millisecond are still each delivered exactly once. Safe under
+     * {@code parallelDispatch}: the delivered set is per-member and each member reads its own
+     * mailbox.
+     */
+    public List<AgentTeamMessage> readUnreadMessages(String memberId) {
+        if (!options.isEnableMessageBus()) {
+            return Collections.emptyList();
+        }
+        String normalizedMemberId = normalize(memberId);
+        if (normalizedMemberId == null || normalizedMemberId.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> delivered = memberDeliveredIds.computeIfAbsent(normalizedMemberId,
+                k -> java.util.Collections.synchronizedSet(new java.util.HashSet<String>()));
+        List<AgentTeamMessage> all = messageBus.historyFor(normalizedMemberId, Integer.MAX_VALUE);
+        List<AgentTeamMessage> unread = new ArrayList<AgentTeamMessage>();
+        for (AgentTeamMessage message : all) {
+            if (message == null) {
+                continue;
+            }
+            String id = message.getId();
+            if (id == null || delivered.add(id)) {
+                unread.add(message);
+            }
+        }
+        return unread;
     }
 
     @Override

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeamControl.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/AgentTeamControl.java
@@ -14,6 +14,13 @@ public interface AgentTeamControl {
 
     List<AgentTeamMessage> listMessagesFor(String memberId, int limit);
 
+    /**
+     * Returns messages addressed to {@code memberId} that arrived since its last read, and
+     * advances that member's read cursor. This is the reactive-receive path behind the
+     * {@code team_read_messages} tool.
+     */
+    List<AgentTeamMessage> readUnreadMessages(String memberId);
+
     void publishMessage(AgentTeamMessage message);
 
     void sendMessage(String fromMemberId, String toMemberId, String type, String taskId, String content);

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/tool/AgentTeamToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/tool/AgentTeamToolExecutor.java
@@ -3,6 +3,7 @@ package io.github.lnyocly.ai4j.agent.team.tool;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.agent.team.AgentTeamControl;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamMessage;
 import io.github.lnyocly.ai4j.agent.team.AgentTeamTaskState;
 import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
 import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
@@ -52,6 +53,9 @@ public class AgentTeamToolExecutor implements ToolExecutor {
         }
         if (AgentTeamToolRegistry.TOOL_BROADCAST.equals(toolName)) {
             return handleBroadcast(args);
+        }
+        if (AgentTeamToolRegistry.TOOL_READ_MESSAGES.equals(toolName)) {
+            return handleReadMessages();
         }
         if (AgentTeamToolRegistry.TOOL_LIST_TASKS.equals(toolName)) {
             return handleListTasks();
@@ -116,6 +120,30 @@ public class AgentTeamToolExecutor implements ToolExecutor {
         List<AgentTeamTaskState> tasks = control.listTaskStates();
         JSONObject result = baseResult(AgentTeamToolRegistry.TOOL_LIST_TASKS, true);
         result.put("tasks", tasks == null ? new ArrayList<AgentTeamTaskState>() : tasks);
+        return result.toJSONString();
+    }
+
+    private String handleReadMessages() {
+        List<AgentTeamMessage> unread = control.readUnreadMessages(memberId);
+        JSONObject result = baseResult(AgentTeamToolRegistry.TOOL_READ_MESSAGES, true);
+        int count = unread == null ? 0 : unread.size();
+        result.put("count", count);
+        result.put("hasNewMessages", count > 0);
+        if (count > 0) {
+            List<JSONObject> summaries = new ArrayList<JSONObject>();
+            for (AgentTeamMessage message : unread) {
+                JSONObject summary = new JSONObject();
+                summary.put("from", message.getFromMemberId());
+                summary.put("to", message.getToMemberId());
+                summary.put("type", message.getType());
+                if (message.getTaskId() != null) {
+                    summary.put("taskId", message.getTaskId());
+                }
+                summary.put("content", message.getContent());
+                summaries.add(summary);
+            }
+            result.put("messages", summaries);
+        }
         return result.toJSONString();
     }
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/tool/AgentTeamToolRegistry.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/team/tool/AgentTeamToolRegistry.java
@@ -16,6 +16,7 @@ public class AgentTeamToolRegistry implements AgentToolRegistry {
 
     public static final String TOOL_SEND_MESSAGE = "team_send_message";
     public static final String TOOL_BROADCAST = "team_broadcast";
+    public static final String TOOL_READ_MESSAGES = "team_read_messages";
     public static final String TOOL_LIST_TASKS = "team_list_tasks";
     public static final String TOOL_CLAIM_TASK = "team_claim_task";
     public static final String TOOL_RELEASE_TASK = "team_release_task";
@@ -25,6 +26,7 @@ public class AgentTeamToolRegistry implements AgentToolRegistry {
     private static final Set<String> TOOL_NAMES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             TOOL_SEND_MESSAGE,
             TOOL_BROADCAST,
+            TOOL_READ_MESSAGES,
             TOOL_LIST_TASKS,
             TOOL_CLAIM_TASK,
             TOOL_RELEASE_TASK,
@@ -51,6 +53,7 @@ public class AgentTeamToolRegistry implements AgentToolRegistry {
         List<Object> list = new ArrayList<>();
         list.add(createSendMessageTool());
         list.add(createBroadcastTool());
+        list.add(createReadMessagesTool());
         list.add(createListTasksTool());
         list.add(createClaimTaskTool());
         list.add(createReleaseTaskTool());
@@ -80,6 +83,16 @@ public class AgentTeamToolRegistry implements AgentToolRegistry {
                 "Broadcast a message to the whole team.",
                 props,
                 Arrays.asList("content"));
+    }
+
+    private Tool createReadMessagesTool() {
+        Map<String, Tool.Function.Property> props = new LinkedHashMap<>();
+        return createTool(TOOL_READ_MESSAGES,
+                "Check your mailbox for messages teammates sent you since your last read. "
+                        + "Returns only new direct/broadcast messages addressed to you. "
+                        + "Call this during long tasks to stay responsive to teammates' questions or findings.",
+                props,
+                Collections.<String>emptyList());
     }
 
     private Tool createListTasksTool() {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/TeamReactiveMessagingTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/TeamReactiveMessagingTest.java
@@ -1,0 +1,175 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.Agent;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.Agents;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.team.AgentTeam;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamMember;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamMessage;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamOptions;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamResult;
+import io.github.lnyocly.ai4j.agent.team.AgentTeamTask;
+import io.github.lnyocly.ai4j.agent.team.tool.AgentTeamToolExecutor;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolResult;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Verifies reactive team messaging: a member can call {@code team_read_messages} to pull
+ * messages a teammate sent it, and the per-member cursor means a second read does not
+ * re-report the same message.
+ */
+public class TeamReactiveMessagingTest {
+
+    @Test
+    public void memberReceivesPeerMessageViaReadToolAndCursorAdvances() throws Exception {
+        // Two members; researcher's first task is to send a message to writer.
+        ScriptedClient researcherClient = new ScriptedClient();
+        researcherClient.enqueue(toolCall("c1", "team_send_message",
+                "{\"toMemberId\":\"writer\",\"content\":\"hey, is the API ready?\"}"));
+        researcherClient.enqueue(text("sent"));
+
+        ScriptedClient writerClient = new ScriptedClient();
+        // writer checks its mailbox, sees the message, replies, then finishes
+        writerClient.enqueue(toolCall("c1", "team_read_messages", "{}"));
+        writerClient.enqueue(toolCall("c2", "team_send_message",
+                "{\"toMemberId\":\"researcher\",\"content\":\"yes, shipped\"}"));
+        writerClient.enqueue(text("writer-done"));
+
+        AgentTeam team = Agents.team()
+                .planner((objective, members, options) -> io.github.lnyocly.ai4j.agent.team.AgentTeamPlan.builder()
+                        .tasks(Arrays.asList(
+                                AgentTeamTask.builder().id("t1").memberId("researcher")
+                                        .task("ask writer").build(),
+                                AgentTeamTask.builder().id("t2").memberId("writer")
+                                        .task("answer researcher").dependsOn(Arrays.asList("t1")).build()
+                        ))
+                        .build())
+                .synthesizerAgent(newAgent("synth", new ScriptedClient().enqueue(text("synth"))))
+                .member(AgentTeamMember.builder().id("researcher").name("Researcher")
+                        .agent(newAgent("researcher", researcherClient)).build())
+                .member(AgentTeamMember.builder().id("writer").name("Writer")
+                        .agent(newAgent("writer", writerClient)).build())
+                .options(AgentTeamOptions.builder()
+                        .enableMessageBus(true)
+                        .enableMemberTeamTools(true)   // required so team_* tools are exposed
+                        .build())
+                .build();
+
+        AgentTeamResult result = team.run(AgentRequest.builder().input("coordinate").build());
+        Assert.assertNotNull(result);
+
+        // The writer's first tool call was team_read_messages — its result should contain the
+        // message the researcher sent. Extract it from the writer agent's tool results via the
+        // team result's member outputs.
+        List<io.github.lnyocly.ai4j.agent.team.AgentTeamMemberResult> memberResults = result.getMemberResults();
+        io.github.lnyocly.ai4j.agent.team.AgentTeamMemberResult writerResult = null;
+        for (io.github.lnyocly.ai4j.agent.team.AgentTeamMemberResult mr : memberResults) {
+            if ("writer".equals(mr.getMemberId())) {
+                writerResult = mr;
+                break;
+            }
+        }
+        Assert.assertNotNull("writer should have a result", writerResult);
+
+        // The raw AgentResult carries the tool calls/results the writer made.
+        AgentResult writerRaw = (AgentResult) writerResult.getRawResult();
+        Assert.assertNotNull("writer raw result should be present", writerRaw);
+
+        boolean sawReadWithMessage = false;
+        boolean sawSecondReadEmpty = false;
+        for (AgentToolResult tr : writerRaw.getToolResults()) {
+            if ("team_read_messages".equals(tr.getName()) && tr.getOutput().contains("hey, is the API ready?")) {
+                sawReadWithMessage = true;
+            }
+        }
+        Assert.assertTrue("writer's team_read_messages should have surfaced the researcher's message. "
+                        + "Outputs: " + toolOutputs(writerRaw),
+                sawReadWithMessage);
+    }
+
+    /**
+     * Cursor advances: a second read with no intervening message reports nothing new.
+     * Tested at the executor/control level without a full team run.
+     */
+    @Test
+    public void readCursorAdvancesSoRereadReportsNothingNew() {
+        // Use a real AgentTeam built minimally so readUnreadMessages + cursor logic is exercised.
+        AgentTeam team = Agents.team()
+                .planner((objective, members, options) -> io.github.lnyocly.ai4j.agent.team.AgentTeamPlan.builder()
+                        .tasks(Collections.<AgentTeamTask>emptyList()).build())
+                .synthesizerAgent(newAgent("synth", new ScriptedClient().enqueue(text("synth"))))
+                .member(AgentTeamMember.builder().id("alice").name("Alice")
+                        .agent(newAgent("alice", new ScriptedClient().enqueue(text("a")))).build())
+                .member(AgentTeamMember.builder().id("bob").name("Bob")
+                        .agent(newAgent("bob", new ScriptedClient().enqueue(text("b")))).build())
+                .options(AgentTeamOptions.builder().enableMessageBus(true).build())
+                .build();
+
+        // alice sends bob a direct message
+        team.sendMessage("alice", "bob", "peer.message", null, "first");
+        // bob reads — should see "first"
+        List<AgentTeamMessage> first = team.readUnreadMessages("bob");
+        Assert.assertEquals("first read should surface the message", 1, first.size());
+        Assert.assertTrue(first.get(0).getContent().contains("first"));
+        // bob reads again with no new message — should be empty (cursor advanced)
+        List<AgentTeamMessage> second = team.readUnreadMessages("bob");
+        Assert.assertTrue("second read should report nothing new: " + second.size(), second.isEmpty());
+        // alice sends another; bob reads — sees only the new one
+        team.sendMessage("alice", "bob", "peer.message", null, "second");
+        List<AgentTeamMessage> third = team.readUnreadMessages("bob");
+        Assert.assertEquals("third read should surface only the new message", 1, third.size());
+        Assert.assertTrue(third.get(0).getContent().contains("second"));
+    }
+
+    private static List<String> toolOutputs(AgentResult r) {
+        List<String> out = new ArrayList<String>();
+        if (r == null || r.getToolResults() == null) return out;
+        for (AgentToolResult tr : r.getToolResults()) out.add(tr.getName() + "=" + tr.getOutput());
+        return out;
+    }
+
+    private static Agent newAgent(String name, ScriptedClient client) {
+        return Agents.react().modelClient(client).model(name).build();
+    }
+
+    private static AgentModelResult text(String t) {
+        return AgentModelResult.builder().outputText(t)
+                .memoryItems(new ArrayList<Object>())
+                .toolCalls(new ArrayList<AgentToolCall>()).build();
+    }
+
+    private static AgentModelResult toolCall(String id, String name, String args) {
+        return AgentModelResult.builder()
+                .toolCalls(Arrays.asList(AgentToolCall.builder()
+                        .callId(id).name(name).arguments(args).type("function_call").build()))
+                .memoryItems(new ArrayList<Object>()).build();
+    }
+
+    static class ScriptedClient implements AgentModelClient {
+        final Deque<AgentModelResult> q = new ArrayDeque<>();
+        ScriptedClient enqueue(AgentModelResult r) { q.addLast(r); return this; }
+        @Override public AgentModelResult create(AgentPrompt p) {
+            AgentModelResult r = q.pollFirst();
+            if (r == null) return text("(done)");
+            return r;
+        }
+        @Override public AgentModelResult createStream(AgentPrompt p, AgentModelStreamListener l) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/docs-site/docs/agent/agent-teams.md
+++ b/docs-site/docs/agent/agent-teams.md
@@ -23,7 +23,7 @@ tags: [concept]
 与 [SubAgent 的工具调用 RPC](/docs/agent/subagent-handoff-policy#0-通讯与并行模型先建立正确心智) 不同，Teams 成员之间**不是工具调用关系**，而是通过两个共享组件协作：
 
 - **任务板（TaskBoard）**：planner 拆任务 → 成员 `claim_task` 抢占 → 执行 → 编排器自动 `markCompleted`。是分工的源头。
-- **消息总线（MessageBus）**：成员用 `team_send_message`（点对点）/ `team_broadcast` 发消息；**下个成员执行前**，编排器把 `historyFor(member)` 注入它的 prompt（拉模型，详见 §7.2）。
+- **消息总线（MessageBus）**：成员用 `team_send_message`（点对点）/ `team_broadcast` 发消息；接收有两条路径——编排器在下个成员执行前注入历史（拉模型，§7.2），成员也可在执行中调 `team_read_messages` 主动拉取新消息（reactive，§7.3）。
 
 成员间是**协作式**（共享状态），不是层级式（父调子）。同一轮多个 ready task 可并行（§5），board/bus 全 `synchronized` 保证线程安全。
 :::
@@ -386,17 +386,24 @@ Agent Teams 的并发不是 actor model，也不是复杂异步框架，而是�
 
 ### 6.1 `AgentTeamToolRegistry` 暴露了哪些能力
 
-默认工具有 7 个：
+默认工具有 8 个：
 
 - `team_send_message`
 - `team_broadcast`
+- `team_read_messages`
 - `team_list_tasks`
 - `team_claim_task`
 - `team_release_task`
 - `team_reassign_task`
 - `team_heartbeat_task`
 
-其中前两个是消息面，后五个是任务控制面。
+其中前三个是消息面（发、广播、收），后五个是任务控制面。
+
+:::tip `team_read_messages`：成员的 reactive receive
+成员执行中可调 `team_read_messages`（无参）主动检查自己的 mailbox，拉取**自上次读取以来**同伴发给自己的新消息（点对点 + 广播）。每次只返回未读的，已读不会重复报。这让"成员 A 发批判给 B、B 在执行中收到并回击"这类**辩论式协作**成为可能——对齐 Claude Code agent teams 的 teammate 互发消息能力。
+
+注意 AI4J 用**共享消息日志 + per-member 已读集合**实现这个能力，而不是 Claude Code 那种每 agent 一个 mailbox JSON 文件（文件式 IPC 是为多进程设计的，单 JVM 内的 SDK 不需要）。
+:::
 
 ### 6.2 `AgentTeamToolExecutor` 的拦截语义
 
@@ -468,6 +475,15 @@ Agent Teams 的并发不是 actor model，也不是复杂异步框架，而是�
 
 - Team 的连续性主要来自外部化的消息与任务状态
 - 不是来自成员 session 的长期复用
+
+### 7.3 两条接收路径：派发注入 + 主动读取
+
+成员看到同伴消息有两条路径，互补：
+
+- **派发注入（拉模型，§7.2）**：编排器在成员**开始执行前**把 `historyFor(member)` 拼进 prompt。这给成员起步时的上下文。
+- **主动读取（reactive，§6.1）**：成员在**执行中**调 `team_read_messages` 拉取新到达的消息。这覆盖"长任务中段收到同伴的新发现/提问"的场景。
+
+两条路径不冲突：派发注入的是"开始前"的历史，`team_read_messages` 返回的是"自上次读以来"的新消息（按消息 id 跟踪，已读不重复）。需要辩论/互相挑战的协作（Claude Code agent teams 的主打场景）靠第二条路径实现。
 
 ## 8. 持久化与恢复的边界，要讲清楚
 


### PR DESCRIPTION
Closes #241

对齐 Claude Code agent teams 的「teammates 互发消息、互相挑战」能力。

## 不照搬文件 mailbox
Claude Code 每 agent 一个 JSON mailbox 文件 + 推送投递，是因为多进程必须用文件做 IPC。AI4J 单 JVM 不缺共享内存——对齐**能力**（reactive receive），不对齐**机制**（文件 IPC）。保留共享消息日志作 source of truth。

## 改动
- 新增 `team_read_messages` 工具（第 8 个 team_* 工具，无参）：成员执行中主动拉取发给自己的新消息（点对点 + 广播）
- per-member 已投递消息 id 集合跟踪未读；按 id 而非时间戳（消除同毫秒消息丢失的粒度 bug）
- additive，既有 7 个工具行为不变；parallelDispatch 下安全

## 接收两条路径互补
1. 派发注入（拉模型，既有）：执行前编排器注入 historyFor
2. 主动读取（reactive，新增）：执行中 team_read_messages 拉新消息

## 验证
- `TeamReactiveMessagingTest`（2 用例）：端到端（researcher 发→writer 收到回复）+ 单元（cursor 推进、重读不报已读、新消息只报新的）
- ai4j-agent 全量绿
- docs(agent-teams.md) 同步：工具列表、§7.3 两条接收路径、Claude Code 对齐 callout；docs 构建零警告