### PR TITLE
docs(agent): workflow cookbook 完整装配 + stategraph/runtime 交叉链接

### DIFF
--- a/docs-site/docs/agent/runtime-implementations.md
+++ b/docs-site/docs/agent/runtime-implementations.md
@@ -316,6 +316,24 @@ Plan:
 - `buildPrompt(...)`
 - 局部 `runInternal(...)`
 
+最小骨架（参考 `ReActRuntime`，它本身只覆写了 `runtimeName()`，主循环复用 base）：
+
+```java
+public class MyRuntime extends BaseAgentRuntime {
+    @Override
+    protected String runtimeName() {
+        return "my-runtime";
+    }
+
+    // 只在需要改主循环时才覆写；不改就完全复用 base 的 runInternal
+    // @Override
+    // protected AgentResult runInternal(AgentContext context, AgentRequest request,
+    //                                   AgentListener listener) throws Exception { ... }
+}
+```
+
+挂到 Agent 上：`Agents.builder().runtime(new MyRuntime())...build()`（或经 `AgentBuilder.runtime(...)`）。
+
 ### 9.2 真正换主循环
 
 只有当你要改变：

--- a/docs-site/docs/agent/weather-workflow-cookbook.md
+++ b/docs-site/docs/agent/weather-workflow-cookbook.md
@@ -14,9 +14,47 @@ tags: [how-to]
 - 为什么一个节点用 `ChatModelClient`，另一个节点用 `ResponsesModelClient`
 - 为什么 cookbook 里还要自己包 `NamedNode` 做开始/结束日志
 
-对应测试源码：
+对应测试源码（已 live 跑通，需 `DOUBAO_API_KEY`）：
 
-- `ai4j-agent/src/test/java/io/github/lnyocly/agent/WeatherAgentWorkflowTest.java`
+- [`WeatherAgentWorkflowTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j-agent/src/test/java/io/github/lnyocly/agent/WeatherAgentWorkflowTest.java)
+
+## 0. 先把 workflow 装起来
+
+两阶段：分析节点（Chat + 工具）→ 格式化节点（Responses + strict JSON）。`SequentialWorkflow` 把上一节点的 `outputText` 默认接力成下一节点的 input。
+
+```java
+// 分析节点：Chat 主线 + queryWeather 工具
+Agent weatherAgent = Agents.react()
+        .modelClient(new ChatModelClient(aiService.getChatService(PlatformType.DOUBAO)))
+        .model("doubao-seed-1-8-251228")
+        .systemPrompt("You are a weather analyst. Always call queryWeather before answering.")
+        .instructions("Use queryWeather with the user's location, type=now, days=1.")
+        .toolRegistry(Arrays.asList("queryWeather"), null)
+        .options(AgentOptions.builder().maxSteps(2).build())
+        .build();
+
+// 格式化节点：Responses 主线，把分析收口成严格 JSON
+Agent formatAgent = Agents.react()
+        .modelClient(new ResponsesModelClient(aiService.getResponsesService(PlatformType.DOUBAO)))
+        .model("doubao-seed-1-8-251228")
+        .systemPrompt("You format weather analysis into strict JSON.")
+        .instructions("Return JSON with fields: city, summary, advice.")
+        .options(AgentOptions.builder().maxSteps(2).build())
+        .build();
+
+// 串成 workflow：NamedNode 只是包一层日志，RuntimeAgentNode 才是执行体
+SequentialWorkflow workflow = new SequentialWorkflow()
+        .addNode(new NamedNode("WeatherAnalysis", new RuntimeAgentNode(weatherAgent.newSession())))
+        .addNode(new NamedNode("FormatOutput", new RuntimeAgentNode(formatAgent.newSession())));
+
+WorkflowAgent runner = new WorkflowAgent(workflow, weatherAgent.newSession());
+AgentResult result = runner.run(AgentRequest.builder()
+        .input("Get the current weather in Beijing and provide advice.")
+        .build());
+// result.getOutputText() 是格式化节点产出的 JSON
+```
+
+`NamedNode` 是测试里自定义的一个薄包装，只做节点开始/结束日志——`SequentialWorkflow` 本身不要求它，`RuntimeAgentNode` 才是真正的执行节点。
 
 ## 1. 这个例子到底证明什么
 

--- a/docs-site/docs/agent/workflow-stategraph.md
+++ b/docs-site/docs/agent/workflow-stategraph.md
@@ -9,6 +9,10 @@ tags: [concept]
 
 这一层解决的不是“再造一个 runtime”，而是把多个 Agent 节点串成一个显式流程。
 
+:::tip StateGraph 装配有可跑通的单元测试
+[`StateGraphWorkflowTest`](https://github.com/LnYo-Cly/ai4j/blob/main/ai4j-agent/src/test/java/io/github/lnyocly/agent/StateGraphWorkflowTest.java) 用 `StaticNode`/`CounterNode`（无需密钥）演示条件分支 + 循环路由，是 §5/§6 的可执行佐证。天气场景的 live 双节点 workflow 见 [实战 cookbook](/docs/agent/weather-workflow-cookbook)。
+:::
+
 如果 `ReActRuntime` 负责单个 Agent run 的循环，那么 `workflow` 包负责的是：
 
 - 节点之间怎么接力


### PR DESCRIPTION
agent 文档 P4-P6 收尾。

## weather-workflow-cookbook.md（how-to）
原本只描述测试不贴代码（最严重的「how-to 却零可跑代码」）。补 §0 完整 SequentialWorkflow 装配：分析节点（Chat+工具）→ 格式化节点（Responses+strict JSON），NamedNode 包日志、RuntimeAgentNode 执行。指向已 live 跑通的 WeatherAgentWorkflowTest。

## workflow-stategraph.md（concept）
顶部 callout 指向 StateGraphWorkflowTest（无密钥，StaticNode/CounterNode 演示条件分支+循环）作为 §5/§6 可执行佐证；交叉链接天气 cookbook。

## runtime-implementations.md（concept）
§9「自定义 runtime 从哪切」补最小骨架（extends BaseAgentRuntime，参考 ReActRuntime 只覆写 runtimeName()），标注 AgentBuilder.runtime() 入口。

agent-teams.md 经此前 AgentTeamsDocExamplesTest 验证 + §10 完整示例 + §2-§11 覆盖 planner/synthesizer/planApproval/hooks，已充分，不再追加。

docs 构建零警告。