### PR TITLE
docs(agents): 加 Scope Limits——界定提什么修法，不界定看什么

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,38 @@ When reviewing changes in this repo, prioritize:
 3. Runtime / CLI / FlowGram behavioral regressions
 4. Missing regression updates for newly touched surfaces
 5. Drift between code changes and docs/reference guidance
+
+## Scope Limits
+
+These bound what you **propose**, never what you look for. Report anything that is actually wrong here — including a rare-looking case, if this project actually produces it. Then keep the fix in scope.
+
+1. This is not a security paper. Verification is welcome; over-defense is not. Unless this project states otherwise, assume a cooperating operator on their own machine; if it has a real adversary, it will say so and that scope wins.
+2. Do not add hashes, checksums, or fingerprints unless the hash replaces a materially more expensive operation **and** its result changes what happens next.
+3. No defensive scaffolding: no feature flags, migration frameworks, compat layers, or wrappers for cases that do not occur here.
+4. No corner-case obsession: exotic encodings, symlink races, RTL text, and millisecond races are out of scope unless the case is reachable through this project's supported use — its documented inputs, its published interface, its real data. Reachable is enough; you do not need a reproduction. Constructible in principle is not enough.
+5. Where judgement is needed, judge. Do not replace it with a scoring table, a checklist, or a re-verification loop over something already settled.
+6. None of this overrides security, migration, verification, or review that the user, this project's own conventions, or a higher-priority rule asked for. Those were requested; they are the work, not scope creep.
+
+### Calibration
+
+Shapes already seen. Examples, not a checklist — a real finding is not dismissed by resembling one:
+
+| | Shape |
+|---|---|
+| H | hashing every row of two spreadsheets to answer what comparing cells answers |
+| H | writing checksum files that nothing ever reads |
+| E | hardening the accounts of an app that has no users and no deployment |
+| R | auditing your own patch all night while the feature stays unwritten |
+| R | a reviewer that returns a failing verdict on everything |
+| O | guards whose justification is the previous guard, not the requirement |
+
+And two that look like the above and are not. **Report these:**
+
+| | Shape |
+|---|---|
+| ✓ | a digest that lets you skip re-reading a large file you already have |
+| ✓ | a rare-looking input this project's own documentation example produces |
+
+Before running any check, answer: what specific failure would this detect, and what would I do differently if it occurred? No answer means do not run it.
+
+Say plainly when something is correct. Do not manufacture findings.


### PR DESCRIPTION
## 做了什么

`AGENTS.md` 末尾新增 `## Scope Limits` + `### Calibration`，+35 行，只动这一个文件。

这节约束的是 agent **提什么修法**，不是**排查到什么程度**。实际存在的问题照报——包括本项目真会产出的罕见输入——但修法要留在范围内。

六条硬规则：

1. 默认协作型操作者在自己机器上，除非项目另有声明；真有对手时以项目声明为准。
2. 哈希 / 校验和 / 指纹只在替代了显著更贵的操作**且**结果影响后续分支时才加。
3. 不为本项目不会出现的情况加 feature flag、迁移框架、兼容层、包装器。
4. 罕见路径要「经本项目支持用法可达」（文档化输入、公开接口、真实数据）；可达就够，不需要复现，但仅理论上可构造不算。
5. 需要判断的地方就判断，不用评分表 / 清单 / 对已定事项的复核循环替代。
6. 不覆盖用户、项目惯例或更高优先级规则明确要求的安全 / 迁移 / 验证 / 审查——那些是被要求的工作，不是范围蔓延。

另附校准样例表，含两个「形似过度设计但应当上报」的反例（能省掉重读大文件的摘要；本项目文档示例自己就会产出的罕见输入），以及一条前置自问：这个检查能发现什么具体故障、发现了我会做什么不同的事——答不上就别跑。

## 为什么放在 Review Focus 之后

它约束的正是「审查时提什么」，紧挨着那五条审查优先项读起来才连贯。

## 体例

跟随文件既有约定：英文正文、`##` 分节、编号硬规则、表格代替缩进列表（与 `Monorepo Scope`、`Task-Type Reading Matrix` 一致）。

依 `CLAUDE.md`，`AGENTS.md` 是 agent 指令的唯一权威入口，规则不向别处复制，因此这份新增只存在这一处，不会两套规则漂移。

## 验证

纯指令文档变更，不涉及代码、构建或 `docs-site`（`AGENTS.md` 在仓库根，非 Docusaurus 内容目录）。
