### PR TITLE
docs(i18n): 搭建英文 locale 脚手架(双 locale + 首页翻译)

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
   onBrokenLinks: 'throw',
   i18n: {
     defaultLocale: 'zh-Hans',
-    locales: ['zh-Hans'],
+    locales: ['zh-Hans', 'en'],
   },
   presets: [
     [
@@ -244,6 +244,10 @@ const config: Config = {
         },
         {
           type: 'search',
+          position: 'right',
+        },
+        {
+          type: 'localeDropdown',
           position: 'right',
         },
         {

--- a/docs-site/i18n/en/code.json
+++ b/docs-site/i18n/en/code.json
@@ -1,0 +1,364 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View all tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 item|{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read more",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "Everywhere"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "1 document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No documents were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "No results"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "See all results outside \"{context}\""
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "See all results within \"{context}\""
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View all authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/docs-site/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/docs-site/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,98 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Start Here": {
+    "message": "Start Here",
+    "description": "The label for category 'Start Here' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Core SDK": {
+    "message": "Core SDK",
+    "description": "The label for category 'Core SDK' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Model Access": {
+    "message": "Model Access",
+    "description": "The label for category 'Model Access' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Tools and Skills": {
+    "message": "Tools and Skills",
+    "description": "The label for category 'Tools and Skills' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Memory and RAG": {
+    "message": "Memory and RAG",
+    "description": "The label for category 'Memory and RAG' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.MCP": {
+    "message": "MCP",
+    "description": "The label for category 'MCP' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category 'Integrations' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Spring Boot": {
+    "message": "Spring Boot",
+    "description": "The label for category 'Spring Boot' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Extensions": {
+    "message": "Extensions",
+    "description": "The label for category 'Extensions' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Agent Runtime": {
+    "message": "Agent Runtime",
+    "description": "The label for category 'Agent Runtime' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Runtimes and Orchestration": {
+    "message": "Runtimes and Orchestration",
+    "description": "The label for category 'Runtimes and Orchestration' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Observability and Interoperability": {
+    "message": "Observability and Interoperability",
+    "description": "The label for category 'Observability and Interoperability' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Coding Agent": {
+    "message": "Coding Agent",
+    "description": "The label for category 'Coding Agent' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.coding-agent-advanced": {
+    "message": "Architecture and Advanced Use",
+    "description": "The label for category 'Architecture and Advanced Use' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.FlowGram": {
+    "message": "FlowGram",
+    "description": "The label for category 'FlowGram' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.flowgram-advanced": {
+    "message": "Architecture and Advanced Use",
+    "description": "The label for category 'Architecture and Advanced Use' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Solutions": {
+    "message": "Solutions",
+    "description": "The label for category 'Solutions' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Operate": {
+    "message": "Operate",
+    "description": "The label for category 'Operate' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Reference": {
+    "message": "Reference",
+    "description": "The label for category 'Reference' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.API & Versions": {
+    "message": "API & Versions",
+    "description": "The label for category 'API & Versions' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Architecture & Maps": {
+    "message": "Architecture & Maps",
+    "description": "The label for category 'Architecture & Maps' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.About": {
+    "message": "About",
+    "description": "The label for category 'About' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Maintainers": {
+    "message": "Maintainers",
+    "description": "The label for category 'Maintainers' in sidebar 'tutorialSidebar'"
+  }
+}

--- a/docs-site/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs-site/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 1
+title: AI4J Docs
+description: "AI4J is a Java 8+ AI SDK entry point — an overview, recommended starting points, and a repository module map for its on-demand building blocks: model calls, tools, RAG, MCP, Spring Boot, Agent, Coding Agent, and FlowGram."
+tags: [concept]
+---
+
+# AI4J Docs
+
+AI4J is an AI SDK for `Java 8+`. It is not an all-or-nothing AI platform, but a
+set of Java AI building blocks you can take on demand: start with `ai4j` to get
+model calls working, then bring in Spring Boot, RAG, MCP, Agent, Coding Agent, or
+FlowGram as your project needs them.
+
+If you just want to fire off a first model request, start from plain Java or
+Spring Boot. If you already know you need tool calling, RAG, MCP, an Agent, or the
+Coding Agent, jump straight in from the feature map.
+
+## Start here
+
+| Goal | Recommended entry | What you get |
+| --- | --- | --- |
+| Send your first AI request in plain Java | [Quickstart for Java](/docs/start-here/quickstart-java) | Minimal deps, key config, validation, and your first model call |
+| Get a plain Java project working | [Quickstart for Java](/docs/start-here/quickstart-java) | Minimal deps, config, and your first snippet |
+| Integrate a Spring Boot app | [Quickstart for Spring Boot](/docs/start-here/quickstart-spring-boot) | The starter, config properties, and bean injection |
+| See the full capability surface | [Feature Map](/docs/start-here/feature-map) | Current AI4J capabilities, maturity, and reading paths |
+| Find the canonical doc routes | [Documentation Map](/docs/start-here/documentation-map) | Canonical main lines, legacy sources, and migration directions |
+| Pre-launch checks | [Production Checklist](/docs/operations/production-checklist) | Checks for versions, keys, tools, MCP, RAG, Agent, FlowGram |
+| Understand why AI4J exists | [Why AI4J](/docs/start-here/why-ai4j) | Positioning, fit, and differences from adjacent options |
+
+## Take what you need
+
+You don't need to understand all of AI4J up front, nor pull every module into
+your project. The saner path is to take one module for the problem in front of
+you, then upgrade to the next layer when things get more complex.
+
+| What you want to do now | Take | When to upgrade |
+| --- | --- | --- |
+| Model calls, tools, RAG, MCP | `ai4j` | Add the Spring Boot starter when you need containerized config |
+| Add AI to a Spring Boot app | `ai4j-spring-boot-starter` | Add an Agent when you need richer state or orchestration |
+| Build an embeddable Agent runtime | `ai4j-agent` | Add the Coding Agent when you need codebase tasks |
+| A local entry point for codebase tasks | `ai4j-coding` + `ai4j-cli` | Extend the command layer when you need a productized CLI / TUI |
+| Hook up FlowGram visual workflows | `ai4j-flowgram-spring-boot-starter` | Look at the FlowGram demo when you need a full demo |
+| Align versions across modules | `ai4j-bom` | Use when a project pulls multiple AI4J artifacts |
+
+## What AI4J covers
+
+AI4J's capabilities sit in layers. We recommend getting the Core SDK working
+first, then upgrading upward as your project needs.
+
+| Layer | Capabilities | Entry |
+| --- | --- | --- |
+| Core SDK | `Chat`, `Responses`, streaming, multimodal, image, audio, embedding, rerank | [Core SDK / Model Access](/docs/core-sdk/model-access/overview) |
+| Capability wiring | Function call, local tools, Skills, MCP | [Tools](/docs/core-sdk/tools/overview), [Skills](/docs/core-sdk/skills/overview), [MCP](/docs/mcp/overview) |
+| Data augmentation | Memory, search, RAG, VectorStore, ingestion, hybrid retrieval | [Search & RAG](/docs/core-sdk/search-and-rag/overview) |
+| App integration | Spring Boot starter, config governance, auto-configuration | [Spring Boot](/docs/spring-boot/overview) |
+| Upper runtimes | Agent, Coding Agent, FlowGram workflows | [Agent](/docs/agent/overview), [Coding Agent](/docs/coding-agent/overview), [FlowGram](/docs/flowgram/overview) |
+| Scenario solutions | Common combinations and repeatable integration paths | [Solutions](/docs/solutions/overview) |
+| Production readiness | Version compatibility, release artifacts, security, migration, troubleshooting | [Version Compatibility](/docs/reference/version-compatibility), [Security](/docs/security/overview), [Troubleshooting](/docs/troubleshooting/overview) |
+
+## Three concepts, kept distinct
+
+AI4J docs deliberately separates three kinds of capabilities:
+
+- `Function Call / Tool`: lets the model invoke local functions or controlled tools.
+- `Skill`: on-demand assets the model reads — instructions, templates, flows, know-how.
+- `MCP`: brings in external tools, services, or capability gateways over a protocol.
+
+These compose, but their responsibilities differ. Keeping the boundaries clear is
+what keeps the downstream cost of using them low.
+
+## Repository module map
+
+| Module | Role |
+| --- | --- |
+| `ai4j/` | Core SDK: provider access, Chat, Responses, RAG, MCP, vector, image, audio, realtime |
+| `ai4j-spring-boot-starter/` | Spring Boot auto-configuration and app-side wiring |
+| `ai4j-agent/` | Agent runtime, workflow, trace, memory, team orchestration |
+| `ai4j-coding/` | Coding Agent runtime, workspace tools, outer loop, compaction |
+| `ai4j-cli/` | CLI, TUI, ACP host, and local session entry |
+| `ai4j-flowgram-spring-boot-starter/` | FlowGram integration, task APIs, trace bridge |
+| `ai4j-flowgram-demo/` and `ai4j-flowgram-webapp-demo/` | FlowGram backend and frontend demos |
+| `ai4j-bom/` | Maven version alignment |
+
+These modules exist so you can pull in only what you need right now, while leaving
+room to upgrade upward.
+
+Suggested next step: if you haven't run any code yet, start with the
+[Quickstart for Java](/docs/start-here/quickstart-java); if you'd rather first
+judge whether AI4J fits your project, read [Why AI4J](/docs/start-here/why-ai4j).

--- a/docs-site/i18n/en/docusaurus-theme-classic/footer.json
+++ b/docs-site/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,0 +1,82 @@
+{
+  "link.title.文档": {
+    "message": "Docs",
+    "description": "The title of the footer links column with title=文档 in the footer"
+  },
+  "link.title.资源": {
+    "message": "Resources",
+    "description": "The title of the footer links column with title=资源 in the footer"
+  },
+  "link.title.开源": {
+    "message": "Open Source",
+    "description": "The title of the footer links column with title=开源 in the footer"
+  },
+  "link.item.label.开始阅读": {
+    "message": "Start Reading",
+    "description": "The label of footer link with label=开始阅读 linking to /docs/intro"
+  },
+  "link.item.label.Coding Agent": {
+    "message": "Coding Agent",
+    "description": "The label of footer link with label=Coding Agent linking to /docs/coding-agent/overview"
+  },
+  "link.item.label.Core SDK": {
+    "message": "Core SDK",
+    "description": "The label of footer link with label=Core SDK linking to /docs/core-sdk/overview"
+  },
+  "link.item.label.MCP": {
+    "message": "MCP",
+    "description": "The label of footer link with label=MCP linking to /docs/mcp/overview"
+  },
+  "link.item.label.Agent": {
+    "message": "Agent",
+    "description": "The label of footer link with label=Agent linking to /docs/agent/overview"
+  },
+  "link.item.label.FlowGram": {
+    "message": "FlowGram",
+    "description": "The label of footer link with label=FlowGram linking to /docs/flowgram/overview"
+  },
+  "link.item.label.生产检查清单": {
+    "message": "Production Checklist",
+    "description": "The label of footer link with label=生产检查清单 linking to /docs/operations/production-checklist"
+  },
+  "link.item.label.API Reference": {
+    "message": "API Reference",
+    "description": "The label of footer link with label=API Reference linking to /docs/reference/api"
+  },
+  "link.item.label.版本与兼容性": {
+    "message": "Versions & Compatibility",
+    "description": "The label of footer link with label=版本与兼容性 linking to /docs/reference/version-compatibility"
+  },
+  "link.item.label.安全边界": {
+    "message": "Security",
+    "description": "The label of footer link with label=安全边界 linking to /docs/security/overview"
+  },
+  "link.item.label.选型对比": {
+    "message": "Comparison",
+    "description": "The label of footer link with label=选型对比 linking to /docs/comparison/overview"
+  },
+  "link.item.label.历史博客迁移映射": {
+    "message": "Blog Migration Map",
+    "description": "The label of footer link with label=历史博客迁移映射 linking to /docs/guides/blog-migration-map"
+  },
+  "link.item.label.Cloudflare Pages 部署指南": {
+    "message": "Cloudflare Pages Deployment",
+    "description": "The label of footer link with label=Cloudflare Pages 部署指南 linking to /docs/deploy/cloudflare-pages"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/LnYo-Cly/ai4j"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/LnYo-Cly/ai4j/issues"
+  },
+  "link.item.label.贡献指南": {
+    "message": "Contributing",
+    "description": "The label of footer link with label=贡献指南 linking to /docs/contributing"
+  },
+  "copyright": {
+    "message": "Copyright (c) 2026 AI4J Contributors · Built with Docusaurus",
+    "description": "The footer copyright"
+  }
+}

--- a/docs-site/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/docs-site/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "AI4J Docs",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "AI4J Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.文档": {
+    "message": "Docs",
+    "description": "Navbar item with label 文档"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
## 做了什么

为全站双语(181×2)打地基。这是 i18n 机制的脚手架 + 一页 canonical 翻译,证明管线通。

- `docusaurus.config.ts`:`locales` 加 `'en'`(defaultLocale 仍 `zh-Hans`),navbar 加 `localeDropdown` 切换器。
- `write-translations --locale en` 生成 theme 串骨架;`navbar.json`/`footer.json` 填英文(文档→Docs、资源→Resources、开源→Open Source、生产检查清单→Production Checklist 等)。`code.json`(92 串,主题默认已英文)和 `current.json`(24 串,sidebar label 源本英文)无需改。
- 翻译首页 `intro.md` → `i18n/en/.../intro.md` 作 canonical 首例,证明 docs 翻译管线通。

## 路由

- 中文(默认):`/ai4j/docs/...` 不变
- 英文:`/ai4j/docs/en/...` 新增,navbar 右上出现语言切换

## 验证

- `npm run build` 双 locale 均绿:`[zh-Hans] SUCCESS` → `build/`、`[en] SUCCESS` → `build/en/`。
- 修了一个 frontmatter 坑:EN description 的 ASCII 冒号被 YAML 当键值分隔符(中文版用全角`：`无此问题),已加双引号。

## 之后

剩余 180 页翻译按此管线逐批补(建议 workflow fan-out)。中文版的 factual 错(压缩时机/LlmCompactPolicy)由 PR #255 单独修,不在此 PR。
