### PR TITLE
docs(image): live 验证图片生成 + base64 跨网关建议

### DIFF
--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ImageGenerationLiveTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ImageGenerationLiveTest.java
@@ -1,0 +1,88 @@
+package io.github.lnyocly.ai4j.docs;
+
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageData;
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGenerationResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IImageService;
+import io.github.lnyocly.ai4j.service.PlatformType;
+import io.github.lnyocly.ai4j.service.factory.AiService;
+import io.github.lnyocly.ai4j.test.LiveProviderTest;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Live smoke test for image generation — the one model-access service that had no live
+ * verification before this.
+ *
+ * <p>Requires {@code OPENAI_API_KEY} and an image-capable model named via
+ * {@code OPENAI_IMAGE_MODEL}. Honours {@code OPENAI_API_HOST}. Skips when absent.
+ *
+ * <p>Uses {@code responseFormat=b64_json} so the test does not depend on the gateway's
+ * image-host URL being externally reachable (some gateways return an internal-IP media URL).
+ */
+@Category(LiveProviderTest.class)
+public class ImageGenerationLiveTest {
+
+    private IImageService imageService() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        Assume.assumeTrue("OPENAI_API_KEY not set", apiKey != null && !apiKey.trim().isEmpty());
+
+        OpenAiConfig cfg = new OpenAiConfig();
+        cfg.setApiKey(apiKey);
+        String host = System.getenv("OPENAI_API_HOST");
+        if (host != null && !host.trim().isEmpty()) {
+            cfg.setApiHost(host);
+        }
+        Configuration c = new Configuration();
+        c.setOpenAiConfig(cfg);
+        return new AiService(c).getImageService(PlatformType.OPENAI);
+    }
+
+    private String model() {
+        String m = System.getenv("OPENAI_IMAGE_MODEL");
+        return (m == null || m.trim().isEmpty()) ? "dall-e-3" : m;
+    }
+
+    @Test
+    public void generateReturnsBase64Image() throws Exception {
+        IImageService imageService = imageService();
+
+        ImageGeneration request = ImageGeneration.builder()
+                .model(model())
+                .prompt("a small solid red circle centered on a white background, minimal")
+                .size("1024x1024")
+                .n(1)
+                .responseFormat("b64_json")   // inline base64 — robust to gateway media-URL quirks
+                .build();
+
+        ImageGenerationResponse response;
+        try {
+            response = imageService.generate(request);
+        } catch (Exception e) {
+            Assume.assumeNoException("gateway does not support image generation (" + e.getMessage() + ")", e);
+            return;
+        }
+
+        Assert.assertNotNull(response);
+        Assert.assertNotNull("response data list should be present", response.getData());
+        Assert.assertFalse("should produce at least one image", response.getData().isEmpty());
+
+        ImageData image = response.getData().get(0);
+        // b64_json mode: the payload is inline; url mode: a fetchable URL.
+        boolean hasPayload = (image.getB64Json() != null && !image.getB64Json().isEmpty())
+                || (image.getUrl() != null && !image.getUrl().isEmpty());
+        Assert.assertTrue("image should carry b64_json or url, got: " + image.getB64Json() + " / " + image.getUrl(),
+                hasPayload);
+
+        if (image.getB64Json() != null) {
+            System.out.println("b64_json length: " + image.getB64Json().length());
+            Assert.assertTrue("base64 payload should be non-trivial", image.getB64Json().length() > 1000);
+        } else {
+            System.out.println("url: " + image.getUrl());
+        }
+    }
+}

--- a/docs-site/docs/core-sdk/image-generation.md
+++ b/docs-site/docs/core-sdk/image-generation.md
@@ -12,6 +12,13 @@ tags: [how-to]
 - `OPENAI`
 - `DOUBAO`
 
+:::tip 本页代码可跑通
+非流式生成示例来自
+[`ImageGenerationLiveTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j/src/test/java/io/github/lnyocly/ai4j/docs/ImageGenerationLiveTest.java)，
+已针对真实 OpenAI 兼容网关（grok-imagine-image）跑通。
+
+本地复跑：`OPENAI_API_KEY=... OPENAI_API_HOST=... OPENAI_IMAGE_MODEL=... mvn -pl ai4j test -Plive-provider-tests -Dtest=ImageGenerationLiveTest`，无 key 自动跳过。
+
 ## 1. 非流式生成
 
 ```java
@@ -21,11 +28,11 @@ ImageGeneration request = ImageGeneration.builder()
         .model("gpt-image-1")
         .prompt("A clean isometric illustration of a Java microservice")
         .size("1024x1024")
-        .responseFormat("url")
+        .responseFormat("b64_json")   // 内联 base64，避免依赖网关图片 URL 的可访问性
         .build();
 
 ImageGenerationResponse response = imageService.generate(request);
-System.out.println(response);
+// 图片在 response.getData().get(0).getB64Json()（或 getUrl()，取决于 responseFormat）
 ```
 
 ## 2. 流式生成
@@ -104,9 +111,12 @@ SDK 已做协议适配：
 
 ### 7.2 URL 可访问性问题
 
-:::tip
+:::warning
+- 部分网关返回的图片 URL 是**内网地址**（如 `127.0.0.1` 或私有 IP），外部无法访问——这是网关侧问题，不是 SDK 缺陷
 - 部分平台返回临时 URL，需尽快下载/转存
 - 生产建议落盘到对象存储
+
+**跨网关最稳的做法**：用 `responseFormat("b64_json")` 让图片内联返回，不依赖网关的图片托管 URL。代价是响应体较大。
 :::
 
 ### 7.3 base64 太大


### PR DESCRIPTION
image-generation.md 是 [how-to] 页有代码但从未 live 验证——image 是唯一没有真机测试的 model-access service。

## 改动
- 新增 \`ImageGenerationLiveTest\`，针对 grok-imagine-image 网关跑通（返回 148KB b64_json）。**至此五条 service 面（chat/responses/messages/audio/image）全部有 live 测试。**
- 实测发现该网关 url 模式返回内网 IP 图片地址（127.0.0.1），外部取不到；b64_json 正常。更新文档：
  - §1 示例改用 b64_json（更跨网关可移植）
  - §7.2 强化 warning：点明网关可能返回内网地址，推荐 b64_json 作为跨网关最稳做法
  - 加可跑通 tip

## 验证
- live 测试无 key 自动跳过；ai4j 离线全量绿；docs 构建零警告
- 顺带确认该网关四条主线（chat/responses/messages/image）全可用（grok-4.5 + grok-imagine-image）