### PR TITLE
feat(agent): 三层分级上下文压缩（工具结果/reasoning 投影 + 结构化语义摘要）

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicy.java
@@ -1,6 +1,7 @@
 package io.github.lnyocly.ai4j.agent.compact;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
 import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
 import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
@@ -9,6 +10,7 @@ import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +32,13 @@ import java.util.Set;
 public class LlmCompactPolicy implements CompactPolicy {
 
     private static final String SUMMARY_SYSTEM_PROMPT =
-            "You are a conversation summarizer. Produce a concise structured summary with these sections:\n"
-            + "## Goal\n## Progress\n## Key Decisions\n## Critical Context\n"
-            + "Keep it under 500 words. Preserve any file paths, error messages, or code snippets that are still relevant.";
+            "You are a conversation summarizer for a coding agent. Return ONLY a JSON object — no prose, "
+            + "no code fences — with exactly these keys:\n"
+            + "{\"goal\": string, \"completed\": [string], \"pending\": [string], \"decisions\": [string], "
+            + "\"errors\": [string], \"testResults\": [string], \"openQuestions\": [string]}\n"
+            + "Use an empty array for a key with nothing to report. Keep each entry to one short line.\n"
+            + "Carry forward any still-unresolved entries from the previous summary's pending and decisions.\n"
+            + "Preserve file paths, error messages, and command names verbatim.";
 
     private final AgentModelClient modelClient;
     private final String modelName;
@@ -77,12 +83,19 @@ public class LlmCompactPolicy implements CompactPolicy {
         List<String> readFiles = extractFileOperations(toSummarize, true);
         List<String> modifiedFiles = extractFileOperations(toSummarize, false);
 
-        String summary = generateSummary(toSummarize, snapshot.getSummary(), readFiles, modifiedFiles);
+        StructuredSummary structured = generateSummary(toSummarize, snapshot.getSummary(), readFiles, modifiedFiles);
+        String summary = structured.text;
 
         MemorySnapshot compacted = MemorySnapshot.from(toKeep, summary);
         return CompactResult.builder()
                 .memory(compacted)
                 .summary(summary)
+                .completed(structured.completed)
+                .pending(structured.pending)
+                .decisions(structured.decisions)
+                .failedCommands(structured.errors)
+                .testResults(structured.testResults)
+                .openQuestions(structured.openQuestions)
                 .readFiles(readFiles)
                 .modifiedFiles(modifiedFiles)
                 .build();
@@ -116,8 +129,8 @@ public class LlmCompactPolicy implements CompactPolicy {
         return "user".equals(role);
     }
 
-    private String generateSummary(List<Object> itemsToSummarize, String previousSummary,
-                                   List<String> readFiles, List<String> modifiedFiles) {
+    private StructuredSummary generateSummary(List<Object> itemsToSummarize, String previousSummary,
+                                              List<String> readFiles, List<String> modifiedFiles) {
         StringBuilder userContent = new StringBuilder();
         if (previousSummary != null && !previousSummary.trim().isEmpty()) {
             userContent.append("Previous summary:\n").append(previousSummary.trim()).append("\n\n");
@@ -136,12 +149,133 @@ public class LlmCompactPolicy implements CompactPolicy {
         try {
             AgentModelResult result = modelClient.create(prompt);
             if (result != null && result.getOutputText() != null && !result.getOutputText().trim().isEmpty()) {
-                return result.getOutputText().trim();
+                return StructuredSummary.parse(result.getOutputText().trim());
             }
         } catch (Exception e) {
             // summarization failure → fall back to a mechanical note
         }
-        return "Compaction summary unavailable (LLM summarization failed). " + itemsToSummarize.size() + " items were summarized.";
+        return StructuredSummary.unavailable(itemsToSummarize.size());
+    }
+
+    /**
+     * The model's structured summary, parsed into the fields {@link CompactResult} reserves for it.
+     *
+     * <p>Parsing is best-effort by design: a summarizer that returns prose instead of JSON must not
+     * fail a compaction. In that case {@link #text} holds the raw output verbatim and the lists stay
+     * empty, which is exactly the pre-structured behaviour.
+     */
+    static final class StructuredSummary {
+
+        final String text;
+        final List<String> completed;
+        final List<String> pending;
+        final List<String> decisions;
+        final List<String> errors;
+        final List<String> testResults;
+        final List<String> openQuestions;
+
+        private StructuredSummary(String text, Map<String, List<String>> fields) {
+            this.text = text;
+            this.completed = fields.get("completed");
+            this.pending = fields.get("pending");
+            this.decisions = fields.get("decisions");
+            this.errors = fields.get("errors");
+            this.testResults = fields.get("testResults");
+            this.openQuestions = fields.get("openQuestions");
+        }
+
+        static StructuredSummary parse(String output) {
+            Map<String, List<String>> fields = new LinkedHashMap<String, List<String>>();
+            JSONObject json = parseJsonObject(output);
+            for (String key : STRUCTURED_KEYS) {
+                fields.put(key, json == null ? new ArrayList<String>() : stringList(json.get(key)));
+            }
+            // A structured response reads better as sections than as raw JSON in the system prompt.
+            return new StructuredSummary(json == null ? output : render(json, fields), fields);
+        }
+
+        static StructuredSummary unavailable(int itemCount) {
+            Map<String, List<String>> fields = new LinkedHashMap<String, List<String>>();
+            for (String key : STRUCTURED_KEYS) {
+                fields.put(key, new ArrayList<String>());
+            }
+            return new StructuredSummary("Compaction summary unavailable (LLM summarization failed). "
+                    + itemCount + " items were summarized.", fields);
+        }
+
+        /**
+         * Tolerates the two things summarizers do to JSON: wrapping it in ``` fences, and padding it
+         * with a sentence before or after. Returns null when there is no JSON object to be found.
+         */
+        private static JSONObject parseJsonObject(String output) {
+            int start = output.indexOf('{');
+            int end = output.lastIndexOf('}');
+            if (start < 0 || end <= start) {
+                return null;
+            }
+            try {
+                return JSON.parseObject(output.substring(start, end + 1));
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private static List<String> stringList(Object value) {
+            List<String> result = new ArrayList<String>();
+            if (value instanceof List) {
+                for (Object entry : (List<?>) value) {
+                    if (entry == null) {
+                        continue;
+                    }
+                    String text = String.valueOf(entry).trim();
+                    if (!text.isEmpty()) {
+                        result.add(text);
+                    }
+                }
+            } else if (value != null) {
+                // a single string where an array was asked for
+                String text = String.valueOf(value).trim();
+                if (!text.isEmpty()) {
+                    result.add(text);
+                }
+            }
+            return result;
+        }
+
+        private static String render(JSONObject json, Map<String, List<String>> fields) {
+            StringBuilder sb = new StringBuilder();
+            Object goal = json.get("goal");
+            if (goal != null && !String.valueOf(goal).trim().isEmpty()) {
+                sb.append("## Goal\n").append(String.valueOf(goal).trim()).append('\n');
+            }
+            for (String key : STRUCTURED_KEYS) {
+                List<String> values = fields.get(key);
+                if (values.isEmpty()) {
+                    continue;
+                }
+                sb.append("\n## ").append(SECTION_TITLES.get(key)).append('\n');
+                for (String value : values) {
+                    sb.append("- ").append(value).append('\n');
+                }
+            }
+            return sb.length() == 0 ? json.toString() : sb.toString().trim();
+        }
+    }
+
+    private static final List<String> STRUCTURED_KEYS = Collections.unmodifiableList(java.util.Arrays.asList(
+            "completed", "pending", "decisions", "errors", "testResults", "openQuestions"));
+
+    private static final Map<String, String> SECTION_TITLES;
+
+    static {
+        Map<String, String> titles = new LinkedHashMap<String, String>();
+        titles.put("completed", "Progress");
+        titles.put("pending", "Pending");
+        titles.put("decisions", "Key Decisions");
+        titles.put("errors", "Errors");
+        titles.put("testResults", "Test Results");
+        titles.put("openQuestions", "Open Questions");
+        SECTION_TITLES = Collections.unmodifiableMap(titles);
     }
 
     private static final Set<String> READ_TOOLS = new LinkedHashSet<String>(java.util.Arrays.asList(

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/ContextBudget.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/ContextBudget.java
@@ -18,6 +18,19 @@ public class ContextBudget {
     @Builder.Default
     private Integer pinnedPrefixItems = 0;
 
+    /**
+     * Tier-1 microcompact: maximum recent {@code function_call_output} items whose full content
+     * is kept in the projected prompt. Older tool results are replaced with a placeholder so the
+     * model sees the structure without the bulk. {@code null} (default) disables microcompact.
+     */
+    private Integer maxRecentToolResults;
+
+    /**
+     * Tier-2: when true, reasoning/thinking content from earlier turns is trimmed in the
+     * projected prompt. Default {@code null} treated as false (no trimming).
+     */
+    private Boolean trimOldReasoning;
+
     public static ContextBudget maxItems(int maxItems) {
         return ContextBudget.builder().maxItems(maxItems).build();
     }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/ContextReport.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/ContextReport.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class ContextReport {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/TypeAwareContextProjector.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/context/TypeAwareContextProjector.java
@@ -1,0 +1,232 @@
+package io.github.lnyocly.ai4j.agent.context;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tier-1/2 type-aware context projection for AI4J agent memory.
+ *
+ * <p>This projector layers two deterministic, non-LLM trimming passes on top of the existing
+ * {@link DefaultContextProjector} item/character limits, mirroring the lower tiers of Claude
+ * Code's compaction engine:
+ *
+ * <ol>
+ *   <li><b>Tier-1 microcompact</b>: keeps the full content of only the most recent
+ *       {@code maxRecentToolResults} {@code function_call_output} items; older ones are replaced
+ *       with a placeholder naming the tool that produced them, so the model still sees which call
+ *       happened without carrying the payload. Runs every turn.</li>
+ *   <li><b>Tier-2 reasoning trim</b>: when {@code trimOldReasoning} is set, {@code reasoning} items
+ *       from earlier turns have their payload cleared (item type and id preserved).</li>
+ * </ol>
+ *
+ * <p>Both passes are pure projection: neither the memory list nor any item inside it is mutated —
+ * trimmed items are replaced with freshly built copies. Full tool results and reasoning therefore
+ * stay in memory for Tier-3 compaction, audit, and replay. This is what lets Tier-1 be aggressive:
+ * nothing is lost, the model just doesn't see it this turn.
+ *
+ * <p>When {@code maxRecentToolResults} is null and {@code trimOldReasoning} is null/false, the
+ * behaviour is identical to {@link DefaultContextProjector} — full backwards compatibility.
+ *
+ * <p>Only {@link Map}-shaped items are inspected, matching the rest of this subsystem (see
+ * {@code LlmCompactPolicy}). Items still held as provider POJOs (the Responses API returns
+ * {@code ResponseItem} until a snapshot round-trips them through JSON) pass through untouched.
+ */
+public class TypeAwareContextProjector implements ContextProjector {
+
+    private static final String TYPE = "type";
+    private static final String ROLE = "role";
+    private static final String FUNCTION_CALL_OUTPUT = "function_call_output";
+    private static final String REASONING = "reasoning";
+    private static final String CALL_ID = "call_id";
+    private static final String OUTPUT = "output";
+    private static final String TOOL_CALLS = "tool_calls";
+    private static final String CONTENT = "content";
+
+    private final DefaultContextProjector fallback = new DefaultContextProjector();
+
+    @Override
+    public ContextProjection project(List<Object> items, ContextBudget budget) {
+        if (items == null || items.isEmpty() || budget == null) {
+            return fallback.project(items, budget);
+        }
+
+        List<Object> working = new ArrayList<Object>(items);
+        List<String> notes = new ArrayList<String>();
+
+        Integer maxRecent = budget.getMaxRecentToolResults();
+        if (maxRecent != null && maxRecent >= 0) {
+            int cleared = applyToolResultMicrocompact(working, maxRecent);
+            if (cleared > 0) {
+                notes.add("tier1 microcompact: cleared " + cleared + " old tool result(s), kept recent " + maxRecent);
+            }
+        }
+
+        if (Boolean.TRUE.equals(budget.getTrimOldReasoning())) {
+            int trimmed = trimOldReasoning(working);
+            if (trimmed > 0) {
+                notes.add("tier2 reasoning-trim: cleared " + trimmed + " reasoning item(s)");
+            }
+        }
+
+        ContextProjection projection = fallback.project(working, budget);
+
+        if (notes.isEmpty() || projection == null || projection.getReport() == null) {
+            return projection;
+        }
+        List<String> merged = new ArrayList<String>(notes);
+        merged.addAll(projection.getReport().getNotes());
+        return ContextProjection.of(projection.getItems(),
+                projection.getReport().toBuilder().notes(merged).build());
+    }
+
+    /**
+     * Replaces all but the most recent {@code keep} {@code function_call_output} items with a
+     * placeholder carrying the originating tool name, e.g.
+     * {@code [tool result cleared: read(call-1)]}.
+     *
+     * @return the number of items replaced
+     */
+    private int applyToolResultMicrocompact(List<Object> items, int keep) {
+        List<Integer> toolResultIndices = new ArrayList<Integer>();
+        for (int i = 0; i < items.size(); i++) {
+            if (FUNCTION_CALL_OUTPUT.equals(typeOf(items.get(i)))) {
+                toolResultIndices.add(i);
+            }
+        }
+        if (toolResultIndices.size() <= keep) {
+            return 0;
+        }
+        Map<String, String> toolNamesByCallId = mapCallIdToToolName(items);
+        int firstToKeep = toolResultIndices.size() - keep;
+        for (int j = 0; j < firstToKeep; j++) {
+            int idx = toolResultIndices.get(j);
+            String callId = stringValue(asMap(items.get(idx)), CALL_ID);
+            items.set(idx, toolResultPlaceholder(callId, toolNamesByCallId.get(callId)));
+        }
+        return firstToKeep;
+    }
+
+    private Map<String, Object> toolResultPlaceholder(String callId, String toolName) {
+        StringBuilder label = new StringBuilder("[tool result cleared");
+        if (toolName != null) {
+            label.append(": ").append(toolName);
+            label.append(callId == null ? "" : "(" + callId + ")");
+        } else if (callId != null) {
+            label.append(": ").append(callId);
+        }
+        label.append(']');
+
+        Map<String, Object> placeholder = new LinkedHashMap<String, Object>();
+        placeholder.put(TYPE, FUNCTION_CALL_OUTPUT);
+        if (callId != null) {
+            placeholder.put(CALL_ID, callId);
+        }
+        placeholder.put(OUTPUT, label.toString());
+        return placeholder;
+    }
+
+    /**
+     * Builds {@code call_id -> tool name} from assistant messages. A {@code function_call_output}
+     * only carries {@code call_id}, so the name has to come from the {@code tool_calls} entry that
+     * produced it (OpenAI nests it under {@code function.name}).
+     */
+    private Map<String, String> mapCallIdToToolName(List<Object> items) {
+        Map<String, String> byCallId = new HashMap<String, String>();
+        for (Object item : items) {
+            collectToolNames(asMap(item), byCallId);
+        }
+        return byCallId;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectToolNames(Map<String, Object> map, Map<String, String> byCallId) {
+        if (map == null) {
+            return;
+        }
+        Object toolCalls = map.get(TOOL_CALLS);
+        if (toolCalls instanceof List) {
+            for (Object toolCall : (List<Object>) toolCalls) {
+                Map<String, Object> call = asMap(toolCall);
+                if (call == null) {
+                    continue;
+                }
+                String id = stringValue(call, "id");
+                if (id == null) {
+                    continue;
+                }
+                String name = stringValue(call, "name");
+                if (name == null) {
+                    name = stringValue(asMap(call.get("function")), "name");
+                }
+                if (name != null) {
+                    byCallId.put(id, name);
+                }
+            }
+        }
+        // some protocols nest tool calls inside the content array
+        Object content = map.get(CONTENT);
+        if (content instanceof List) {
+            for (Object part : (List<Object>) content) {
+                collectToolNames(asMap(part), byCallId);
+            }
+        }
+    }
+
+    /**
+     * Clears the payload of {@code reasoning} items belonging to earlier turns — everything before
+     * the last user message. The current turn's reasoning is kept because the model may still be
+     * mid-chain on it. Item {@code type} and {@code id} survive so the sequence stays well-formed.
+     *
+     * @return the number of reasoning items cleared
+     */
+    private int trimOldReasoning(List<Object> items) {
+        int currentTurnStart = lastUserMessageIndex(items);
+        int trimmed = 0;
+        for (int i = 0; i < currentTurnStart; i++) {
+            Map<String, Object> map = asMap(items.get(i));
+            if (map == null || !REASONING.equals(typeOf(items.get(i)))) {
+                continue;
+            }
+            Map<String, Object> cleared = new LinkedHashMap<String, Object>(map);
+            // payload keys across providers: Responses uses summary/content, others use text
+            cleared.remove("summary");
+            cleared.remove(CONTENT);
+            cleared.remove("text");
+            cleared.put(OUTPUT, "[reasoning cleared]");
+            items.set(i, cleared);
+            trimmed++;
+        }
+        return trimmed;
+    }
+
+    /** @return index of the last user-role message, or items.size() when there is none */
+    private int lastUserMessageIndex(List<Object> items) {
+        for (int i = items.size() - 1; i >= 0; i--) {
+            Map<String, Object> map = asMap(items.get(i));
+            if (map != null && "user".equals(map.get(ROLE))) {
+                return i;
+            }
+        }
+        return items.size();
+    }
+
+    private String typeOf(Object item) {
+        return stringValue(asMap(item), TYPE);
+    }
+
+    private String stringValue(Map<String, Object> map, String key) {
+        if (map == null) {
+            return null;
+        }
+        Object value = map.get(key);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object item) {
+        return item instanceof Map ? (Map<String, Object>) item : null;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/memory/AgentMemory.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/memory/AgentMemory.java
@@ -14,6 +14,15 @@ public interface AgentMemory {
 
     String getSummary();
 
+    /**
+     * Sets the compacted summary text. Implementations should store it so that subsequent
+     * {@link #getSummary()} / {@link #snapshot()} calls return it. Default is a no-op so the
+     * interface stays backwards-compatible with implementations that don't track a summary.
+     */
+    default void setSummary(String summary) {
+        // no-op default; implementations that support compaction override this
+    }
+
     default MemorySnapshot snapshot() {
         return MemorySnapshot.from(getItems(), getSummary());
     }
@@ -25,6 +34,10 @@ public interface AgentMemory {
         }
         if (snapshot.getItems() != null) {
             addOutputItems(snapshot.getItems());
+        }
+        // Preserve the compacted summary so it survives a restore cycle.
+        if (snapshot.getSummary() != null) {
+            setSummary(snapshot.getSummary());
         }
     }
 

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicyStructuredSummaryTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/compact/LlmCompactPolicyStructuredSummaryTest.java
@@ -1,0 +1,168 @@
+package io.github.lnyocly.ai4j.agent.compact;
+
+import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the Tier-3 structured backfill in {@link LlmCompactPolicy}: the model's JSON
+ * summary is parsed back into the structured {@link CompactResult} fields, and unparseable output
+ * degrades to the legacy freeform behaviour instead of failing compaction.
+ */
+public class LlmCompactPolicyStructuredSummaryTest {
+
+    private static final String STRUCTURED_JSON = "{"
+            + "\"goal\":\"Implement the login flow\","
+            + "\"completed\":[\"Added LoginController\",\"Wired the form\"],"
+            + "\"pending\":[\"Add tests\"],"
+            + "\"decisions\":[\"Use JWT sessions\"],"
+            + "\"errors\":[\"mvn test: 3 failures\"],"
+            + "\"testResults\":[\"17 passed, 3 failed\"],"
+            + "\"openQuestions\":[\"Refresh-token expiry?\"]"
+            + "}";
+
+    private final LlmCompactPolicy policy =
+            new LlmCompactPolicy(new FixedModelClient(STRUCTURED_JSON), "m", 3);
+
+    private MemorySnapshot snapshotOf(int itemCount) {
+        List<Object> items = new ArrayList<Object>();
+        for (int i = 0; i < itemCount; i++) {
+            items.add(AgentInputItem.userMessage("message " + i));
+        }
+        return MemorySnapshot.from(items, null);
+    }
+
+    @Test
+    public void backfillsStructuredFieldsIntoCompactResult() {
+        CompactResult result = policy.compact(snapshotOf(6));
+
+        assertEquals("3 recent items are kept", 3, result.getMemory().getItems().size());
+        assertEquals(Arrays.asList("Added LoginController", "Wired the form"), result.getCompleted());
+        assertEquals(Arrays.asList("Add tests"), result.getPending());
+        assertEquals(Arrays.asList("Use JWT sessions"), result.getDecisions());
+        assertEquals(Arrays.asList("mvn test: 3 failures"), result.getFailedCommands());
+        assertEquals(Arrays.asList("17 passed, 3 failed"), result.getTestResults());
+        assertEquals(Arrays.asList("Refresh-token expiry?"), result.getOpenQuestions());
+    }
+
+    @Test
+    public void rendersStructuredJsonAsSectionSummary() {
+        CompactResult result = policy.compact(snapshotOf(6));
+
+        String summary = result.getSummary();
+        assertTrue("goal is rendered", summary.contains("## Goal"));
+        assertTrue("goal text is rendered", summary.contains("Implement the login flow"));
+        assertTrue("decisions are rendered", summary.contains("## Key Decisions"));
+        assertTrue("decisions text is rendered", summary.contains("- Use JWT sessions"));
+    }
+
+    @Test
+    public void toleratesFencedJsonOutput() {
+        LlmCompactPolicy fenced = new LlmCompactPolicy(
+                new FixedModelClient("Here is the summary:\n```json\n" + STRUCTURED_JSON + "\n```\n-- end"),
+                "m", 3);
+
+        CompactResult result = fenced.compact(snapshotOf(6));
+
+        assertEquals(Arrays.asList("Add tests"), result.getPending());
+        assertEquals(Arrays.asList("Use JWT sessions"), result.getDecisions());
+        assertTrue(result.getSummary().contains("Implement the login flow"));
+    }
+
+    @Test
+    public void degradesToFreeformWhenOutputIsNotJson() {
+        LlmCompactPolicy prose = new LlmCompactPolicy(
+                new FixedModelClient("The user asked for help with login. Work continues on tests."),
+                "m", 3);
+
+        CompactResult result = prose.compact(snapshotOf(6));
+
+        assertEquals("no structured fields", 0, result.getPending().size());
+        assertEquals("no structured fields", 0, result.getDecisions().size());
+        assertEquals("raw prose is preserved as the summary",
+                "The user asked for help with login. Work continues on tests.", result.getSummary());
+    }
+
+    @Test
+    public void fallsBackWhenModelClientThrows() {
+        LlmCompactPolicy failing = new LlmCompactPolicy(new ThrowingModelClient(), "m", 3);
+
+        CompactResult result = failing.compact(snapshotOf(6));
+
+        assertTrue(result.getSummary().startsWith("Compaction summary unavailable"));
+        assertEquals(0, result.getCompleted().size());
+        assertEquals(0, result.getPending().size());
+    }
+
+    @Test
+    public void previousSummaryIsFedBackToTheModel() {
+        final List<Object> captured = new ArrayList<Object>();
+        AgentModelClient capturing = new AgentModelClient() {
+            @Override
+            public AgentModelResult create(AgentPrompt prompt) {
+                captured.add(prompt.getItems().get(0));
+                return AgentModelResult.builder().outputText(STRUCTURED_JSON).build();
+            }
+
+            @Override
+            public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+                return create(prompt);
+            }
+        };
+        LlmCompactPolicy p = new LlmCompactPolicy(capturing, "m", 3);
+        MemorySnapshot snapshot = MemorySnapshot.from(
+                Arrays.<Object>asList(
+                        AgentInputItem.userMessage("one"),
+                        AgentInputItem.userMessage("two"),
+                        AgentInputItem.userMessage("three"),
+                        AgentInputItem.userMessage("four")),
+                "Pending: [add tests]; Decisions: [use JWT]");
+
+        p.compact(snapshot);
+
+        assertTrue("previous summary must be part of the summarization input",
+                String.valueOf(captured.get(0)).contains("Pending: [add tests]"));
+        assertTrue(String.valueOf(captured.get(0)).contains("Decisions: [use JWT]"));
+    }
+
+    private static final class FixedModelClient implements AgentModelClient {
+        private final String output;
+
+        private FixedModelClient(String output) {
+            this.output = output;
+        }
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            return AgentModelResult.builder().outputText(output).build();
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return create(prompt);
+        }
+    }
+
+    private static final class ThrowingModelClient implements AgentModelClient {
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            throw new IllegalStateException("model unavailable");
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return create(prompt);
+        }
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/context/TypeAwareContextProjectorTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/context/TypeAwareContextProjectorTest.java
@@ -1,0 +1,226 @@
+package io.github.lnyocly.ai4j.agent.context;
+
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests {@link TypeAwareContextProjector} — Tier-1 tool-result microcompact and Tier-2 reasoning trim. */
+public class TypeAwareContextProjectorTest {
+
+    private final TypeAwareContextProjector projector = new TypeAwareContextProjector();
+
+    @Test
+    public void keepsOnlyRecentToolResultsAndPlaceholdersTheRest() {
+        List<Object> items = new ArrayList<Object>();
+        items.add(AgentInputItem.userMessage("do the thing"));
+        for (int i = 1; i <= 5; i++) {
+            items.add(assistantCalling("call-" + i, "read"));
+            items.add(AgentInputItem.functionCallOutput("call-" + i, "payload-" + i));
+        }
+
+        ContextProjection projection = projector.project(items,
+                ContextBudget.builder().maxRecentToolResults(2).build());
+
+        List<Object> projected = projection.getItems();
+        assertEquals("no items are dropped by tier-1", items.size(), projected.size());
+        for (int i = 1; i <= 3; i++) {
+            assertEquals("[tool result cleared: read(call-" + i + ")]", outputOf(projected, "call-" + i));
+        }
+        assertEquals("payload-4", outputOf(projected, "call-4"));
+        assertEquals("payload-5", outputOf(projected, "call-5"));
+        assertTrue(projection.getReport().getNotes().contains(
+                "tier1 microcompact: cleared 3 old tool result(s), kept recent 2"));
+    }
+
+    @Test
+    public void doesNotMutateSourceItemsOrTheirMaps() {
+        Map<String, Object> toolResult = AgentInputItem.functionCallOutput("call-1", "original-payload");
+        List<Object> items = new ArrayList<Object>(Arrays.<Object>asList(
+                assistantCalling("call-1", "read"),
+                toolResult,
+                AgentInputItem.functionCallOutput("call-2", "keep-me")));
+
+        projector.project(items, ContextBudget.builder().maxRecentToolResults(1).build());
+
+        assertEquals("memory item must survive projection untouched", "original-payload", toolResult.get("output"));
+        assertEquals(3, items.size());
+        assertTrue("source list must still hold the same map instance", items.get(1) == toolResult);
+    }
+
+    @Test
+    public void placeholderFallsBackToCallIdWhenToolNameIsUnknown() {
+        List<Object> items = new ArrayList<Object>(Arrays.<Object>asList(
+                AgentInputItem.functionCallOutput("orphan-call", "payload"),
+                AgentInputItem.functionCallOutput("call-2", "keep-me")));
+
+        List<Object> projected = projector.project(items,
+                ContextBudget.builder().maxRecentToolResults(1).build()).getItems();
+
+        assertEquals("[tool result cleared: orphan-call]", outputOf(projected, "orphan-call"));
+    }
+
+    @Test
+    public void resolvesToolNameFromNestedOpenAiFunctionWrapper() {
+        Map<String, Object> function = new LinkedHashMap<String, Object>();
+        function.put("name", "write");
+        Map<String, Object> call = new LinkedHashMap<String, Object>();
+        call.put("id", "call-1");
+        call.put("function", function);
+        Map<String, Object> assistant = new LinkedHashMap<String, Object>();
+        assistant.put("type", "message");
+        assistant.put("role", "assistant");
+        assistant.put("tool_calls", new ArrayList<Object>(Collections.singletonList(call)));
+
+        List<Object> items = new ArrayList<Object>(Arrays.<Object>asList(
+                assistant,
+                AgentInputItem.functionCallOutput("call-1", "payload"),
+                AgentInputItem.functionCallOutput("call-2", "keep-me")));
+
+        List<Object> projected = projector.project(items,
+                ContextBudget.builder().maxRecentToolResults(1).build()).getItems();
+
+        assertEquals("[tool result cleared: write(call-1)]", outputOf(projected, "call-1"));
+    }
+
+    @Test
+    public void microcompactRunsBeforeCharacterLimitSoMoreItemsSurvive() {
+        List<Object> items = new ArrayList<Object>();
+        for (int i = 1; i <= 4; i++) {
+            items.add(AgentInputItem.functionCallOutput("call-" + i, repeat('x', 200)));
+        }
+
+        ContextBudget budget = ContextBudget.builder()
+                .maxRecentToolResults(1)
+                .maxApproxChars(600)
+                .build();
+
+        List<Object> withTier1 = projector.project(items, budget).getItems();
+        List<Object> withoutTier1 = new DefaultContextProjector().project(items, budget).getItems();
+
+        assertTrue("tier-1 shrinks items so the char budget drops fewer of them",
+                withTier1.size() > withoutTier1.size());
+    }
+
+    @Test
+    public void trimsReasoningFromEarlierTurnsButKeepsTheCurrentOne() {
+        List<Object> items = new ArrayList<Object>(Arrays.<Object>asList(
+                AgentInputItem.userMessage("first question"),
+                reasoning("r-1", "long deliberation about the first question"),
+                AgentInputItem.message("assistant", "first answer"),
+                AgentInputItem.userMessage("second question"),
+                reasoning("r-2", "deliberation still in progress")));
+
+        ContextProjection projection = projector.project(items,
+                ContextBudget.builder().trimOldReasoning(true).build());
+        List<Object> projected = projection.getItems();
+
+        Map<?, ?> old = (Map<?, ?>) projected.get(1);
+        assertEquals("reasoning", old.get("type"));
+        assertEquals("r-1", old.get("id"));
+        assertEquals("[reasoning cleared]", old.get("output"));
+        assertFalse("payload must be gone", old.containsKey("summary"));
+
+        Map<?, ?> current = (Map<?, ?>) projected.get(4);
+        assertEquals("current turn reasoning is untouched",
+                "deliberation still in progress", ((List<?>) current.get("summary")).get(0));
+        assertTrue(projection.getReport().getNotes().contains("tier2 reasoning-trim: cleared 1 reasoning item(s)"));
+    }
+
+    @Test
+    public void reasoningTrimIsOffByDefault() {
+        List<Object> items = new ArrayList<Object>(Arrays.<Object>asList(
+                reasoning("r-1", "deliberation"),
+                AgentInputItem.userMessage("question")));
+
+        List<Object> projected = projector.project(items, ContextBudget.builder().maxItems(10).build()).getItems();
+
+        assertTrue("reasoning survives when trimOldReasoning is unset",
+                ((Map<?, ?>) projected.get(0)).containsKey("summary"));
+    }
+
+    /** The backwards-compatibility contract: unconfigured, it must behave exactly like the default. */
+    @Test
+    public void isIdenticalToDefaultProjectorWhenTiersAreUnconfigured() {
+        List<Object> items = new ArrayList<Object>();
+        items.add(AgentInputItem.userMessage("goal"));
+        for (int i = 1; i <= 6; i++) {
+            items.add(assistantCalling("call-" + i, "read"));
+            items.add(AgentInputItem.functionCallOutput("call-" + i, "payload-" + i));
+            items.add(reasoning("r-" + i, "thought-" + i));
+        }
+
+        List<ContextBudget> budgets = Arrays.asList(
+                ContextBudget.builder().build(),
+                ContextBudget.maxItems(5),
+                ContextBudget.maxApproxChars(400),
+                ContextBudget.builder().maxItems(7).pinnedPrefixItems(1).build(),
+                ContextBudget.builder().maxItems(4).maxApproxChars(300).pinnedPrefixItems(2).build());
+
+        DefaultContextProjector reference = new DefaultContextProjector();
+        for (ContextBudget budget : budgets) {
+            ContextProjection actual = projector.project(items, budget);
+            ContextProjection expected = reference.project(items, budget);
+            assertEquals("items must match for " + budget, expected.getItems(), actual.getItems());
+            assertEquals("notes must match for " + budget,
+                    expected.getReport().getNotes(), actual.getReport().getNotes());
+            assertEquals("projected item count must match for " + budget,
+                    expected.getReport().getProjectedItemCount(), actual.getReport().getProjectedItemCount());
+            assertEquals("projected chars must match for " + budget,
+                    expected.getReport().getProjectedApproxChars(), actual.getReport().getProjectedApproxChars());
+        }
+    }
+
+    @Test
+    public void handlesEmptyAndNullInputLikeTheDefaultProjector() {
+        ContextBudget budget = ContextBudget.builder().maxRecentToolResults(1).trimOldReasoning(true).build();
+        assertTrue(projector.project(null, budget).getItems().isEmpty());
+        assertTrue(projector.project(new ArrayList<Object>(), budget).getItems().isEmpty());
+        List<Object> items = Arrays.<Object>asList("plain-string", 42);
+        assertEquals("non-map items pass through", items, projector.project(items, budget).getItems());
+    }
+
+    // --- helpers ---
+
+    private static Map<String, Object> assistantCalling(String callId, String toolName) {
+        return AgentInputItem.assistantToolCallsMessage("working", Collections.singletonList(
+                AgentToolCall.builder().callId(callId).name(toolName).arguments("{}").type("function").build()));
+    }
+
+    /** Mirrors an OpenAI Responses API reasoning item once it has round-tripped through JSON. */
+    private static Map<String, Object> reasoning(String id, String text) {
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("type", "reasoning");
+        item.put("id", id);
+        item.put("summary", new ArrayList<Object>(Collections.<Object>singletonList(text)));
+        return item;
+    }
+
+    private static String outputOf(List<Object> items, String callId) {
+        for (Object item : items) {
+            if (item instanceof Map && callId.equals(((Map<?, ?>) item).get("call_id"))) {
+                Object output = ((Map<?, ?>) item).get("output");
+                return output == null ? null : String.valueOf(output);
+            }
+        }
+        return null;
+    }
+
+    private static String repeat(char c, int times) {
+        StringBuilder sb = new StringBuilder(times);
+        for (int i = 0; i < times; i++) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/memory/AgentMemoryRestoreSummaryTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/ai4j/agent/memory/AgentMemoryRestoreSummaryTest.java
@@ -1,0 +1,107 @@
+package io.github.lnyocly.ai4j.agent.memory;
+
+import io.github.lnyocly.ai4j.agent.util.AgentInputItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * The {@link AgentMemory#restore(MemorySnapshot)} default used to drop
+ * {@link MemorySnapshot#getSummary()}, so a Tier-3 compaction summary vanished on the next restore
+ * and the following turn's prompt lost it. These cover the default path — the one implementations
+ * that don't override {@code restore} inherit — plus the two shipped implementations.
+ */
+public class AgentMemoryRestoreSummaryTest {
+
+    @Test
+    public void defaultRestoreKeepsSummary() {
+        AgentMemory memory = new MinimalAgentMemory();
+        memory.restore(MemorySnapshot.from(
+                Arrays.<Object>asList(AgentInputItem.userMessage("hello")), "compacted summary"));
+
+        assertEquals("compacted summary", memory.getSummary());
+        assertEquals("compacted summary", memory.snapshot().getSummary());
+        assertEquals(1, memory.snapshot().getItems().size());
+    }
+
+    @Test
+    public void defaultRestoreClearsSummaryForSummarylessSnapshot() {
+        AgentMemory memory = new MinimalAgentMemory();
+        memory.restore(MemorySnapshot.from(Arrays.<Object>asList("a"), "old summary"));
+        memory.restore(MemorySnapshot.from(Arrays.<Object>asList("b"), null));
+
+        assertNull("a summaryless snapshot must not resurrect the previous summary", memory.getSummary());
+    }
+
+    @Test
+    public void inMemoryRestoreKeepsSummary() {
+        InMemoryAgentMemory memory = new InMemoryAgentMemory();
+        memory.addUserInput("scratch");
+        memory.restore(MemorySnapshot.from(Arrays.<Object>asList(AgentInputItem.userMessage("kept")), "summary"));
+
+        assertEquals("summary", memory.getSummary());
+        assertEquals("summary survives a snapshot round-trip", "summary",
+                memory.snapshot().getSummary());
+    }
+
+    @Test
+    public void jdbcRestoreKeepsSummary() {
+        JdbcAgentMemory memory = new JdbcAgentMemory(JdbcAgentMemoryConfig.builder()
+                .jdbcUrl("jdbc:h2:mem:restore-summary;DB_CLOSE_DELAY=-1")
+                .sessionId("agent-restore")
+                .build());
+        memory.restore(MemorySnapshot.from(Arrays.<Object>asList(AgentInputItem.userMessage("kept")), "summary"));
+
+        assertEquals("summary", memory.getSummary());
+    }
+
+    /** An implementation that relies on the interface defaults for snapshot/restore. */
+    private static final class MinimalAgentMemory implements AgentMemory {
+
+        private final List<Object> items = new ArrayList<Object>();
+        private String summary;
+
+        @Override
+        public void addUserInput(Object input) {
+            items.add(input);
+        }
+
+        @Override
+        public void addOutputItems(List<Object> outputItems) {
+            if (outputItems != null) {
+                items.addAll(outputItems);
+            }
+        }
+
+        @Override
+        public void addToolOutput(String callId, String output) {
+            items.add(AgentInputItem.functionCallOutput(callId, output));
+        }
+
+        @Override
+        public List<Object> getItems() {
+            return new ArrayList<Object>(items);
+        }
+
+        @Override
+        public String getSummary() {
+            return summary;
+        }
+
+        @Override
+        public void setSummary(String summary) {
+            this.summary = summary;
+        }
+
+        @Override
+        public void clear() {
+            items.clear();
+            summary = null;
+        }
+    }
+}

--- a/docs-site/docs/agent/memory-compact-context.md
+++ b/docs-site/docs/agent/memory-compact-context.md
@@ -48,15 +48,97 @@ P0-B 的价值是让这三层可以被保存、投影、压缩和诊断，而不
 
 | 类 | 包 | 职责 |
 | --- | --- | --- |
-| `ContextBudget` | `io.github.lnyocly.ai4j.agent.context` | 描述上下文预算，例如最大 item 数、近似字符数、保留前缀数量 |
+| `ContextBudget` | `io.github.lnyocly.ai4j.agent.context` | 描述上下文预算，例如最大 item 数、近似字符数、保留前缀数量、Tier-1/2 分级开关 |
 | `ContextProjector` | `io.github.lnyocly.ai4j.agent.context` | 把 memory items 投影成本轮 prompt items |
 | `DefaultContextProjector` | `io.github.lnyocly.ai4j.agent.context` | 默认投影器：保留 pinned prefix 和 recent tail |
+| `TypeAwareContextProjector` | `io.github.lnyocly.ai4j.agent.context` | 类型感知投影器：Tier-1 工具结果 microcompact + Tier-2 reasoning 裁剪 |
 | `ContextProjection` | `io.github.lnyocly.ai4j.agent.context` | 投影后的 items 和报告 |
 | `ContextReport` | `io.github.lnyocly.ai4j.agent.context` | 记录投影前后 item 数、近似字符数、drop 数和 notes |
 | `CompactPolicy` | `io.github.lnyocly.ai4j.agent.compact` | 压缩策略接口 |
 | `CompactResult` | `io.github.lnyocly.ai4j.agent.compact` | 结构化 compact 结果 |
 | `StructuredSummaryCompactPolicy` | `io.github.lnyocly.ai4j.agent.compact` | 内置确定性结构摘要策略 |
+| `LlmCompactPolicy` | `io.github.lnyocly.ai4j.agent.compact` | Tier-3：LLM 结构化摘要，回填 `CompactResult` 字段 |
 | `CompactPolicyMemoryCompressor` | `io.github.lnyocly.ai4j.agent.compact` | 把 `CompactPolicy` 适配成已有 `MemoryCompressor` |
+
+## 2.5 三层分级压缩：投影 vs 压缩
+
+上面两个边界（`ContextProjector` / `CompactPolicy`）合起来是**三层分级**，代价和破坏性逐层升高：
+
+| 层 | 落在哪 | 触发 | 依赖 LLM | 改 memory？ |
+| --- | --- | --- | --- | --- |
+| **Tier-1** 工具结果 microcompact | `TypeAwareContextProjector` | 每轮 | 否 | **否**（只改投影） |
+| **Tier-2** reasoning 裁剪 | `TypeAwareContextProjector` | 每轮（需开关） | 否 | **否**（只改投影） |
+| **Tier-3** LLM 摘要 | `LlmCompactPolicy` | 阈值触发 | 是 | **是**（`memory.restore`） |
+
+关键区别，也是这套设计的核心：
+
+```text
+Tier-1/2 = 投影层。memory 里事实还在，只是这一轮模型看不到。
+Tier-3   = 压缩层。memory 被 summary 替换，旧 item 真的没了。
+```
+
+**所以 Tier-1 可以很激进。** 裁掉的工具结果不是删除——原文还躺在 memory 里，Tier-3 摘要时仍取得到完整内容，replay 和审计也不受影响。这一点和 Claude Code 不同：那边 microcompact 是就地改消息数组，裁了就是裁了。
+
+### Tier-1：只留最近 N 条工具结果
+
+工具结果是最占地方的东西：读一个大文件、跑一次测试，几千字符进 memory，但三轮之后模型基本不会再回头看。
+
+```java
+Agent agent = Agents.react()
+    .modelClient(modelClient)
+    .model("gpt-4.1")
+    .contextProjector(new TypeAwareContextProjector())
+    .contextBudget(ContextBudget.builder()
+        .maxItems(40)
+        .maxRecentToolResults(5)   // 只有最近 5 条工具结果保留原文
+        .build())
+    .build();
+```
+
+更早的 `function_call_output` 会被替换成占位符，而不是直接抽走：
+
+```text
+{type: function_call_output, call_id: call-3, output: "[tool result cleared: read(call-3)]"}
+```
+
+留占位符是刻意的——模型需要知道"这里调过 read，结果现在不在了"，而不是看到一段凭空消失的历史。工具名靠 `call_id` join 回 assistant 消息的 `tool_calls[].id` 拿到（`function_call_output` 本身只有 `call_id`，没有工具名）。
+
+`maxRecentToolResults` 不配（默认 `null`）时 Tier-1 不启用，`TypeAwareContextProjector` 的行为与 `DefaultContextProjector` **完全一致**——这是有回归测试守住的向后兼容契约。
+
+### Tier-2：清掉旧轮次的 reasoning
+
+```java
+ContextBudget.builder()
+    .maxRecentToolResults(5)
+    .trimOldReasoning(true)     // 默认 false
+    .build();
+```
+
+只清**最后一条 user 消息之前**的 `reasoning` item——当前轮的推理链保留，因为模型可能还在上面继续。item 的 `type` 和 `id` 保留，只清 payload，序列结构不破。
+
+:::note 只对 Responses API 形态生效
+`reasoning` 作为独立 memory item 存在，是 OpenAI Responses API 的形态。Anthropic / OpenAI Chat 路径下 reasoning 走 `AgentModelResult.reasoningText`，本来就不进 memory，Tier-2 对它们是空操作。
+:::
+
+### 哪一层生效：看 ContextReport.notes
+
+三层都发 `MEMORY_COMPRESS` 事件，靠 `notes` 区分：
+
+```text
+tier1 microcompact: cleared 3 old tool result(s), kept recent 5
+tier2 reasoning-trim: cleared 2 reasoning item(s)
+maxItems applied: 40
+```
+
+### 和 Claude Code 的对照
+
+| Claude Code | AI4J | 差异 |
+| --- | --- | --- |
+| Tier-1 microcompact（每轮清旧工具结果） | `TypeAwareContextProjector` + `maxRecentToolResults` | AI4J 走投影不改 memory；keep-N 可配，非硬编码 |
+| Tier-2 类型感知裁剪 | `trimOldReasoning` | Claude Code 该层部分是 API 服务端行为，AI4J 作为 SDK 只做客户端可控的部分 |
+| Tier-3 九段结构化摘要 | `LlmCompactPolicy` | AI4J 是七段（见下）；`sandboxState`/`userConfirmations` 属 coding-agent 场景，不在 core agent 层强求 |
+| `cache_edits`（prompt cache 外科删除） | 不做 | 需要服务端协同，SDK 侧无对应物 |
+
 
 ## 3. Context Projector：控制本轮 prompt
 
@@ -225,7 +307,14 @@ System.out.println(result.getContextReport().getDroppedItemCount());
 - `openQuestions`
 - `contextReport`
 
-当前内置策略是确定性基础策略，不会伪装成模型级语义抽取器。后续可以由插件或业务方提供更强的 `CompactPolicy`，例如调用模型把事件日志提炼成这些结构化字段。
+这些字段的填充情况按策略分：
+
+| 策略 | 填哪些字段 |
+| --- | --- |
+| `StructuredSummaryCompactPolicy`（确定性） | 只填 `contextReport`；不做语义抽取 |
+| `LlmCompactPolicy`（Tier-3） | 填 `completed` / `pending` / `decisions` / `failedCommands` / `testResults` / `openQuestions`，外加机械扫描得到的 `readFiles` / `modifiedFiles` |
+
+`changedArtifacts` / `userConfirmations` / `sandboxState` 仍然留空——它们需要 workspace 和 approval 上下文，属于 `ai4j-coding` 的地盘，core agent 层不硬凑。
 
 ## 7. 与 AgentSession 的关系
 
@@ -301,8 +390,7 @@ InMemoryAgentMemory memory = new InMemoryAgentMemory(compressor);
 
 P0-B 是基础层，不包含：
 
-- 模型驱动的自动语义提取。
-- token 级精确预算。
+- token 级精确预算（`ContextBudget` 的字符数是近似值）。
 - event log 到 compact result 的完整提炼。
 - sandbox artifact 的真实压缩。
 - 远端 Runner 的 checkpoint 协议。
@@ -330,9 +418,34 @@ Agent agent = Agents.react()
         .build();
 ```
 
-`LlmCompactPolicy` keeps the most recent N items and asks the LLM to summarize everything older
-into a structured summary (Goal/Progress/Key Decisions/Critical Context). For a mechanical
-(non-LLM) option, use `StructuredSummaryCompactPolicy` with a `ContextBudget`.
+`LlmCompactPolicy` keeps the most recent N items and asks the LLM to summarize everything older.
+For a mechanical (non-LLM) option, use `StructuredSummaryCompactPolicy` with a `ContextBudget`.
+
+### Structured backfill
+
+The summarizer is asked for a JSON object, which is parsed back into `CompactResult`:
+
+```text
+goal · completed · pending · decisions · errors · testResults · openQuestions
+        ↓           ↓         ↓           ↓        ↓             ↓
+   getCompleted  getPending  getDecisions  getFailedCommands  getTestResults  getOpenQuestions
+```
+
+The JSON is then rendered into a section-formatted summary (`## Goal`, `## Pending`, …) rather than
+stored raw, because that summary is what gets injected as a system message on the next turn.
+
+Parsing is deliberately forgiving — a summarizer is a model, not a schema-guaranteed API:
+
+- ```` ```json ```` fences and surrounding prose are tolerated (first `{` to last `}` is extracted).
+- A single string where an array was requested is accepted as a one-element list.
+- **Unparseable output is not an error.** The raw text becomes the summary and the lists stay empty —
+  exactly the pre-structured behaviour. A prose-returning model degrades, it does not break compaction.
+
+Cross-compaction accumulation needs no extra state: the rendered summary already contains the
+`Pending` and `Key Decisions` sections, and it is fed back in as `Previous summary` on the next
+compaction, where the prompt instructs the model to carry unresolved entries forward. Because the
+channel is the summary text itself, accumulation survives session save/resume — and cannot leak
+between sessions the way a stateful policy instance would.
 
 The `BEFORE_COMPACT` lifecycle hook fires before compaction (interception/customize);
 `ON_COMPACT` fires after (observe).
@@ -349,3 +462,9 @@ leaving assistant messages or tool results orphaned without their preceding cont
 (`read`/`grep`/`find` → readFiles; `write`/`edit`/`create`/`delete` → modifiedFiles), deduplicates,
 includes them in the summary prompt so the LLM knows what was touched, and carries them forward
 in `CompactResult.readFiles` / `CompactResult.modifiedFiles` for the next compaction to accumulate.
+
+### Restore keeps the summary
+
+`AgentMemory.restore(snapshot)` 会把 `snapshot.getSummary()` 一起写回，不再只恢复 items。Tier-3
+压缩产出的 summary 因此能跨 restore 存活——否则 resume/compact 一轮之后摘要就丢了，下一轮 prompt
+取不到它。该行为同时覆盖默认实现和 `InMemoryAgentMemory` / `JdbcAgentMemory`。


### PR DESCRIPTION
## 做了什么

按"改不改 memory"把上下文压缩分成三层，对齐 Claude Code 的分级压缩思路。投影与压缩的既有边界不变：Tier-1/2 只投影，Tier-3 才动 memory。

| 层 | 触发 | 手段 | 是否改 memory |
|---|---|---|---|
| Tier-1 | 预算内的常态 | 旧 `function_call_output` 换占位符 | 否 |
| Tier-2 | 预算偏紧 | 清旧的顶层 `reasoning` item payload | 否 |
| Tier-3 | 逼近上限 | LLM 结构化语义摘要 | 是 |

### Tier-1/2 — `TypeAwareContextProjector`（新增）

- 保留最近 `maxRecentToolResults` 条工具结果，更早的替换为 `[tool result cleared: <tool>(<callId>)]`。工具名由 `call_id` join assistant 消息的 `tool_calls[].id` 得到，因为 `function_call_output` 本身不带工具名。
- `trimOldReasoning` 清最后一条 user 消息之前的 reasoning payload，保留 `type`/`id`，当前轮思维链不动。
- 投影产出全新副本，不 mutate 源 item 及其 Map。

### Tier-3 — `LlmCompactPolicy`（增强）

摘要 prompt 由 4 段 freeform 改为要求 JSON，解析回填 `CompactResult` 的 `completed`/`pending`/`decisions`/`failedCommands`/`testResults`/`openQuestions`——这些字段此前一直存在但内置策略从不填。

解析刻意宽容：容忍代码围栏与前后散文、单字符串当单元素数组；彻底解析失败时退化为原文作 summary、列表留空。摘要模型返回散文不该让压缩失败。

### 顺带修的 bug

`AgentMemory.restore` 默认实现丢弃 `snapshot.getSummary()`，Tier-3 摘要活不过一次 restore。两个内置实现自己覆写了 `restore` 所以不受影响，这修的是不覆写 `restore` 的实现所继承的路径。

## 两处偏离原计划稿

**Tier-2 的目标形态。** 计划稿清的是 `content` 数组里的 `thinking` block，但该形态在本仓库 memory 中不存在——Anthropic（`MessagesModelClient.java:541`）和 OpenAI Chat（`ChatModelClient.java:422`）的思维链走 `AgentModelResult.reasoningText`，从不进 memory items；只有 Responses API 以顶层 `type:reasoning` item 入 memory。照抄会在除 Responses API 外所有 provider 上成为静默空操作。已按真实形态重写，该限制写进文档。

**不 mutate 源 Map。** 计划稿就地 `blockMap.put(...)`，破坏"投影不改 memory"这条让 Tier-1 敢激进的不变量。改为替换副本，`doesNotMutateSourceItemsOrTheirMaps` 锁死。

## 向后兼容

`maxRecentToolResults` 未配置时，`TypeAwareContextProjector` 与 `DefaultContextProjector` 逐项、逐 note 一致，5 种 budget 组合有回归测试守住。所有新字段默认关闭，现有调用方零改动。

## 验证

- `mvn -pl ai4j-agent test`：**385 tests, 0 failures, 0 errors**（新增 19：projector 9 + Tier-3 结构化 6 + restore summary 4）
- `docs-site npm run build`：SUCCESS，无坏链
