### PR TITLE
docs(a2a): 修编译不过的示例——删 server.start()、补 getPort()/getBaseUrl()

### DIFF
--- a/docs-site/docs/agent/a2a.md
+++ b/docs-site/docs/agent/a2a.md
@@ -115,6 +115,8 @@ A2AServer server = new A2AServer(
         "does stuff", // description
         "secret-key"  // optional shared-secret auth (null = open)
 );
+int port = server.getPort();        // actual port when 0 = auto-assign
+String baseUrl = server.getBaseUrl(); // http://localhost:<port>
 
 // External agents (LangChain, CrewAI, etc.) can now call:
 //   GET  http://localhost:PORT/.well-known/agent-card.json  → AgentCard
@@ -175,8 +177,6 @@ List<SkillDescriptor> allowedSkills = resolver.resolveAllowedSkills(currentTenan
 
 // 把 ai4j Skills 发布为 AgentCard 上的 A2A skills
 A2ASkillMapper.addSkillsToServer(server, allowedSkills);
-
-server.start();
 ```
 
 :::warning 映射不等于授权


### PR DESCRIPTION
## 做了什么

`docs-site/docs/agent/a2a.md` 两处示例 bug,各改一处:

1. **删 `server.start()`(编译不过)** —— Skills 发布示例末尾调了 `server.start()`,但 `A2AServer` 没有 public `start()` 方法。服务在构造器里就启动了(源码里唯一的 `start()` 是内部 JDK `HttpServer.start()`)。复制示例即编译失败。
2. **补 `getPort()` / `getBaseUrl()`** —— Server 示例用 `port = 0` 自动分配端口,却从不展示怎么拿到实际监听端口。补上与方法实际签名一致的两行(`A2AServer.getPort()` / `getBaseUrl()`,源码 148/152 行)。

## 不在本 PR 范围

A2A 文档更深的缺口——客户端 push-notification 配置 CRUD(5 方法)整组缺失、缺「Server 内部机制 / 当前限制」专节、`asToolRegistry()` / `a2aRegistry` 示例变量未定义、`withPushNotificationUrlValidator` 签名——另立 HA 任务做深度补充。本 PR 只收「阻塞 + 自相矛盾」两行。

## 验证

- `docs-site npm run build`:SUCCESS,无坏链。
- 方法签名已对源码核过:`A2AServer` 无 public `start()`;`getPort()`/`getBaseUrl()` 存在于 148/152 行。
