### PR TITLE
docs(zh): 109 页英文标题中文化——侧边栏叶子与分区语言统一

### DIFF
--- a/docs-site/docs/agent/agent-blueprint.md
+++ b/docs-site/docs/agent/agent-blueprint.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 9
-title: Agent Blueprint YAML
+title: Agent 蓝图 YAML
 description: "用声明式 YAML 描述单 Agent 的模型、指令、工具、memory、compact、sandbox 与 workflow 参数，支持加载、校验与模板化，并由宿主提供依赖后创建可运行 Agent。"
 tags: [reference]
 ---
 
-# Agent Blueprint YAML
-
+# Agent 蓝图 YAML
 `AgentBlueprint` 是 `ai4j-agent` 的声明式单 Agent 配置模型。它解决的问题是：
 
 > 当 Java API 能动态组装 Agent 之后，如何让一个 Agent 的模型、指令、插件、工具、memory、compact、sandbox 开关和 workflow 参数可以被保存、分享、模板化和校验？
@@ -457,7 +456,7 @@ P1-B 仍不直接生成 `AgentPermissionPolicy`。Factory/host 可以在后续�
 - 要求用户审批
 - 只允许在 sandbox 中执行
 
-底层策略语义见 [Agent Approval / Permission Policy](/docs/agent/governance/approval-permission-policy)。
+底层策略语义见 [Agent 审批与权限策略](/docs/agent/governance/approval-permission-policy)。
 
 ## 10. 与 Sandbox 的关系
 

--- a/docs-site/docs/agent/agent-concepts.md
+++ b/docs-site/docs/agent/agent-concepts.md
@@ -73,7 +73,7 @@ ai4j 的文档按子系统组织（Core SDK / Agent Runtime / Coding Agent / MCP
 - **MCP** = 模型→外部工具服务器（cross-process）
 - **Skill** = 模型→方法论文档（no execution, just knowledge）
 
-详细的对比表和决策框架见 [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)。
+详细的对比表和决策框架见 [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)。
 :::
 
 ---
@@ -85,9 +85,9 @@ ai4j 的文档按子系统组织（Core SDK / Agent Runtime / Coding Agent / MCP
 | 概念 | 一句话 | 所在层 | 详细页 |
 |---|---|---|---|
 | **Memory / Chat Memory** | session 级事实存储（system/user/assistant/tool-call/tool-output/summary），存储与保留策略分离 | Core SDK | [Memory 总览](/docs/capabilities/chat-memory/overview) |
-| **Context Window Management** | 管理进入模型的上下文窗口大小（ContextBudget 限制条目/字符/pinned prefix） | Agent Runtime | [Context Window Management](/docs/agent/memory/context-window-management) |
+| **Context Window Management** | 管理进入模型的上下文窗口大小（ContextBudget 限制条目/字符/pinned prefix） | Agent Runtime | [上下文窗口管理](/docs/agent/memory/context-window-management) |
 | **Compaction** | 压缩上下文（ContextProjector 按策略裁剪/microcompact 工具结果/auto-compact 熔断） | Agent + Coding Agent | [Memory Compact Context](/docs/agent/memory/memory-compact-context) · [Compact & Checkpoint](/docs/products/coding-agent/compact-and-checkpoint) |
-| **Checkpoint / Resume** | 结构化存档 + 崩溃恢复（ResumeCache 跳过已完成副作用 + hash-chained 防篡改审计） | Agent + Coding Agent | [Replay, Recovery & Audit](/docs/agent/observability/replay-recovery-audit) · [Compact & Checkpoint](/docs/products/coding-agent/compact-and-checkpoint) |
+| **Checkpoint / Resume** | 结构化存档 + 崩溃恢复（ResumeCache 跳过已完成副作用 + hash-chained 防篡改审计） | Agent + Coding Agent | [重放、恢复与审计](/docs/agent/observability/replay-recovery-audit) · [Compact & Checkpoint](/docs/products/coding-agent/compact-and-checkpoint) |
 
 :::note 跨层注意
 Compaction 和 Checkpoint 在 Agent Runtime 和 Coding Agent 两个层都有实现，各层关注点不同：
@@ -108,7 +108,7 @@ Compaction 和 Checkpoint 在 Agent Runtime 和 Coding Agent 两个层都有实�
 | **Agent Loop (ReAct / CodeAct)** | 单 agent 的 think→act→observe 循环；ReAct 用 tool-call、CodeAct 用代码执行 | Agent Runtime | [Minimal React Agent](/docs/agent/runtimes/minimal-react-agent) · [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime) |
 | **DAG / Workflow Orchestration** | 把多个 agent 步骤编排成有向无环图（StateGraph），声明节点 + 边 + 条件分支 | Agent Runtime | [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph) |
 | **Subagents** | 主 agent 把子任务委派给隔离的子 agent（独立 memory + tool + session） | Agent Runtime | [Subagent Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy) |
-| **Agent Teams** | 多个 agent 组成团队，通过 TaskBoard 协调任务分配、并行执行、结果汇总 | Agent Runtime | [Agent Teams](/docs/agent/orchestration/agent-teams) |
+| **Agent Teams** | 多个 agent 组成团队，通过 TaskBoard 协调任务分配、并行执行、结果汇总 | Agent Runtime | [Agent 团队](/docs/agent/orchestration/agent-teams) |
 
 ---
 
@@ -119,7 +119,7 @@ Compaction 和 Checkpoint 在 Agent Runtime 和 Coding Agent 两个层都有实�
 | 概念 | 一句话 | 所在层 | 详细页 |
 |---|---|---|---|
 | **Sandbox** | 隔离代码执行环境（E2B / Daytona / CubeSandbox），agent 在远程沙箱里跑代码 | Agent Runtime | [Sandbox SPI](/docs/agent/governance/sandbox-spi) · [CubeSandbox](/docs/agent/governance/cubesandbox-provider) |
-| **Lifecycle Hooks** | 在 PreToolUse / PostToolUse / Stop 等事件点拦截、审批或观察 agent 行为 | Agent + Coding Agent | [Plugin Lifecycle Hooks](/docs/agent/governance/plugin-lifecycle-hooks) · [Lifecycle Hooks](/docs/products/coding-agent/lifecycle-hooks) |
+| **Lifecycle Hooks** | 在 PreToolUse / PostToolUse / Stop 等事件点拦截、审批或观察 agent 行为 | Agent + Coding Agent | [插件生命周期钩子](/docs/agent/governance/plugin-lifecycle-hooks) · [Lifecycle Hooks](/docs/products/coding-agent/lifecycle-hooks) |
 | **Plugin / Extension** | 第三方打 jar 贡献 tool/command/skill/prompt，经 discover→enable→expose 三段式门禁 | Core SDK (extension-api) | [Extension 总览](/docs/extending/overview) · [扩展 ai4j](/docs/extending/extend-ai4j) |
 | **Workspace Trust** | 首次进入未信任目录时暂停问 y/n，`~/.ai4j/trusted-dirs.txt` 管理；`ai4j cli trust` 命令 | Coding Agent | [Lifecycle Hooks & Trust](/docs/products/coding-agent/lifecycle-hooks) |
 
@@ -141,7 +141,7 @@ Compaction 和 Checkpoint 在 Agent Runtime 和 Coding Agent 两个层都有实�
 | 概念 | 一句话 | 所在层 | 详细页 |
 |---|---|---|---|
 | **Agent Trace / Observability** | runtime 发布统一事件流（MODEL_REQUEST / TOOL_CALL / TOOL_RESULT），trace 消费并折叠成 span 导出到 OTel / Langfuse / JSONL | Agent Runtime | [Trace 与可观测性](/docs/agent/observability/trace-observability) |
-| **Replay / Audit** | 节点级 I/O 重放（live/mock）、崩溃续跑（ResumeCache）、防篡改 hash-chained 审计日志 | Agent Runtime | [Replay, Recovery & Audit](/docs/agent/observability/replay-recovery-audit) |
+| **Replay / Audit** | 节点级 I/O 重放（live/mock）、崩溃续跑（ResumeCache）、防篡改 hash-chained 审计日志 | Agent Runtime | [重放、恢复与审计](/docs/agent/observability/replay-recovery-audit) |
 
 :::note 事件流是基础
 Trace 和 Replay 都是 runtime 事件流的**消费者**，不是埋点——事件已经发布了，trace/replay 只是决定怎么消费。这意味着你可以在不改动 agent 代码的前提下，随时加 trace 导出或 replay 恢复。
@@ -169,7 +169,7 @@ Trace 和 Replay 都是 runtime 事件流的**消费者**，不是埋点——�
 | 概念 | 一句话 | 所在层 | 详细页 |
 |---|---|---|---|
 | **Session Management** | AgentSession 作为有状态长运行容器（sessionId + 独立 memory + event log + snapshot/restore） | Agent + Coding Agent | [Session Runtime](/docs/agent/session-runtime) · [Coding Session Runtime](/docs/products/coding-agent/session-runtime) |
-| **Prompt / System Prompt** | systemPrompt（运行时指令合并）vs instructions（独立保留）的字段语义 + coding-agent 的 prompt 组装管线 | Agent + Coding Agent | [System Prompt vs Instructions](/docs/agent/system-prompt-vs-instructions) · [Prompt Assembly](/docs/products/coding-agent/prompt-assembly) |
+| **Prompt / System Prompt** | systemPrompt（运行时指令合并）vs instructions（独立保留）的字段语义 + coding-agent 的 prompt 组装管线 | Agent + Coding Agent | [系统提示词与指令](/docs/agent/system-prompt-vs-instructions) · [Prompt Assembly](/docs/products/coding-agent/prompt-assembly) |
 | **Harness / Coding Agent** | 完整的终端 coding agent 宿主（CLI/TUI + ACP + sandbox-routing + tools + approvals + compaction） | Coding Agent | [Coding Agent 总览](/docs/products/coding-agent/overview) · [编程式集成](/docs/getting-started/programmatic-integration) |
 
 ---
@@ -184,8 +184,8 @@ Trace 和 Replay 都是 runtime 事件流的**消费者**，不是埋点——�
 
 ## 继续阅读
 
-- [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)——能力三角的详细消歧
+- [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)——能力三角的详细消歧
 - [Agent Runtime 总览](/docs/agent/overview)——agent 子系统的完整入口
 - [扩展 ai4j](/docs/extending/extend-ai4j)——插件/Skill/Prompt/自定义 provider 的聚合入口
 - [编程式集成](/docs/getting-started/programmatic-integration)——SDK/RPC/事件流/TUI 的聚合入口
-- [Feature Map](/docs/getting-started/feature-map)——功能成熟度地图
+- [功能地图](/docs/getting-started/feature-map)——功能成熟度地图

--- a/docs-site/docs/agent/architecture.md
+++ b/docs-site/docs/agent/architecture.md
@@ -1,11 +1,10 @@
 ---
-title: Agent Architecture
+title: Agent 架构
 description: "拆解 ai4j-agent 的 Builder、Runtime、ModelClient 三层边界，工具声明与执行双面，memory 作为状态源，以及事件流与 trace 的架构定位。"
 tags: [concept]
 ---
 
-# Agent Architecture
-
+# Agent 架构
 `ai4j-agent` 的架构核心，不是“封装一下模型调用”，而是把多步推理、工具调用、状态延续和可观测性收敛成一套可复用 runtime。
 
 如果你把它当成一个“大一点的 SDK helper”，很多设计都会显得复杂；一旦把它当成“通用 Agent runtime”，这些分层就会合理很多。
@@ -471,7 +470,7 @@ TOOL_ERROR: {...}
 ## 12. 继续阅读
 
 1. [Quickstart](/docs/agent/quickstart)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
-4. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
+4. [运行时实现](/docs/agent/runtimes/runtime-implementations)
 5. [Trace 与可观测性](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/governance/approval-permission-policy.md
+++ b/docs-site/docs/agent/governance/approval-permission-policy.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 8
-title: Agent Approval / Permission Policy
+title: Agent 审批与权限策略
 description: "AgentPermissionPolicy 在工具执行前做权限判断：ALLOW / DENY / REQUIRE_APPROVAL，可被普通 Agent、Blueprint、CLI 审批界面与后续 Sandbox SPI 复用。"
 tags: [concept]
 ---
 
-# Agent Approval / Permission Policy
-
+# Agent 审批与权限策略
 `AgentPermissionPolicy` 是 `ai4j-agent` 的工具执行前置策略层。它解决的问题很明确：
 
 > 模型已经决定要调用某个工具，但宿主程序是否允许它现在执行？

--- a/docs-site/docs/agent/governance/cubesandbox-provider.md
+++ b/docs-site/docs/agent/governance/cubesandbox-provider.md
@@ -212,6 +212,6 @@ mvn -pl ai4j-agent -am -P live-provider-tests "-Dtest=CubeSandboxLiveProviderTes
 
 ## 10. 相关文档
 
-- [Agent Sandbox SPI](/docs/agent/governance/sandbox-spi)
+- [Agent 沙箱 SPI](/docs/agent/governance/sandbox-spi)
 - [Approval / Permission Policy](/docs/agent/governance/approval-permission-policy)
 - [Coding Agent Sandbox Routing](/docs/products/coding-agent/sandbox-routing)

--- a/docs-site/docs/agent/governance/plugin-lifecycle-hooks.md
+++ b/docs-site/docs/agent/governance/plugin-lifecycle-hooks.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 7
-title: Plugin Lifecycle Hooks
+title: 插件生命周期钩子
 description: 说明 ai4j-extension-api 的 Agent 生命周期 Hook：插件如何观察 BEFORE_TURN/BEFORE_MODEL_REQUEST/BEFORE_TOOL_CALL/ON_COMPACT 等事件，事件 payload、异常策略与 Guardrail 的区别。
 tags: [integration]
 ---
 
-# Plugin Lifecycle Hooks
-
+# 插件生命周期钩子
 `ai4j-extension-api` 现在支持 Agent 生命周期 Hook。它让插件不只贡献 Tool、Command、Skill、Prompt 或 Guardrail，还可以观察 Agent 的运行过程。
 
 这是一层插件生态基础能力，适合做：

--- a/docs-site/docs/agent/governance/sandbox-spi.md
+++ b/docs-site/docs/agent/governance/sandbox-spi.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 9
-title: Agent Sandbox SPI
+title: Agent 沙箱 SPI
 description: 介绍 ai4j-agent 的 Sandbox SPI：SandboxProvider/SandboxSession 合同如何把执行交给隔离环境，AgentSessionSandboxBinding 只保存非敏感摘要，Daytona、E2B、CubeSandbox 三个官方真实 provider，以及 AgentBuilder/CodingAgentBuilder 如何消费 sandbox。
 tags: [integration]
 ---
 
-# Agent Sandbox SPI
-
+# Agent 沙箱 SPI
 `io.github.lnyocly.ai4j.agent.sandbox` 是 `ai4j-agent` 的真实沙箱执行环境抽象。它解决的问题是：
 
 > Agent 已经决定要执行 shell、文件、浏览器或项目命令时，宿主如何把这次执行交给一个真实的隔离环境，并拿回 stdout、stderr、artifact 和事件？

--- a/docs-site/docs/agent/governance/tool-interceptor.md
+++ b/docs-site/docs/agent/governance/tool-interceptor.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 11
-title: Interception Hooks
+title: 拦截钩子
 description: ai4j-agent 的拦截层：ToolInterceptor(block/modify/routeTo sandbox) 与 PromptInterceptor 对应 Claude Code 的 PreToolUse/PostToolUse/UserPromptSubmit，加上 observe-only 生命周期 Hook，附 hooks 门面与 CLI 配置。
 tags: [how-to]
 ---
 
-# Interception Hooks (block / modify / route-to-sandbox + observe events)
-
+# 拦截钩子（block / modify / 路由到沙箱 + observe 事件）
 ai4j covers every Claude-Code-equivalent hook event: **interception** (can veto/rewrite) for tool
 calls and prompts, plus **observe** side-effect hooks for turn/compact/session boundaries. Two
 control-flow interfaces plus the existing observe-only [lifecycle hooks](/docs/agent/governance/plugin-lifecycle-hooks).
@@ -239,6 +238,6 @@ They coexist — register both; observe hooks see what happens, interceptors dec
 
 ## Where this fits
 
-- Observe/audit layer (tracing, replay, hash-chain audit): [Replay, Recovery & Audit](/docs/agent/observability/replay-recovery-audit).
+- Observe/audit layer (tracing, replay, hash-chain audit): [重放、恢复与审计](/docs/agent/observability/replay-recovery-audit).
 - The sandbox the `routeTo` decision targets: [Sandbox SPI](/docs/agent/governance/sandbox-spi).
 - The veto-by-exception policy mechanism (a coarser sibling): [Approval & Permission Policy](/docs/agent/governance/approval-permission-policy).

--- a/docs-site/docs/agent/memory/context-window-management.md
+++ b/docs-site/docs/agent/memory/context-window-management.md
@@ -1,11 +1,10 @@
 ---
-title: Context Window Management
+title: 上下文窗口管理
 description: 讲清 ai4j 的上下文窗口管理机制：ContextBudget 设预算（maxItems/maxApproxChars/pinnedPrefixItems），DefaultContextProjector 按"保留头部 + 尾部"策略投影，ContextReport 报告丢弃诊断。这是 Compaction 之前的第一道闸，负责"选哪些进窗口"，而 Compaction 负责"怎么压缩"。
 tags: [concept]
 ---
 
-# Context Window Management
-
+# 上下文窗口管理
 > **上下文窗口管理 = 决定哪些历史条目进入模型的上下文窗口。** 它是 Compaction 之前的第一道闸：Projection 负责"选哪些进"，Compaction 负责"怎么压缩还太大的"。
 
 ## 为什么需要管

--- a/docs-site/docs/agent/memory/memory-and-state.md
+++ b/docs-site/docs/agent/memory/memory-and-state.md
@@ -1,11 +1,10 @@
 ---
-title: Memory and State
+title: 记忆与状态
 description: 拆解 ai4j-agent 的 AgentMemory 状态模型：用户输入、模型输出与工具输出如何统一回灌下一轮 prompt，以及 InMemoryAgentMemory、JdbcAgentMemory 的写入、压缩与 session 隔离真实语义。
 tags: [concept]
 ---
 
-# Memory and State
-
+# 记忆与状态
 在 `ai4j-agent` 里，memory 不是“聊天记录附件”，而是 Agent loop 的状态源。
 
 只要进入多步推理，runtime 每一轮都要回答四个问题：
@@ -351,6 +350,6 @@ summary 不是冗余字符串拼在 item 里，而是单独存一条记录；但
 ## 12. 继续阅读
 
 1. [Memory 管理与压缩策略](/docs/agent/memory/memory-compact-context)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Agent Architecture](/docs/agent/architecture)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [Agent 架构](/docs/agent/architecture)
 4. [Trace Observability](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/memory/memory-compact-context.md
+++ b/docs-site/docs/agent/memory/memory-compact-context.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 6
-title: Memory Compact Context Projector
+title: 记忆压缩与上下文投影器
 description: 介绍 ai4j-agent 的 ContextProjector 与 CompactPolicy：如何把 memory snapshot 投影成本轮 prompt、用结构化 CompactResult 压缩长程上下文，并让压缩过程可诊断、可恢复。
 tags: [concept]
 ---
 
-# Memory Compact Context Projector
-
+# 记忆压缩与上下文投影器
 这一页说明 `ai4j-agent` 里新加入的 Memory / Compact / Context Projector 基础能力。
 
 先说结论：它不是“自动变聪明的摘要器”，而是把长程 Agent 里最容易混乱的三件事拆开：
@@ -400,9 +399,9 @@ P0-B 是基础层，不包含：
 
 ## 12. 推荐继续阅读
 
-- [Agent Session Runtime](/docs/agent/session-runtime)
-- [Memory and State](/docs/agent/memory/memory-and-state)
-- [AI4J Agent SDK Roadmap](/docs/reference/about/sdk-roadmap)
+- [Agent 会话运行时](/docs/agent/session-runtime)
+- [记忆与状态](/docs/agent/memory/memory-and-state)
+- [AI4J Agent SDK 路线图](/docs/reference/about/sdk-roadmap)
 - [Coding Agent Compact and Checkpoint](/docs/products/coding-agent/compact-and-checkpoint)
 
 ## Auto-compaction (runtime-triggered)

--- a/docs-site/docs/agent/model-client-selection.md
+++ b/docs-site/docs/agent/model-client-selection.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 3
-title: Model Client Selection
+title: 模型客户端选型
 description: 对比 ChatModelClient 与 ResponsesModelClient：systemPrompt/instructions 的协议映射、顶层字段下推差异、流式信号与 memoryItems 形状，帮你为 Agent 选对模型协议路径。
 tags: [concept]
 ---
 
-# Model Client Selection
-
+# 模型客户端选型
 `AgentModelClient` 决定的不是“你用哪个 provider”，而是：
 
 > Agent runtime 组装好的 `AgentPrompt`，最终以什么协议形态发给模型。
@@ -439,6 +438,6 @@ Agent agent = Agents.react()
 ## 13. 继续阅读
 
 1. [Quickstart](/docs/agent/quickstart)
-2. [System Prompt vs Instructions](/docs/agent/system-prompt-vs-instructions)
-3. [Tools and Registry](/docs/agent/tools-and-registry)
-4. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+2. [系统提示词与指令](/docs/agent/system-prompt-vs-instructions)
+3. [工具与注册表](/docs/agent/tools-and-registry)
+4. [运行时实现](/docs/agent/runtimes/runtime-implementations)

--- a/docs-site/docs/agent/observability/a2a.md
+++ b/docs-site/docs/agent/observability/a2a.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 12
-title: A2A Protocol (Agent-to-Agent)
+title: A2A 协议 (Agent-to-Agent)
 description: "Discover agents, exchange JSON-RPC tasks, stream SSE updates, and expose your ai4j agent as an A2A service with optional auth — JDK stdlib only."
 tags: [integration]
 ---
 
-# A2A Protocol (Agent-to-Agent)
-
+# A2A 协议 (Agent-to-Agent)
 ai4j provides a Java 8-compatible A2A integration surface for agent discovery, JSON-RPC task
 exchange, task lifecycle, SSE streaming, push-notification configuration, Skills metadata, and
 standard API-key or Bearer authentication. An ai4j agent can call an A2A endpoint as a client or
@@ -217,7 +216,7 @@ predicate receives the raw callback URL and returns whether delivery is allowed.
 
 ## Publish ai4j Skills to the AgentCard
 
-`A2ASkill` describes a capability in an A2A AgentCard; an ai4j `SkillDescriptor` describes a local `SKILL.md` Skill (see [Agent Skills](/docs/agent/skills)). They are different models, so the SDK ships a small bridge — `io.github.lnyocly.ai4j.agent.a2a.A2ASkillMapper` — that publishes your resolved ai4j Skills as A2A skills on the server's card.
+`A2ASkill` describes a capability in an A2A AgentCard; an ai4j `SkillDescriptor` describes a local `SKILL.md` Skill (see [Agent 技能](/docs/agent/skills)). They are different models, so the SDK ships a small bridge — `io.github.lnyocly.ai4j.agent.a2a.A2ASkillMapper` — that publishes your resolved ai4j Skills as A2A skills on the server's card.
 
 `A2ASkillMapper` is a final utility class with three static entry points:
 
@@ -293,6 +292,6 @@ none are committed or required by default CI.
 
 ## Where this fits
 
-- **Interception hooks** (control what the agent does): [Interception Hooks](/docs/agent/governance/tool-interceptor).
+- **Interception hooks** (control what the agent does): [拦截钩子](/docs/agent/governance/tool-interceptor).
 - **Sandbox SPI** (isolate tool execution): [Sandbox SPI](/docs/agent/governance/sandbox-spi).
 - **Session + compaction** (manage long sessions): [Memory & Compact](/docs/agent/memory/memory-compact-context).

--- a/docs-site/docs/agent/observability/replay-recovery-audit.md
+++ b/docs-site/docs/agent/observability/replay-recovery-audit.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 10
-title: Replay, Recovery & Audit
+title: 重放、恢复与审计
 description: "ai4j-agent 事件流上的四层生产能力逐个讲透：节点 I/O 捕获与重放（IoCaptureAgentListener/NodeReplayer/NodeIoRecord）、resume-cache 故障恢复（ResumeCache/ResumableModelClient/ResumableToolExecutor，内容寻址、副作用不重放）、持久化 session store、以及 SHA-256 哈希链防篡改审计（HashChainedEventLog）。"
 tags: [reference]
 ---
 
-# Replay, Recovery & Audit
-
+# 重放、恢复与审计
 `ai4j-agent` 在 runtime 事件流上叠了四层**可选的生产能力**。它们都是**消费者/装饰器**，不改 runtime——复用 runtime 本来就发的事件（`MODEL_REQUEST`/`MODEL_RESPONSE`/`MODEL_REASONING`/`MODEL_RETRY`/`TOOL_CALL`/`TOOL_RESULT`/`STEP_END`）。需要哪层就接哪层。
 
 | 能力 | 主要类 | 解决什么 |

--- a/docs-site/docs/agent/observability/trace-observability.md
+++ b/docs-site/docs/agent/observability/trace-observability.md
@@ -706,7 +706,7 @@ TraceConfig traceConfig = TraceConfig.builder()
 - Agent trace 是后端运行视角
 - FlowGram trace projection 是画布与节点视角
 
-如果你在看 FlowGram 集成，继续读 [Flowgram Runtime](/docs/products/flowgram/runtime) 会更合适。
+如果你在看 FlowGram 集成，继续读 [Flowgram 运行时](/docs/products/flowgram/runtime) 会更合适。
 
 ## 13. 排障时应该怎么读 trace
 
@@ -742,8 +742,8 @@ TraceConfig traceConfig = TraceConfig.builder()
 
 ## 15. 继续阅读
 
-1. [Agent Architecture](/docs/agent/architecture)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
+1. [Agent 架构](/docs/agent/architecture)
+2. [工具与注册表](/docs/agent/tools-and-registry)
 3. [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-4. [Agent Teams](/docs/agent/orchestration/agent-teams)
-5. [Flowgram Runtime](/docs/products/flowgram/runtime)
+4. [Agent 团队](/docs/agent/orchestration/agent-teams)
+5. [Flowgram 运行时](/docs/products/flowgram/runtime)

--- a/docs-site/docs/agent/orchestration/agent-teams-api-reference.md
+++ b/docs-site/docs/agent/orchestration/agent-teams-api-reference.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 15
-title: Agent Teams API Reference
+title: Agent 团队 API 参考
 description: "以源码视角导航 Agent Teams runtime：AgentTeamBuilder 字段如何映射到运行链、task board 状态机、team 工具面、持久化恢复与扩展点。"
 tags: [reference]
 ---
 
-# Agent Teams API Reference
-
+# Agent 团队 API 参考
 这页不是脚本导出的类表，而是 `ai4j-agent` Team runtime 的源码导航。
 
 如果你要做的事情是：
@@ -480,8 +479,8 @@ Team 工具返回的是 JSON 字符串，里面通常至少包含：
 
 ## 12. 继续阅读
 
-1. [Agent Teams](/docs/agent/orchestration/agent-teams)
+1. [Agent 团队](/docs/agent/orchestration/agent-teams)
 2. [Subagent Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-3. [Tools and Registry](/docs/agent/tools-and-registry)
-4. [Memory and State](/docs/agent/memory/memory-and-state)
+3. [工具与注册表](/docs/agent/tools-and-registry)
+4. [记忆与状态](/docs/agent/memory/memory-and-state)
 5. [Trace Observability](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/orchestration/agent-teams.md
+++ b/docs-site/docs/agent/orchestration/agent-teams.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 11
-title: Agent Teams
+title: Agent 团队
 description: "ai4j Agent Teams 是带控制面的团队运行时：planner 拆任务、task board 维护依赖与状态、成员注入 team_* 工具协作、synthesizer 汇总最终答案。"
 tags: [concept]
 ---
 
-# Agent Teams
-
+# Agent 团队
 `AgentTeam` 不是“把多个 Agent 放进一个列表里依次调用”，而是一个带控制面的团队运行时。
 
 它把多成员协作拆成 5 个显式部件：
@@ -709,7 +708,7 @@ AgentTeamResult result = team.run("Review the latest release candidate and summa
 
 如果读完这一页还想往下钻，建议继续：
 
-1. [Agent Teams API Reference](/docs/agent/orchestration/agent-teams-api-reference)
+1. [Agent 团队 API 参考](/docs/agent/orchestration/agent-teams-api-reference)
 2. [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
 3. [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph)
 4. [Trace 与可观测性](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/orchestration/subagent-handoff-policy.md
+++ b/docs-site/docs/agent/orchestration/subagent-handoff-policy.md
@@ -579,6 +579,6 @@ Agent parent = Agents.react()
 
 ## 17. 继续阅读
 
-1. [Tools and Registry](/docs/agent/tools-and-registry)
-2. [Agent Teams](/docs/agent/orchestration/agent-teams)
+1. [工具与注册表](/docs/agent/tools-and-registry)
+2. [Agent 团队](/docs/agent/orchestration/agent-teams)
 3. [Trace 与可观测性](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/orchestration/weather-workflow-cookbook.md
+++ b/docs-site/docs/agent/orchestration/weather-workflow-cookbook.md
@@ -277,6 +277,6 @@ WorkflowAgent runner = new WorkflowAgent(workflow, weatherAgent.newSession());
 ## 12. 继续阅读
 
 1. [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
-4. [Model Client Selection](/docs/agent/model-client-selection)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
+4. [模型客户端选型](/docs/agent/model-client-selection)

--- a/docs-site/docs/agent/overview.md
+++ b/docs-site/docs/agent/overview.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Agent Overview
+title: Agent 总览
 description: ai4j-agent 总览：它在 Core SDK 之上提供多步推理、工具闭环、memory、workflow、trace 与多 Agent 协作，何时该用 Agent、最小心智模型、runtime 选型与模块边界。
 tags: [concept]
 ---
 
-# Agent Overview
-
+# Agent 总览
 `ai4j-agent` 是建立在 Core SDK 之上的 Java Agent runtime。它不替代模型调用层，而是解决“模型调用一次之后，系统如何继续推进任务”的问题。
 
 如果你只是想发一条消息，先看 [Core SDK / Model Access](/docs/capabilities/models/overview)。如果你需要多步推理、工具闭环、memory、workflow、trace 或多 agent 协作，再进入本章。
@@ -76,7 +75,7 @@ AgentRequest
 
 Agent 是一层通用 runtime。它可以被 Coding Agent 和 FlowGram 复用，但它本身不负责宿主产品形态。
 
-如果你关心后续 Agent SDK 会怎样增强 Session、Memory、Blueprint、Sandbox 和 Runner，看 [AI4J Agent SDK Roadmap](/docs/reference/about/sdk-roadmap)。
+如果你关心后续 Agent SDK 会怎样增强 Session、Memory、Blueprint、Sandbox 和 Runner，看 [AI4J Agent SDK 路线图](/docs/reference/about/sdk-roadmap)。
 
 ## 生产接入要注意什么
 
@@ -87,34 +86,34 @@ Agent 是一层通用 runtime。它可以被 Coding Agent 和 FlowGram 复用，
 - 多用户场景下，session 隔离不等于工具权限隔离。
 - SubAgent 或 team orchestration 要有明确 handoff 和权限边界。
 
-更多检查项见 [Security Overview](/docs/production/security) 和 [Production Checklist](/docs/production/production-checklist)。
+更多检查项见 [安全总览](/docs/production/security) 和 [生产检查清单](/docs/production/production-checklist)。
 
 ## 推荐阅读顺序
 
 ### 想先判断是否需要 Agent
 
-1. [Why Agent](/docs/agent/why-agent)
+1. [为什么需要 Agent 层](/docs/agent/why-agent)
 2. [Use Cases and Paths](/docs/agent/use-cases-and-paths)
 3. [Architecture](/docs/agent/architecture)
-4. [AI4J Agent SDK Roadmap](/docs/reference/about/sdk-roadmap)
+4. [AI4J Agent SDK 路线图](/docs/reference/about/sdk-roadmap)
 
 ### 想先跑通
 
 1. [Quickstart](/docs/agent/quickstart)
-2. [Model Client Selection](/docs/agent/model-client-selection)
+2. [模型客户端选型](/docs/agent/model-client-selection)
 3. [Minimal ReAct Agent](/docs/agent/runtimes/minimal-react-agent)
 
 ### 想深入运行时
 
-1. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
+1. [运行时实现](/docs/agent/runtimes/runtime-implementations)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
 4. [Trace Observability](/docs/agent/observability/trace-observability)
 
 ### 想做编排和协作
 
 1. [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph)
 2. [SubAgent Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-3. [Agent Teams](/docs/agent/orchestration/agent-teams)
+3. [Agent 团队](/docs/agent/orchestration/agent-teams)
 
 如果你想直接做本地代码仓任务，不要从这里硬扩展，直接看 [Coding Agent Overview](/docs/products/coding-agent/overview)。

--- a/docs-site/docs/agent/quickstart.md
+++ b/docs-site/docs/agent/quickstart.md
@@ -1,11 +1,10 @@
 ---
-title: Agent Quickstart
+title: Agent 快速开始
 description: 用最小但真实的链路帮你跑通第一条 Agent 主线：AgentBuilder 默认装配、ReActRuntime step loop、AgentModelClient 协议适配、AgentMemory 回灌与 AgentResult 收口。
 tags: [how-to]
 ---
 
-# Agent Quickstart
-
+# Agent 快速开始
 这页的目标不是展示“最短 demo”，而是帮你先跑通一条最小但真实的 Agent 主链。
 
 所谓真实，是指这条链里至少要经过：
@@ -355,7 +354,7 @@ quickstart 的使命是帮你先把入口打通，不是承载全部复杂度。
 ## 11. 下一步读什么
 
 1. [Minimal ReAct Agent](/docs/agent/runtimes/minimal-react-agent)
-2. [Model Client Selection](/docs/agent/model-client-selection)
-3. [Tools and Registry](/docs/agent/tools-and-registry)
-4. [Memory and State](/docs/agent/memory/memory-and-state)
-5. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+2. [模型客户端选型](/docs/agent/model-client-selection)
+3. [工具与注册表](/docs/agent/tools-and-registry)
+4. [记忆与状态](/docs/agent/memory/memory-and-state)
+5. [运行时实现](/docs/agent/runtimes/runtime-implementations)

--- a/docs-site/docs/agent/runtimes/codeact-custom-sandbox.md
+++ b/docs-site/docs/agent/runtimes/codeact-custom-sandbox.md
@@ -514,6 +514,6 @@ runtime 会误判成功。
 ## 15. 继续阅读
 
 1. [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)
-2. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
-3. [Tools and Registry](/docs/agent/tools-and-registry)
+2. [运行时实现](/docs/agent/runtimes/runtime-implementations)
+3. [工具与注册表](/docs/agent/tools-and-registry)
 4. [Trace 与可观测性](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/runtimes/codeact-runtime.md
+++ b/docs-site/docs/agent/runtimes/codeact-runtime.md
@@ -442,6 +442,6 @@ exec error
 ## 13. 继续阅读
 
 1. [CodeAct Custom Sandbox](/docs/agent/runtimes/codeact-custom-sandbox)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
-4. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
+4. [运行时实现](/docs/agent/runtimes/runtime-implementations)

--- a/docs-site/docs/agent/runtimes/minimal-react-agent.md
+++ b/docs-site/docs/agent/runtimes/minimal-react-agent.md
@@ -335,7 +335,7 @@ TOOL_ERROR: {"errorType":"...","error":"...","tool":"...","callId":"..."}
 - 需要执行模型生成的代码：进入 [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)
 - 需要显式节点和状态推进：进入 [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph)
 - 需要主从委派：进入 [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-- 需要团队协作：进入 [Agent Teams](/docs/agent/orchestration/agent-teams)
+- 需要团队协作：进入 [Agent 团队](/docs/agent/orchestration/agent-teams)
 
 判断标准不是“功能多不多”，而是当前问题是否还属于单一 tool loop。
 
@@ -351,7 +351,7 @@ TOOL_ERROR: {"errorType":"...","error":"...","tool":"...","callId":"..."}
 
 ## 15. 继续阅读
 
-1. [Agent Architecture](/docs/agent/architecture)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
+1. [Agent 架构](/docs/agent/architecture)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
 4. [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)

--- a/docs-site/docs/agent/runtimes/runtime-implementations.md
+++ b/docs-site/docs/agent/runtimes/runtime-implementations.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 5
-title: Runtime Implementations
+title: 运行时实现
 description: 拆解 ReActRuntime、CodeActRuntime、DeepResearchRuntime 三种 runtime：它们共享 BaseAgentRuntime 主循环，差异在于模型输出的中间表示，以及何时换中间表示、何时自定义 runtime。
 tags: [concept]
 ---
 
-# Runtime Implementations
-
+# 运行时实现
 `AgentRuntime` 决定的不是“模型用哪个 provider”，而是“一次 Agent run 如何推进、何时停止、何时发事件、工具结果如何回灌”。
 
 同一个 `AgentBuilder`，之所以可以切 `ReActRuntime`、`CodeActRuntime`、`DeepResearchRuntime`，是因为这三种 runtime 代表了三种不同的执行语义，而不是同一条链路的文案差异。
@@ -378,8 +377,8 @@ public class MyRuntime extends BaseAgentRuntime {
 
 ## 12. 继续阅读
 
-1. [Agent Architecture](/docs/agent/architecture)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Memory and State](/docs/agent/memory/memory-and-state)
+1. [Agent 架构](/docs/agent/architecture)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [记忆与状态](/docs/agent/memory/memory-and-state)
 4. [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)
 5. [CodeAct Custom Sandbox](/docs/agent/runtimes/codeact-custom-sandbox)

--- a/docs-site/docs/agent/runtimes/workflow-stategraph.md
+++ b/docs-site/docs/agent/runtimes/workflow-stategraph.md
@@ -506,7 +506,7 @@ IllegalStateException: node not found: <id>
 - 只是单个 Agent 的工具循环
 - 只是想要更强工具编排，这通常先看 [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)
 - 只是要把一个能力委派给另一个 Agent，这通常先看 [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-- 需要任务板、角色和消息总线，这通常应该看 [Agent Teams](/docs/agent/orchestration/agent-teams)
+- 需要任务板、角色和消息总线，这通常应该看 [Agent 团队](/docs/agent/orchestration/agent-teams)
 
 ## 12. 推荐阅读源码顺序
 
@@ -522,7 +522,7 @@ IllegalStateException: node not found: <id>
 
 ## 13. 继续阅读
 
-1. [Agent Architecture](/docs/agent/architecture)
+1. [Agent 架构](/docs/agent/architecture)
 2. [Minimal ReAct Agent](/docs/agent/runtimes/minimal-react-agent)
 3. [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-4. [Agent Teams](/docs/agent/orchestration/agent-teams)
+4. [Agent 团队](/docs/agent/orchestration/agent-teams)

--- a/docs-site/docs/agent/session-runtime.md
+++ b/docs-site/docs/agent/session-runtime.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 5
-title: Agent Session Runtime
+title: Agent 会话运行时
 description: 讲解 AgentSession 长程运行态容器：sessionId、独立 memory、event log、snapshot/restore 与 AgentSessionStore，以及它与 memory/compact、Coding Agent/CLI 的边界和生产实现建议。
 tags: [concept]
 ---
 
-# Agent Session Runtime
-
+# Agent 会话运行时
 `AgentSession` 是 `ai4j-agent` 的长程运行态入口。它不是另一个模型客户端，也不是 CLI 会话的替代品，而是把一次 Agent 任务的状态收拢到一个可保存、可恢复、可观测的容器里。
 
 ## 1. 它解决什么问题
@@ -158,7 +157,7 @@ P0-B 已补上：
 - `AgentSession.compact(...)`
 - `AgentSessionSnapshot.compactResult`
 
-使用细节见 [Memory Compact Context Projector](/docs/agent/memory/memory-compact-context)。
+使用细节见 [记忆压缩与上下文投影器](/docs/agent/memory/memory-compact-context)。
 
 ## 8. 与 Coding Agent / CLI 的关系
 
@@ -197,4 +196,4 @@ P0-A 只是运行态容器基础。完整 Agent SDK 还会继续推进：
 5. CLI `/sandbox` 体验
 6. 远端 Agent Runner
 
-完整路线见 [AI4J Agent SDK Roadmap](/docs/reference/about/sdk-roadmap)。
+完整路线见 [AI4J Agent SDK 路线图](/docs/reference/about/sdk-roadmap)。

--- a/docs-site/docs/agent/skills.md
+++ b/docs-site/docs/agent/skills.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 8
-title: Agent Skills
+title: Agent 技能
 description: "Explains ai4j-agent Skills: how the SDK discovers and scopes SKILL.md, the workspace-safe vs user-home roots, request-scoped AgentSkillResolver for tenants, and why Skills never bypass tool authorization."
 tags: [how-to]
 ---
 
-# Agent Skills
-
+# Agent 技能
 A Skill is a reusable instruction asset. It tells an Agent how to approach a class of work; it does not grant a tool, data access, or an approval bypass.
 
 AI4J's Agent integration follows the same split that makes Skills safe in local and service hosts:
@@ -161,7 +160,7 @@ This separation is intentional. A reusable SDK cannot infer a tenant's authoriza
 - MCP is a protocol for connecting or publishing external capabilities.
 - `A2ASkill` describes an agent capability in an A2A AgentCard; it is not a local `SKILL.md` file. 用 `A2ASkillMapper` 可以把已授权的 ai4j `SkillDescriptor` 发布成 AgentCard 上的 A2A skill（见 [A2A — Publish ai4j Skills](/docs/agent/observability/a2a#publish-ai4j-skills-to-the-agentcard)）。
 
-Read [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp) for the Core distinction and [A2A](/docs/agent/observability/a2a) for the AgentCard capability model.
+Read [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp) for the Core distinction and [A2A](/docs/agent/observability/a2a) for the AgentCard capability model.
 
 ## Next pages
 

--- a/docs-site/docs/agent/system-prompt-vs-instructions.md
+++ b/docs-site/docs/agent/system-prompt-vs-instructions.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 2
-title: System Prompt vs Instructions
+title: 系统提示词与指令
 description: 厘清 ai4j-agent 里 systemPrompt 与 instructions 的源码语义：两者都是 AgentContext 配置、每步重复进入模型，但在 Chat 与 Responses 路径映射不同，CodeAct 下更需分层。
 tags: [concept]
 ---
 
-# System Prompt vs Instructions
-
+# 系统提示词与指令
 这一页讲的不是泛泛的 prompt engineering，而是 AI4J Agent 里这两个字段在源码中的真实语义。
 
 如果这里理解错了，后面会连带把这些事情一起理解错：
@@ -454,7 +453,7 @@ Agent agent = Agents.react()
 
 ## 13. 继续阅读
 
-1. [Model Client Selection](/docs/agent/model-client-selection)
+1. [模型客户端选型](/docs/agent/model-client-selection)
 2. [Quickstart](/docs/agent/quickstart)
 3. [Architecture](/docs/agent/architecture)
-4. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+4. [运行时实现](/docs/agent/runtimes/runtime-implementations)

--- a/docs-site/docs/agent/tools-and-registry.md
+++ b/docs-site/docs/agent/tools-and-registry.md
@@ -1,11 +1,10 @@
 ---
-title: Tools and Registry
+title: 工具与注册表
 description: 拆解 ai4j-agent 工具体系：AgentToolRegistry 只管暴露面、ToolExecutor 管执行与权限边界，runtime 如何归一化、校验、执行工具并把结果回灌 memory，以及审批拦截该放哪层。
 tags: [concept]
 ---
 
-# Tools and Registry
-
+# 工具与注册表
 在 `ai4j-agent` 里，工具体系真正解决的不是“函数怎么暴露给模型”，而是四个边界如何拆开：
 
 - 模型能看见什么工具
@@ -424,8 +423,8 @@ Agent agent = Agents.builder()
 
 ## 12. 继续阅读
 
-1. [Memory and State](/docs/agent/memory/memory-and-state)
+1. [记忆与状态](/docs/agent/memory/memory-and-state)
 2. [Minimal ReAct Agent](/docs/agent/runtimes/minimal-react-agent)
 3. [Subagent Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-4. [Agent Teams](/docs/agent/orchestration/agent-teams)
+4. [Agent 团队](/docs/agent/orchestration/agent-teams)
 5. [Trace Observability](/docs/agent/observability/trace-observability)

--- a/docs-site/docs/agent/use-cases-and-paths.md
+++ b/docs-site/docs/agent/use-cases-and-paths.md
@@ -174,8 +174,8 @@ Team 的本质变化是：
 
 继续看：
 
-- [Agent Teams](/docs/agent/orchestration/agent-teams)
-- [Agent Teams API Reference](/docs/agent/orchestration/agent-teams-api-reference)
+- [Agent 团队](/docs/agent/orchestration/agent-teams)
+- [Agent 团队 API 参考](/docs/agent/orchestration/agent-teams-api-reference)
 
 ## 7. 一张更实用的决策表
 
@@ -245,4 +245,4 @@ ReAct 不是 demo 层，而是默认 runtime 语义。很多生产任务真正�
 3. [Runtime 实现详解](/docs/agent/runtimes/runtime-implementations)
 4. [Workflow StateGraph](/docs/agent/runtimes/workflow-stategraph)
 5. [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-6. [Agent Teams](/docs/agent/orchestration/agent-teams)
+6. [Agent 团队](/docs/agent/orchestration/agent-teams)

--- a/docs-site/docs/agent/why-agent.md
+++ b/docs-site/docs/agent/why-agent.md
@@ -1,11 +1,10 @@
 ---
-title: Why Agent
+title: 为什么需要 Agent 层
 description: 回答 ai4j 为什么要单独的 Agent 层：多步执行迟早会逼出 runtime、状态源与工具治理，Agent 把主循环、状态语义、治理边界和可观测性统一下来，而不是平行再造框架。
 tags: [concept]
 ---
 
-# Why Agent
-
+# 为什么需要 Agent 层
 `Agent` 这一层存在的原因，不是为了把 Core SDK 再包一层，而是因为一旦系统进入多步执行，业务代码迟早会自己长出一套 runtime。
 
 这不是抽象爱好，而是工程事实。
@@ -387,8 +386,8 @@ Agent 不自动具备：
 
 ## 12. 继续阅读
 
-1. [Agent Overview](/docs/agent/overview)
+1. [Agent 总览](/docs/agent/overview)
 2. [Architecture](/docs/agent/architecture)
 3. [Quickstart](/docs/agent/quickstart)
-4. [Tools and Registry](/docs/agent/tools-and-registry)
-5. [Memory and State](/docs/agent/memory/memory-and-state)
+4. [工具与注册表](/docs/agent/tools-and-registry)
+5. [记忆与状态](/docs/agent/memory/memory-and-state)

--- a/docs-site/docs/capabilities/chat-memory/chat-memory.md
+++ b/docs-site/docs/capabilities/chat-memory/chat-memory.md
@@ -1,11 +1,10 @@
 ---
-title: "Chat Memory"
+title: Chat 记忆
 description: "深入 ChatMemory 契约：ChatMemoryItem 承载多模态与工具事实、InMemory 与 Jdbc 两种存储、窗口与摘要策略、快照恢复，及投影到 Chat 与 Responses 的共享基座。"
 tags: [concept]
 ---
 
-# Chat Memory
-
+# Chat 记忆
 `ChatMemory` 是 AI4J 基座里一个非常核心、但容易被低估的对象。  
 它真正做的不是“帮你存一份 messages”，而是 **把多轮会话事实组织成可投影、可裁剪、可快照、可恢复的统一上下文抽象**。
 

--- a/docs-site/docs/capabilities/chat-memory/memory-and-tool-boundaries.md
+++ b/docs-site/docs/capabilities/chat-memory/memory-and-tool-boundaries.md
@@ -1,11 +1,10 @@
 ---
-title: "Memory and Tool Boundaries"
+title: 记忆与工具边界
 description: "厘清 ChatMemory、Tool、MCP 三层职责边界：memory 只保存会话事实，工具审批与副作用治理归 runtime；说明为何不该把执行控制耦合进 memory 抽象。"
 tags: [concept]
 ---
 
-# Memory and Tool Boundaries
-
+# 记忆与工具边界
 这一页只讲边界。把 memory、tool 和 MCP 分开，才能知道 Core SDK 到底负责到哪里。
 
 ## 1. `ChatMemory` 负责什么

--- a/docs-site/docs/capabilities/chat-memory/overview.md
+++ b/docs-site/docs/capabilities/chat-memory/overview.md
@@ -153,7 +153,7 @@ AI4J 保存的不是“最后一句聊天文本”，而是更完整的会话事
 ## 9. 推荐阅读顺序
 
 1. [Chat Memory](/docs/capabilities/chat-memory/)
-2. [Memory and Tool Boundaries](/docs/capabilities/chat-memory/memory-and-tool-boundaries)
+2. [记忆与工具边界](/docs/capabilities/chat-memory/memory-and-tool-boundaries)
 3. [Agent / Memory and State](/docs/agent/memory/memory-and-state)
 
 ## 10. 这一页的结论

--- a/docs-site/docs/capabilities/mcp/build-your-mcp-server.md
+++ b/docs-site/docs/capabilities/mcp/build-your-mcp-server.md
@@ -229,7 +229,7 @@ server.start().join();
 - `http`
   仅兼容别名，最终映射为 `streamable_http`
 
-`http` 只是 `streamable_http` 的 transport 类型别名，并保留 AUTO 的有限 Streamable HTTP compatibility 语义。已知的 session-era peer 可以在 `ServerConfig` 或客户端 `TransportConfig` 中固定具体 legacy profile；deprecated HTTP+SSE 则应使用 `sse`。详见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+`http` 只是 `streamable_http` 的 transport 类型别名，并保留 AUTO 的有限 Streamable HTTP compatibility 语义。已知的 session-era peer 可以在 `ServerConfig` 或客户端 `TransportConfig` 中固定具体 legacy profile；deprecated HTTP+SSE 则应使用 `sse`。详见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 
 ## 7. 服务端安全默认值与 HTTP 层扩展
 

--- a/docs-site/docs/capabilities/mcp/client-integration.md
+++ b/docs-site/docs/capabilities/mcp/client-integration.md
@@ -97,7 +97,7 @@ client.connect().join();
 config.withProtocolProfile(McpProtocolProfile.LEGACY_2025_03_26);
 ```
 
-完整请求头、server profile 和升级路线见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+完整请求头、server profile 和升级路线见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 
 ### SSE
 

--- a/docs-site/docs/capabilities/mcp/configuration-and-gateway-reference.md
+++ b/docs-site/docs/capabilities/mcp/configuration-and-gateway-reference.md
@@ -218,7 +218,7 @@ tags: [reference]
 - `MODERN_2026_07_28` 禁止 legacy fallback，适合已确定为现代的 peer。
 - `LEGACY_2025_11_25`、`LEGACY_2025_06_18` 和 `LEGACY_2025_03_26` 固定使用对应的初始化时代 profile。
 
-这不是万能自动识别：认证失败、可识别的现代 JSON-RPC error、或非预期成功响应不会降级。deprecated HTTP+SSE 仍然必须配置 `type: "sse"`。完整行为见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+这不是万能自动识别：认证失败、可识别的现代 JSON-RPC error、或非预期成功响应不会降级。deprecated HTTP+SSE 仍然必须配置 `type: "sse"`。完整行为见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 
 ## 7. `enabled` 是真正的开关字段
 

--- a/docs-site/docs/capabilities/mcp/overview.md
+++ b/docs-site/docs/capabilities/mcp/overview.md
@@ -119,7 +119,7 @@ MCP 在仓库里的位置，不属于某个工具实现细节，而属于 AI 能
 - AUTO 仅在未识别的 `400`、`404` 或 `405` 时回退到 initialization-era Streamable HTTP。它不会因认证失败或可识别的现代错误降级，也不能自动识别 deprecated HTTP+SSE。
 - STDIO、显式 `sse` transport，以及显式选择 legacy Streamable HTTP profile 的 client，保留 session-era 流程：`initialize`、能力协商、`notifications/initialized`。
 
-因此，`isInitialized()` 表示 client 已准备好调用，不应被理解成“所有 transport 都已经完成了一次初始化握手”。现代 HTTP 的协议详情和升级路径见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+因此，`isInitialized()` 表示 client 已准备好调用，不应被理解成“所有 transport 都已经完成了一次初始化握手”。现代 HTTP 的协议详情和升级路径见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 
 ### 3.2 它默认会做缓存
 

--- a/docs-site/docs/capabilities/mcp/protocol-capabilities.md
+++ b/docs-site/docs/capabilities/mcp/protocol-capabilities.md
@@ -1,11 +1,10 @@
 ---
-title: Protocol Capabilities
+title: 协议能力
 description: 讲清 AI4J MCP 协议面：服务端支持 tools/resources/prompts 三类 capability 与 list_changed 通知，legacy profile 需 initialize 握手而现代 Streamable HTTP 无状态，transport 会影响 capability 边界。
 tags: [concept]
 ---
 
-# Protocol Capabilities
-
+# 协议能力
 如果把 MCP 只理解成 `tools/call`，你只看到了最薄的一层。
 
 AI4J 当前实现里的 MCP 协议面至少包括：
@@ -82,7 +81,7 @@ AI4J 当前实现里的 MCP 协议面至少包括：
 `AUTO` 只发送现代 `server/discover` 探测；只有未识别的 HTTP `400`、`404` 或 `405` 才会选择 initialization-era Streamable HTTP 并回到本节的初始化链。认证失败、可识别的现代 JSON-RPC error、或不合格的 discovery response 不会触发降级，因此 AUTO 不是通用的 MCP server 探测器。
 
 :::warning
-不要把 legacy 的初始化状态、session affinity 或 capability declaration 迁移到现代 endpoint。详见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+不要把 legacy 的初始化状态、session affinity 或 capability declaration 迁移到现代 endpoint。详见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 :::
 
 ## 3. 服务端返回的 capability 长什么样

--- a/docs-site/docs/capabilities/mcp/streamable-http.md
+++ b/docs-site/docs/capabilities/mcp/streamable-http.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 6
-title: Streamable HTTP
+title: Streamable HTTP 传输
 description: "Streamable HTTP transport for AI4J MCP: AUTO profile discovery, modern vs initialization-era peers, protocol headers, publishing a server, and upgrade paths."
 tags: [integration]
 ---
 
-# Streamable HTTP
-
+# Streamable HTTP 传输
 Streamable HTTP is the HTTP transport for connecting AI4J to an MCP server or publishing an MCP server from Java. `TransportConfig.streamableHttp(...)` and `McpServerFactory.ServerConfig` both default to `McpProtocolProfile.AUTO`.
 
 `AUTO` is a limited compatibility strategy, not universal protocol detection. A client starts with one modern `server/discover` request; an AUTO server accepts modern and initialization-era Streamable HTTP requests on the same `/mcp` endpoint. The deprecated HTTP+SSE transport remains separate and must be configured as `type: "sse"`.

--- a/docs-site/docs/capabilities/mcp/third-party-mcp-integration.md
+++ b/docs-site/docs/capabilities/mcp/third-party-mcp-integration.md
@@ -21,7 +21,7 @@ tags: [integration]
 
 :::note Streamable HTTP peer profile
 
-`streamable_http` 默认使用 `AUTO`，且 Gateway JSON 支持 `protocolProfile`。AUTO 只用现代 `server/discover` 探测 Streamable HTTP：有效发现结果走无状态 `2026-07-28`，只有未识别的 `400`、`404` 或 `405` 才会回退到 initialization-era profile。它不是万能识别，也不会自动选用 deprecated HTTP+SSE；后者必须显式配置 `type: "sse"`。本页的 STDIO 示例仍是 session-era 流程，因此会使用 `initialize`。见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+`streamable_http` 默认使用 `AUTO`，且 Gateway JSON 支持 `protocolProfile`。AUTO 只用现代 `server/discover` 探测 Streamable HTTP：有效发现结果走无状态 `2026-07-28`，只有未识别的 `400`、`404` 或 `405` 才会回退到 initialization-era profile。它不是万能识别，也不会自动选用 deprecated HTTP+SSE；后者必须显式配置 `type: "sse"`。本页的 STDIO 示例仍是 session-era 流程，因此会使用 `initialize`。见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 
 :::
 

--- a/docs-site/docs/capabilities/mcp/transport-types.md
+++ b/docs-site/docs/capabilities/mcp/transport-types.md
@@ -195,7 +195,7 @@ config.withProtocolProfile(McpProtocolProfile.LEGACY_2025_03_26);
 ```
 
 :::note AUTO 不是万能识别
-AUTO 不是万能识别：认证失败、可识别的现代 JSON-RPC error、或无效发现响应都不会降级。`http` 类型别名会归一化成 `streamable_http` 并保留这个 profile 语义；deprecated HTTP+SSE 则必须显式使用 `sse`。完整差异和升级路线见 [Streamable HTTP](/docs/capabilities/mcp/streamable-http)。
+AUTO 不是万能识别：认证失败、可识别的现代 JSON-RPC error、或无效发现响应都不会降级。`http` 类型别名会归一化成 `streamable_http` 并保留这个 profile 语义；deprecated HTTP+SSE 则必须显式使用 `sse`。完整差异和升级路线见 [Streamable HTTP 传输](/docs/capabilities/mcp/streamable-http)。
 :::
 
 ### 5.5 为什么它通常是生产优先选项

--- a/docs-site/docs/capabilities/models/chat-vs-responses.md
+++ b/docs-site/docs/capabilities/models/chat-vs-responses.md
@@ -1,11 +1,10 @@
 ---
-title: Chat vs Responses
+title: Chat 与 Responses 对比
 description: 从输入心智、provider 覆盖、工具集成、流式语义和多模态投影等维度对比 Chat 与 Responses 两条主线，帮你完成选型。
 tags: [concept]
 ---
 
-# Chat vs Responses
-
+# Chat 与 Responses 对比
 这是 AI4J 基座里最重要的选型问题之一。
 
 真正的区别不在“哪个更新”，而在 **你到底想消费什么样的模型输出语义，以及你更在意 provider 覆盖还是事件结构**。

--- a/docs-site/docs/capabilities/models/chat.md
+++ b/docs-site/docs/capabilities/models/chat.md
@@ -1,11 +1,10 @@
 ---
-title: Chat
+title: Chat 主线
 description: 解析 AI4J Chat 主线的请求对象、自动 tool loop、passThroughToolCalls、SseListener 流式聚合和多模态接入等运行时行为。
 tags: [concept]
 ---
 
-# Chat
-
+# Chat 主线
 `Chat` 是 AI4J 当前最成熟、provider 覆盖最广、也最容易先跑通的一条模型访问主线。
 
 但它不是“老接口兼容层”。从实现看，`Chat` 已经同时承载了：
@@ -209,7 +208,7 @@ public static class GetOrderStatus implements Function<GetOrderStatus.Request, S
 }
 ```
 
-这里 `@FunctionCall` / `@FunctionRequest` / `@FunctionParameter` 三注解 + 反射会自动把 Java 类型生成 provider 的 JSON Schema（`String`→`string`、`enum`→`string+enum`、`Integer`→`integer`…），你不用手写 schema。`required`、复杂类型边界、`strict` 模式详见 [Annotation-based Tools](/docs/capabilities/tools/annotation-based-tools)。
+这里 `@FunctionCall` / `@FunctionRequest` / `@FunctionParameter` 三注解 + 反射会自动把 Java 类型生成 provider 的 JSON Schema（`String`→`string`、`enum`→`string+enum`、`Integer`→`integer`…），你不用手写 schema。`required`、复杂类型边界、`strict` 模式详见 [注解式工具](/docs/capabilities/tools/annotation-based-tools)。
 
 调用时用 `functions(...)` 按 name 注册，其余交给 SDK：
 

--- a/docs-site/docs/capabilities/models/messages.md
+++ b/docs-site/docs/capabilities/models/messages.md
@@ -167,7 +167,7 @@ AgentResult result = agent.newSession().run("Introduce yourself in one sentence.
 // result.getRawResponse() —— 原生 AnthropicChatCompletionResponse（非 OpenAI 类型）
 ```
 
-底层是 `MessagesModelClient`（与 `ChatModelClient` / `ResponsesModelClient` 并列的第三个 `AgentModelClient`）。详见 [Model Client Selection](/docs/agent/model-client-selection)。
+底层是 `MessagesModelClient`（与 `ChatModelClient` / `ResponsesModelClient` 并列的第三个 `AgentModelClient`）。详见 [模型客户端选型](/docs/agent/model-client-selection)。
 
 ## 6. coding-plan：智谱 / MiniMax 的 Anthropic 入口
 
@@ -226,8 +226,8 @@ ai:
 
 ## 11. 继续阅读
 
-1. [Chat](/docs/capabilities/models/chat)
-2. [Responses](/docs/capabilities/models/responses)
-3. [Chat vs Responses](/docs/capabilities/models/chat-vs-responses)
-4. [Model Client Selection](/docs/agent/model-client-selection)
+1. [Chat 主线](/docs/capabilities/models/chat)
+2. [Responses 主线](/docs/capabilities/models/responses)
+3. [Chat 与 Responses 对比](/docs/capabilities/models/chat-vs-responses)
+4. [模型客户端选型](/docs/agent/model-client-selection)
 5. [平台与服务矩阵](/docs/capabilities/models/platform-service-matrix)

--- a/docs-site/docs/capabilities/models/multimodal.md
+++ b/docs-site/docs/capabilities/models/multimodal.md
@@ -1,11 +1,10 @@
 ---
-title: Multimodal
+title: 多模态
 description: 说明图文输入如何作为会话事实经 ChatMemoryItem 投影到 Chat 与 Responses 两条主线，区分模型原生输入与外部视觉工具。
 tags: [concept]
 ---
 
-# Multimodal
-
+# 多模态
 `Multimodal` 这一页讲的是：**文本之外的输入如何进入 AI4J 的统一模型请求链**。
 
 重点不是“支持图片”这件事本身，而是：

--- a/docs-site/docs/capabilities/models/openai-compatible-and-trovebox.md
+++ b/docs-site/docs/capabilities/models/openai-compatible-and-trovebox.md
@@ -99,6 +99,6 @@ AI4J 的 `OpenAiConfig` 默认使用：
 
 ## 6. 下一步
 
-- 普通 Java 接入：看 [Quickstart for Java](/docs/getting-started/quickstart-java)
-- Spring Boot 接入：看 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
-- 多实例入口：看 [Service Entry and Registry](/docs/capabilities/service-entry)
+- 普通 Java 接入：看 [Java 快速开始](/docs/getting-started/quickstart-java)
+- Spring Boot 接入：看 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
+- 多实例入口：看 [服务入口与注册表](/docs/capabilities/service-entry)

--- a/docs-site/docs/capabilities/models/overview.md
+++ b/docs-site/docs/capabilities/models/overview.md
@@ -163,13 +163,13 @@ AI4J 把图文输入纳入了统一会话抽象：
 
 建议按下面顺序读：
 
-1. [Chat](/docs/capabilities/models/chat)
-2. [Responses](/docs/capabilities/models/responses)
+1. [Chat 主线](/docs/capabilities/models/chat)
+2. [Responses 主线](/docs/capabilities/models/responses)
 3. [Messages](/docs/capabilities/models/messages)
-4. [Chat vs Responses](/docs/capabilities/models/chat-vs-responses)
-5. [Streaming](/docs/capabilities/models/streaming)
-6. [Multimodal](/docs/capabilities/models/multimodal)
-7. [Request and Response Conventions](/docs/capabilities/models/request-and-response-conventions)
+4. [Chat 与 Responses 对比](/docs/capabilities/models/chat-vs-responses)
+5. [流式语义](/docs/capabilities/models/streaming)
+6. [多模态](/docs/capabilities/models/multimodal)
+7. [请求与返回约定](/docs/capabilities/models/request-and-response-conventions)
 
 ## 9. 这一页的结论
 

--- a/docs-site/docs/capabilities/models/request-and-response-conventions.md
+++ b/docs-site/docs/capabilities/models/request-and-response-conventions.md
@@ -1,11 +1,10 @@
 ---
-title: Request and Response Conventions
+title: 请求与返回约定
 description: 统一讲解请求构造与返回读取约定，区分本地注册字段与 provider payload 字段、extraBody 角色及常见接入误区。
 tags: [concept]
 ---
 
-# Request and Response Conventions
-
+# 请求与返回约定
 这一页统一解释：**在 AI4J 里，请求应该怎么构造，返回应该怎么读，哪些字段是 SDK 本地语义，哪些字段才会真正进入 provider payload。**
 
 很多接入问题看起来像 provider 不稳定，实际上只是没有建立统一的请求/返回约定。

--- a/docs-site/docs/capabilities/models/responses.md
+++ b/docs-site/docs/capabilities/models/responses.md
@@ -1,11 +1,10 @@
 ---
-title: Responses
+title: Responses 主线
 description: 解析 AI4J Responses 主线的 ResponseRequest 语义、工具解析基座、payload 构建、流式事件聚合与 runtime 友好的运行模型。
 tags: [concept]
 ---
 
-# Responses
-
+# Responses 主线
 `Responses` 是 AI4J 当前更现代、更结构化的一条模型访问主线。
 
 它和 `Chat` 最大的差异，不是字段名从 `messages` 变成 `input`，而是 **它把模型输出首先当成事件和 item 流，而不是单条 assistant message**。

--- a/docs-site/docs/capabilities/models/streaming.md
+++ b/docs-site/docs/capabilities/models/streaming.md
@@ -1,11 +1,10 @@
 ---
-title: Streaming
+title: 流式语义
 description: 讲解 Chat 与 Responses 两条流式主线的聚合模型：SseListener 与 ResponseSseListener 维护的状态、tool call 聚合与终止条件差异。
 tags: [concept]
 ---
 
-# Streaming
-
+# 流式语义
 这一页只讲流式语义。
 
 在 AI4J 里，“streaming” 不是一个统一的 token 输出概念，而是三条不同主线各自对应的消费模型：

--- a/docs-site/docs/capabilities/overview.md
+++ b/docs-site/docs/capabilities/overview.md
@@ -34,7 +34,7 @@ Core SDK 解决的是：
 | 想做知识库或检索增强 | [Search & RAG](/docs/capabilities/rag/overview) | ingestion、chunk、embedding、vector、rerank、citation |
 | 想扩展 provider 或服务 | [Extension](/docs/extending/overview) | provider、model、service、HTTP stack 扩展方式 |
 
-如果你是第一次使用，先看 [Quickstart for Java](/docs/getting-started/quickstart-java)，再回到本页选择能力线。
+如果你是第一次使用，先看 [Java 快速开始](/docs/getting-started/quickstart-java)，再回到本页选择能力线。
 
 ## Core SDK 包含哪些能力
 
@@ -89,14 +89,14 @@ MCP 是协议化能力连接层。它既可以连接第三方 MCP server，也�
 
 上线前建议看：
 
-- [Version Compatibility](/docs/reference/version-compatibility)
-- [Security Overview](/docs/production/security)
-- [Production Checklist](/docs/production/production-checklist)
-- [Troubleshooting](/docs/production/troubleshooting)
+- [版本兼容性](/docs/reference/version-compatibility)
+- [安全总览](/docs/production/security)
+- [生产检查清单](/docs/production/production-checklist)
+- [排障指南](/docs/production/troubleshooting)
 
 ## 推荐阅读顺序
 
-1. [Service Entry and Registry](/docs/capabilities/service-entry)
+1. [服务入口与注册表](/docs/capabilities/service-entry)
 2. [Platform and Service Matrix](/docs/capabilities/models/platform-service-matrix)
 3. [Model Access](/docs/capabilities/models/overview)
 4. [Tools](/docs/capabilities/tools/overview)
@@ -106,4 +106,4 @@ MCP 是协议化能力连接层。它既可以连接第三方 MCP server，也�
 8. [Search & RAG](/docs/capabilities/rag/overview)
 9. [Extension](/docs/extending/overview)
 
-旧的 `ai-basics/`、`core-sdk/chat/`、`core-sdk/responses/`、`core-sdk/mcp/` 中仍有历史细节，但当前正式阅读路径以 sidebar 和 [Documentation Map](/docs/reference/maps/documentation-map) 为准。
+旧的 `ai-basics/`、`core-sdk/chat/`、`core-sdk/responses/`、`core-sdk/mcp/` 中仍有历史细节，但当前正式阅读路径以 sidebar 和 [文档地图](/docs/reference/maps/documentation-map) 为准。

--- a/docs-site/docs/capabilities/rag/chunking-strategies.md
+++ b/docs-site/docs/capabilities/rag/chunking-strategies.md
@@ -1,11 +1,10 @@
 ---
-title: Chunking Strategies
+title: 分块策略
 description: 讲清 AI4J 默认 RecursiveTextChunker 的真实行为与边界：它只填充 documentId/content/chunkIndex，不自动生成 chunkId、页码或章节元数据，以及 chunk 边界稳定性如何决定后续检索去重与引用质量。
 tags: [concept]
 ---
 
-# Chunking Strategies
-
+# 分块策略
 很多 RAG 文档会把 `chunking` 写成“把长文切成几段”。  
 在 AI4J 里，这样写太轻了。因为从源码看，chunking 决定的不只是文本长度，还决定：
 
@@ -257,6 +256,6 @@ AI4J 当前默认 chunking 的本质是：
 
 ## 12. 继续阅读
 
-- [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-- [Vector Store and Backends](/docs/capabilities/rag/vector-store-and-backends)
+- [摄取管线](/docs/capabilities/rag/ingestion-pipeline)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+- [向量存储与后端](/docs/capabilities/rag/vector-store-and-backends)

--- a/docs-site/docs/capabilities/rag/citations-and-trace.md
+++ b/docs-site/docs/capabilities/rag/citations-and-trace.md
@@ -1,11 +1,10 @@
 ---
-title: Citations and Trace
+title: 引用与 Trace
 description: 区分 AI4J 的 citation 与 trace 两条链：citation 由 DefaultRagContextAssembler 基于最终命中生成，trace 记录检索与 rerank 中间状态，generation usage 与 judge 分数需上层显式回填。
 tags: [concept]
 ---
 
-# Citations and Trace
-
+# 引用与 Trace
 AI4J 这一章里，`citation` 和 `trace` 很容易被一起写成“可解释性能力”。
 这个说法不算错，但太粗。源码里这两者其实解决的是两件不同的事：
 
@@ -382,6 +381,6 @@ AI4J 当前的 citation 和 trace 不是同一件事：
 
 ## 15. 继续阅读
 
-- [Chunking Strategies](/docs/capabilities/rag/chunking-strategies)
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
-- [Rerank](/docs/capabilities/rag/rerank)
+- [分块策略](/docs/capabilities/rag/chunking-strategies)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)
+- [重排](/docs/capabilities/rag/rerank)

--- a/docs-site/docs/capabilities/rag/embedding.md
+++ b/docs-site/docs/capabilities/rag/embedding.md
@@ -1,11 +1,10 @@
 ---
-title: Embedding
+title: 嵌入
 description: 讲清 AI4J embedding 层的薄接口与强约束：它统一 provider 调用但只支持 OPENAI/OLLAMA，ingest 与 query 必须使用同一模型，混用不会被框架自动阻止，是索引级协议的一部分。
 tags: [concept]
 ---
 
-# Embedding
-
+# 嵌入
 在 AI4J 当前实现里，`embedding` 不是一个孤立 API，而是离线 RAG 两端都在依赖的公共底座：
 
 - ingest 时，它把 chunk 变成向量
@@ -218,6 +217,6 @@ AI4J 当前的 embedding，是离线 RAG 的共享底层变换层：
 
 ## 12. 继续阅读
 
-- [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline)
-- [Vector Store and Backends](/docs/capabilities/rag/vector-store-and-backends)
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
+- [摄取管线](/docs/capabilities/rag/ingestion-pipeline)
+- [向量存储与后端](/docs/capabilities/rag/vector-store-and-backends)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)

--- a/docs-site/docs/capabilities/rag/evaluation.md
+++ b/docs-site/docs/capabilities/rag/evaluation.md
@@ -1,11 +1,10 @@
 ---
-title: RAG Evaluation
+title: RAG 评测
 description: 讲清 AI4J 两套评估器的边界：离线 RagEvaluator 用人工标注的相关 id 算 precision/recall/F1/MRR/NDCG 衡量检索质量，在线 RagOnlineEvaluator 在生成回答后用 judge 模型打 faithfulness 分，两者不混用、不替代。
 tags: [concept]
 ---
 
-# RAG Evaluation
-
+# RAG 评测
 在 AI4J 里，“评估 RAG” 不是一件事，而是两件边界完全不同的事：
 
 - **离线检索质量评估**：`RagEvaluator`，衡量“召回准不准”
@@ -187,7 +186,7 @@ RagEvaluation eval = new RagEvaluator().evaluate(hits, Arrays.asList("b", "d"), 
 
 在线评判层（`RagJudge` SPI、`ChatRagJudge` 三维评分协议、评判如何写进 `RagTrace`）的完整说明见 [LLM-as-Judge](/docs/capabilities/rag/llm-as-judge)。
 
-如果你要看在线 judge 怎么用，参考 [Citations and Trace](/docs/capabilities/rag/citations-and-trace)。
+如果你要看在线 judge 怎么用，参考 [引用与 Trace](/docs/capabilities/rag/citations-and-trace)。
 
 ## 9. 当前这一层没有替你做什么
 
@@ -222,7 +221,7 @@ precision@K = 0.6 这个数字本身没意义，只有和“换策略前的 0.5�
 
 ## 12. 继续阅读
 
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
-- [Rerank](/docs/capabilities/rag/rerank)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-- [Query Planning](/docs/capabilities/rag/query-planning)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)
+- [重排](/docs/capabilities/rag/rerank)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+- [查询规划](/docs/capabilities/rag/query-planning)

--- a/docs-site/docs/capabilities/rag/hybrid-retrieval.md
+++ b/docs-site/docs/capabilities/rag/hybrid-retrieval.md
@@ -1,11 +1,10 @@
 ---
-title: Hybrid Retrieval
+title: 混合检索
 description: 讲清 AI4J HybridRetriever 的本质是多检索器结果融合器而非固定 Dense+BM25 套餐：默认 RRF 按排名融合，用稳定 key 去重，融合后 score 语义变化以及无 getHybridRagService 便利入口的设计原因。
 tags: [concept]
 ---
 
-# Hybrid Retrieval
-
+# 混合检索
 在 AI4J 里，`hybrid retrieval` 不是一个“神秘黑盒检索器”，而是一个非常具体的组合器：
 
 - 先让多个 `Retriever` 各自出结果
@@ -291,7 +290,7 @@ new HybridRetriever(Arrays.asList(dense, bm25), new RsfFusionStrategy());
 new HybridRetriever(Arrays.asList(dense, bm25), new DbsfFusionStrategy());
 ```
 
-到底哪个更好，没有普适答案——它取决于你的 embedding 模型、BM25 语料分布和召回集大小。建议用 [RAG Evaluation](/docs/capabilities/rag/evaluation) 的 NDCG 指标在同一批标注 query 上做 A/B 对比，而不是拍脑袋选。
+到底哪个更好，没有普适答案——它取决于你的 embedding 模型、BM25 语料分布和召回集大小。建议用 [RAG 评测](/docs/capabilities/rag/evaluation) 的 NDCG 指标在同一批标注 query 上做 A/B 对比，而不是拍脑袋选。
 
 ## 5. “同一个命中” 是怎么判定的
 
@@ -455,8 +454,8 @@ AI4J 当前的 hybrid retrieval，本质上是一个 **`Retriever` 级结果融�
 
 ## 13. 继续阅读
 
-- [RAG Evaluation](/docs/capabilities/rag/evaluation)
-- [Query Planning](/docs/capabilities/rag/query-planning)
-- [Rerank](/docs/capabilities/rag/rerank)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-- [Vector Store and Backends](/docs/capabilities/rag/vector-store-and-backends)
+- [RAG 评测](/docs/capabilities/rag/evaluation)
+- [查询规划](/docs/capabilities/rag/query-planning)
+- [重排](/docs/capabilities/rag/rerank)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+- [向量存储与后端](/docs/capabilities/rag/vector-store-and-backends)

--- a/docs-site/docs/capabilities/rag/ingestion-pipeline.md
+++ b/docs-site/docs/capabilities/rag/ingestion-pipeline.md
@@ -1,11 +1,10 @@
 ---
-title: Ingestion Pipeline
+title: 摄取管线
 description: 讲清 AI4J IngestionPipeline 这条 RAG 入库编排层：source 加载、文本清洗、chunk、metadata 富化、批量 embedding 与 vector upsert 如何串成统一流水线，以及 documentId/contentHash 稳定性与可插拔扩展位点。
 tags: [concept]
 ---
 
-# Ingestion Pipeline
-
+# 摄取管线
 这页讲“文档如何进入知识库”。在 AI4J 里，`IngestionPipeline` 不是一个随手拼出来的 demo helper，而是一条明确的 RAG 入库编排层。
 
 如果你想真正看懂 AI4J 的 RAG 基座，这页必须讲透。因为它决定了：

--- a/docs-site/docs/capabilities/rag/llm-as-judge.md
+++ b/docs-site/docs/capabilities/rag/llm-as-judge.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 12
-title: LLM-as-Judge (Answer Quality)
+title: LLM-as-Judge（回答质量评判）
 description: "讲透 ai4j 的 RAG 回答质量评判层：RagJudge SPI、内置 ChatRagJudge 的三维评分协议（faithfulness/contextRelevance/answerRelevance，temperature 0、json_object、容错解析、分数钳制 [0,1]）、RagOnlineEvaluator 如何把评判写进 RagTrace，以及它与离线 RagEvaluator 检索指标的分工。"
 tags: [reference]
 ---
 
 # LLM-as-Judge（回答质量评判）
 
-[RAG Evaluation](/docs/capabilities/rag/evaluation) 里的 `RagEvaluator` 算的是**检索质量**——召回的相关 id 对不对。但召回准不代表回答好:一个 recall@K = 1.0 的系统,生成阶段仍可能跑题或幻觉。回答质量要用**评判层**(LLM-as-judge)来估。
+[RAG 评测](/docs/capabilities/rag/evaluation) 里的 `RagEvaluator` 算的是**检索质量**——召回的相关 id 对不对。但召回准不代表回答好:一个 recall@K = 1.0 的系统,生成阶段仍可能跑题或幻觉。回答质量要用**评判层**(LLM-as-judge)来估。
 
 这一层很小,但和检索指标不可互替。这页讲清它的 SPI、内置实现的固定协议、评判结果去哪了、以及它和离线指标的边界。
 
@@ -87,7 +87,7 @@ RagJudgeEvaluation evaluation = evaluator.evaluate(ragResult, answer);
 result.getTrace().setJudgeEvaluation(evaluation);
 ```
 
-所以回答质量的分数跟着 trace 走,后续在 [Citations and Trace](/docs/capabilities/rag/citations-and-trace) 里能取到。这让"检索的引用"和"回答质量的评判"挂在同一条 trace 上,审计和 UI 展示能一起拿。
+所以回答质量的分数跟着 trace 走,后续在 [引用与 Trace](/docs/capabilities/rag/citations-and-trace) 里能取到。这让"检索的引用"和"回答质量的评判"挂在同一条 trace 上,审计和 UI 展示能一起拿。
 
 ## 6. 自定义 judge:实现 `RagJudge` SPI
 
@@ -134,6 +134,6 @@ RagOnlineEvaluator evaluator = new RagOnlineEvaluator(new MyPairwiseJudge());
 
 ## 9. 继续阅读
 
-- **离线检索指标**(recall/NDCG,与 judge 分工):[RAG Evaluation](/docs/capabilities/rag/evaluation)
-- **评判结果随 trace 走**:[Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-- **检索本身怎么做**:[Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
+- **离线检索指标**(recall/NDCG,与 judge 分工):[RAG 评测](/docs/capabilities/rag/evaluation)
+- **评判结果随 trace 走**:[引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+- **检索本身怎么做**:[混合检索](/docs/capabilities/rag/hybrid-retrieval)

--- a/docs-site/docs/capabilities/rag/online-search.md
+++ b/docs-site/docs/capabilities/rag/online-search.md
@@ -1,11 +1,10 @@
 ---
-title: Online Search
+title: 联网搜索
 description: 讲清 AI4J Online Search 的真实定位：它不是统一检索框架，而是包裹 IChatService 的联网搜索增强层，用最后一条消息做 query 调 SearXNG，把结果 JSON 直接拼进用户 prompt，并会原地改写请求。
 tags: [concept]
 ---
 
-# Online Search
-
+# 联网搜索
 AI4J 当前的 `online search` 不是一套通用检索框架，也不是把网页抓取结果自动接进 `Retriever` 体系。  
 从源码看，它其实是一个更具体的东西：
 
@@ -270,5 +269,5 @@ AI4J 当前的 Online Search，本质上是一个 `IChatService` 级的联网搜
 ## 12. 继续阅读
 
 - [Search and RAG 总览](/docs/capabilities/rag/overview)
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)

--- a/docs-site/docs/capabilities/rag/overview.md
+++ b/docs-site/docs/capabilities/rag/overview.md
@@ -84,7 +84,7 @@ Retriever hybrid = new HybridRetriever(Arrays.asList(denseRetriever, bm25Retriev
 RagService rag = new DefaultRagService(hybrid);
 ```
 
-详见 [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)。
+详见 [混合检索](/docs/capabilities/rag/hybrid-retrieval)。
 
 ## 4. 入库主线默认怎么跑
 
@@ -218,15 +218,15 @@ Agent 负责多步决策、工具使用、状态推进；RAG 负责给模型补�
 
 如果你想建立最稳的源码心智模型，建议按下面顺序读：
 
-1. [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline)
-2. [Chunking Strategies](/docs/capabilities/rag/chunking-strategies)
-3. [Embedding](/docs/capabilities/rag/embedding)
-4. [Vector Store and Backends](/docs/capabilities/rag/vector-store-and-backends)
-5. [Query Planning](/docs/capabilities/rag/query-planning)
-6. [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
-7. [Rerank](/docs/capabilities/rag/rerank)
-8. [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-9. [Online Search](/docs/capabilities/rag/online-search)
+1. [摄取管线](/docs/capabilities/rag/ingestion-pipeline)
+2. [分块策略](/docs/capabilities/rag/chunking-strategies)
+3. [嵌入](/docs/capabilities/rag/embedding)
+4. [向量存储与后端](/docs/capabilities/rag/vector-store-and-backends)
+5. [查询规划](/docs/capabilities/rag/query-planning)
+6. [混合检索](/docs/capabilities/rag/hybrid-retrieval)
+7. [重排](/docs/capabilities/rag/rerank)
+8. [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+9. [联网搜索](/docs/capabilities/rag/online-search)
 
 这个顺序的核心逻辑是：
 

--- a/docs-site/docs/capabilities/rag/query-planning.md
+++ b/docs-site/docs/capabilities/rag/query-planning.md
@@ -1,11 +1,10 @@
 ---
-title: Query Planning
+title: 查询规划
 description: 讲清 AI4J RagQueryPlanner 检索前处理层：它在 Retriever 之前产出 rewrite/multi-query/HyDE/step-back 检索计划，多 variant 用 RRF 融合，rerank 与上下文组装仍回原 query，planner 异常自动回退。
 tags: [concept]
 ---
 
-# Query Planning
-
+# 查询规划
 `Query Planning` 是 RAG 检索前处理层。它只回答一个问题：
 
 > 原始用户问题进入 `Retriever` 之前，要不要先变成一条或多条更适合检索的 query？

--- a/docs-site/docs/capabilities/rag/rerank.md
+++ b/docs-site/docs/capabilities/rag/rerank.md
@@ -1,11 +1,10 @@
 ---
-title: Rerank
+title: 重排
 description: 讲清 AI4J rerank 层：它夹在 retrieval 与 context assembly 之间做排序修正，默认 NoopReranker 不远程重排，ModelReranker 靠 provider 返回 index 映射，finalTopK 在 rerank 之后裁剪，returnDocuments 可能改写命中内容。
 tags: [concept]
 ---
 
-# Rerank
-
+# 重排
 `rerank` 在 AI4J 里的位置很容易被写浅。  
 它既不是“第二个 retriever”，也不是“最后给模型的 prompt 优化器”，而是夹在 **retrieval** 和 **context assembly** 之间的一层排序修正。
 
@@ -295,6 +294,6 @@ AI4J 当前的 rerank，不是另一套检索框架，而是 `DefaultRagService`
 
 ## 13. 继续阅读
 
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-- [Embedding](/docs/capabilities/rag/embedding)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
+- [嵌入](/docs/capabilities/rag/embedding)

--- a/docs-site/docs/capabilities/rag/vector-store-and-backends.md
+++ b/docs-site/docs/capabilities/rag/vector-store-and-backends.md
@@ -1,11 +1,10 @@
 ---
-title: Vector Store and Backends
+title: 向量存储与后端
 description: 讲清 AI4J VectorStore 统一契约如何收口 Pinecone/Qdrant/Milvus/PgVector/Redis 五个后端：dataset 是硬边界，capabilities() 显式暴露 returnStoredVector/metadataLookup 差异，统一调用但不抹平存储现实。
 tags: [concept]
 ---
 
-# Vector Store and Backends
-
+# 向量存储与后端
 AI4J 这一层如果只写成“支持 Pinecone / Qdrant / Milvus / PgVector / Redis”，信息密度其实很低。
 真正重要的是：**它怎样用统一 `VectorStore` 契约把不同后端收口，同时又不假装这些后端完全等价。**
 
@@ -261,6 +260,6 @@ AI4J 当前的向量存储层，本质上是：
 
 ## 11. 继续阅读
 
-- [Embedding](/docs/capabilities/rag/embedding)
-- [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline)
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
+- [嵌入](/docs/capabilities/rag/embedding)
+- [摄取管线](/docs/capabilities/rag/ingestion-pipeline)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)

--- a/docs-site/docs/capabilities/service-entry.md
+++ b/docs-site/docs/capabilities/service-entry.md
@@ -1,11 +1,10 @@
 ---
-title: Service Entry and Registry
+title: 服务入口与注册表
 description: 厘清 AiService 单实例入口与 AiServiceRegistry 多实例注册表的真实职责、配置回退和扩展边界。
 tags: [concept]
 ---
 
-# Service Entry and Registry
-
+# 服务入口与注册表
 这一页回答 `Core SDK` 最核心的工程问题之一：**当你真正开始接 provider、切模型、加能力时，代码应该从哪里进入。**
 
 ## 1. 先记住两条主线

--- a/docs-site/docs/capabilities/skills/overview.md
+++ b/docs-site/docs/capabilities/skills/overview.md
@@ -154,7 +154,7 @@ skill 不负责：
 这四层一起构成的，才是当前 AI4J 的 skill 体系。
 
 :::note 第三方 Skill 也可以走扩展 SPI
-除内置的 `.ai4j/skills` 目录发现外，第三方 jar 同样能通过扩展 SPI（`ServiceLoader` + `ExtensionRegistry`）把 Skill 作为资源注入，门禁规则与 Tool/Prompt 一致，默认不自动暴露。见 [Plugin Packages](/docs/extending/plugins/plugin-packages)。
+除内置的 `.ai4j/skills` 目录发现外，第三方 jar 同样能通过扩展 SPI（`ServiceLoader` + `ExtensionRegistry`）把 Skill 作为资源注入，门禁规则与 Tool/Prompt 一致，默认不自动暴露。见 [插件包](/docs/extending/plugins/plugin-packages)。
 :::
 
 ## 7. 典型工作流是什么
@@ -258,7 +258,7 @@ AI4J 的设计重点是：
 ## 11. 推荐阅读顺序
 
 1. [Discovery and Loading](/docs/capabilities/skills/discovery)
-2. [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)
+2. [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)
 3. [Coding Agent / Skills](/docs/products/coding-agent/skills)
 
 ## 12. 这页最该记住的结论

--- a/docs-site/docs/capabilities/skills/skill-vs-tool-vs-mcp.md
+++ b/docs-site/docs/capabilities/skills/skill-vs-tool-vs-mcp.md
@@ -1,11 +1,10 @@
 ---
-title: "Skill vs Tool vs MCP"
+title: Skill、Tool 与 MCP 对比
 description: "用定义、对比表与源码入口区分 AI4J 三大基座概念：Skill 管方法论上下文、Tool 管宿主内执行、MCP 管外部协议接入，澄清投影与归属的常见混淆。"
 tags: [concept]
 ---
 
-# Skill vs Tool vs MCP
-
+# Skill、Tool 与 MCP 对比
 这三个词是 AI4J 文档里最容易被混掉的部分。
 
 原因很简单：

--- a/docs-site/docs/capabilities/tools/annotation-based-tools.md
+++ b/docs-site/docs/capabilities/tools/annotation-based-tools.md
@@ -1,11 +1,10 @@
 ---
-title: "Annotation-based Tools"
+title: 注解式工具
 description: "深入 @FunctionCall、@FunctionRequest、@FunctionParameter 三注解如何把 Java 类型绑定为 provider tool schema，详解 ToolUtil 生成链、类型映射规则与真实约束。"
 tags: [concept]
 ---
 
-# Annotation-based Tools
-
+# 注解式工具
 AI4J 推荐注解式工具，不是因为“代码更短”，而是因为它把 Java 类型、字段说明和 provider tool schema 绑定到了同一条生成链上。
 
 如果这一页只停留在“三个注解怎么写”，会漏掉两个真正重要的点：
@@ -247,7 +246,7 @@ public class WeatherMcpService {
 | 暴露名 | `@FunctionCall(name)` 原样 | 由 `generateApiFunctionName(service, tool)` 生成（仅保留字母/数字/下划线/连字符，最长 64，必要时加 `tool_` 前缀） |
 | 扫描入口 | `ToolUtil.scanFunctionTools()` | `ToolUtil.scanMcpTools()` |
 
-两套注解最终都会被 `ToolUtil` 扫描、缓存，并投影成统一的 `Tool.Function` 视图进入请求白名单（见 [Tool Execution Model](/docs/capabilities/tools/tool-execution-model)）。完整的 transport 启停、网关治理、远端/本地投影语义属于 MCP 协议层，见 [构建 MCP 服务](/docs/capabilities/mcp/build-your-mcp-server)。
+两套注解最终都会被 `ToolUtil` 扫描、缓存，并投影成统一的 `Tool.Function` 视图进入请求白名单（见 [工具执行模型](/docs/capabilities/tools/tool-execution-model)）。完整的 transport 启停、网关治理、远端/本地投影语义属于 MCP 协议层，见 [构建 MCP 服务](/docs/capabilities/mcp/build-your-mcp-server)。
 
 ## 10. 最稳的设计建议
 

--- a/docs-site/docs/capabilities/tools/function-calling.md
+++ b/docs-site/docs/capabilities/tools/function-calling.md
@@ -1,11 +1,10 @@
 ---
-title: "Function Calling"
+title: 函数调用
 description: "讲清 AI4J 基座层 Function Calling 执行链：用注解声明工具、ToolUtil 按白名单生成 provider tool schema、请求挂载与 tool call 回流，及其与 MCP、Agent 的边界。"
 tags: [concept]
 ---
 
-# Function Calling
-
+# 函数调用
 `Function Calling` 是 AI4J 基座层最核心的一条执行链。它不是简单的“把一个 Java 方法暴露给模型”，而是把本地能力稳定地转成模型可理解的 schema，再把调用结果交回当前 runtime 处理。
 
 如果这页没讲清楚，后面的 `Tool`、`Skill`、`MCP`、`Agent`、`Coding Agent` 都会看起来像混在一起的“模型扩展”。

--- a/docs-site/docs/capabilities/tools/overview.md
+++ b/docs-site/docs/capabilities/tools/overview.md
@@ -83,7 +83,7 @@ tags: [concept]
 
 ### 3.5 第三方扩展插件（SPI）
 
-上述四类都是基座内置来源。若要让**第三方 jar** 也注入工具（或命令、Skill、Prompt、Guardrail），走的是扩展 SPI——`ServiceLoader` 发现 + `ExtensionRegistry` 的 `discover/enable/exposeTool` 三段式门禁，**默认不自动把插件工具暴露给模型**。这条注入路径与本章的注解/白名单机制互补，详见 [Plugin Packages](/docs/extending/plugins/plugin-packages)。
+上述四类都是基座内置来源。若要让**第三方 jar** 也注入工具（或命令、Skill、Prompt、Guardrail），走的是扩展 SPI——`ServiceLoader` 发现 + `ExtensionRegistry` 的 `discover/enable/exposeTool` 三段式门禁，**默认不自动把插件工具暴露给模型**。这条注入路径与本章的注解/白名单机制互补，详见 [插件包](/docs/extending/plugins/plugin-packages)。
 
 ## 4. 一条最重要的主线
 
@@ -187,28 +187,28 @@ Core SDK 负责：
 
 重点看：
 
-- [Function Calling](/docs/capabilities/tools/function-calling)
-- [Annotation-based Tools](/docs/capabilities/tools/annotation-based-tools)
+- [函数调用](/docs/capabilities/tools/function-calling)
+- [注解式工具](/docs/capabilities/tools/annotation-based-tools)
 
 ### 想理解模型返回 tool call 后怎么执行
 
 重点看：
 
-- [Tool Execution Model](/docs/capabilities/tools/tool-execution-model)
+- [工具执行模型](/docs/capabilities/tools/tool-execution-model)
 
 ### 关心暴露边界和宿主安全
 
 重点看：
 
-- [Tool Whitelist and Security](/docs/capabilities/tools/tool-whitelist-and-security)
+- [工具白名单与安全](/docs/capabilities/tools/tool-whitelist-and-security)
 
 ## 11. 推荐阅读顺序
 
-1. [Function Calling](/docs/capabilities/tools/function-calling)
-2. [Annotation-based Tools](/docs/capabilities/tools/annotation-based-tools)
-3. [Tool Execution Model](/docs/capabilities/tools/tool-execution-model)
-4. [Tool Whitelist and Security](/docs/capabilities/tools/tool-whitelist-and-security)
-5. [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)
+1. [函数调用](/docs/capabilities/tools/function-calling)
+2. [注解式工具](/docs/capabilities/tools/annotation-based-tools)
+3. [工具执行模型](/docs/capabilities/tools/tool-execution-model)
+4. [工具白名单与安全](/docs/capabilities/tools/tool-whitelist-and-security)
+5. [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)
 
 ## 12. 这页最该记住的结论
 

--- a/docs-site/docs/capabilities/tools/tool-execution-model.md
+++ b/docs-site/docs/capabilities/tools/tool-execution-model.md
@@ -1,11 +1,10 @@
 ---
-title: "Tool Execution Model"
+title: 工具执行模型
 description: "拆解 AI4J 工具执行模型四段链：发现注册、请求级白名单、provider 返回 tool call、本地调用路由与执行，讲清 built-in/Function/MCP 优先级与结果文本化回流。"
 tags: [concept]
 ---
 
-# Tool Execution Model
-
+# 工具执行模型
 这一页讲的不是“工具怎么声明”，而是工具一旦进入请求链后，AI4J 实际怎样完成：
 
 - 工具集合生成

--- a/docs-site/docs/capabilities/tools/tool-whitelist-and-security.md
+++ b/docs-site/docs/capabilities/tools/tool-whitelist-and-security.md
@@ -1,11 +1,10 @@
 ---
-title: "Tool Whitelist and Security"
+title: 工具白名单与安全
 description: "讲清 AI4J 工具安全两层防线：请求级 functions/mcpServices 白名单与 BuiltInToolContext 工作区读写边界，剖析 bash 等高风险 built-in 与待补的审批沙箱治理。"
 tags: [concept]
 ---
 
-# Tool Whitelist and Security
-
+# 工具白名单与安全
 工具安全里最重要的原则不是“模型能不能调”，而是“默认让模型看见什么、让它能碰到什么”。
 
 AI4J 当前基座层采用的是两层防线：

--- a/docs-site/docs/extending/code-level/model-extension.md
+++ b/docs-site/docs/extending/code-level/model-extension.md
@@ -1,11 +1,10 @@
 ---
-title: Model Extension
+title: 模型扩展
 description: 讲清 AI4J model extension：在不新增 PlatformType 的前提下，把新模型能力吸收进现有 provider 与现有契约，主战场是请求对象和 provider 适配层，强调把 provider 差异收敛在 provider service 内部而非泄漏到业务层。
 tags: [concept]
 ---
 
-# Model Extension
-
+# 模型扩展
 `model extension` 解决的是：**在不新增 `PlatformType`、不新增顶层 service 的前提下，把新的模型能力吸收到现有 provider 与现有契约中。**
 
 这是 AI4J 里最常见、也最容易被误判的一类扩展。

--- a/docs-site/docs/extending/code-level/provider-extension.md
+++ b/docs-site/docs/extending/code-level/provider-extension.md
@@ -1,11 +1,10 @@
 ---
-title: Provider Extension
+title: Provider 扩展
 description: 讲清 AI4J provider extension：新增模型平台是显式工厂分发扩展，必须同时触碰 PlatformType、Configuration、AiService、DefaultAiServiceRegistry 与 Spring Boot starter，provider 支持矩阵显式维护而非自动发现。
 tags: [concept]
 ---
 
-# Provider Extension
-
+# Provider 扩展
 `provider extension` 解决的是：**把一个新的模型平台正式纳入 AI4J 的平台分发体系**。  
 它不是“再写一个 service 类”这么简单，因为 AI4J 当前对 provider 的建模是显式的、枚举驱动的。
 
@@ -56,7 +55,7 @@ AI4J 目前并没有“注册一个 provider 插件即可接入”的通用 prov
 - 某个 provider 的 `Chat` 已有能力里增加一个可选选项
 - 同一协议族下只是切换 `apiHost`
 
-这些更像 [Model Extension](/docs/extending/code-level/model-extension)。
+这些更像 [模型扩展](/docs/extending/code-level/model-extension)。
 
 只有当你需要：
 

--- a/docs-site/docs/extending/code-level/service-extension.md
+++ b/docs-site/docs/extending/code-level/service-extension.md
@@ -1,11 +1,10 @@
 ---
-title: Service Extension
+title: 服务扩展
 description: 讲清 AI4J service extension：新增顶层能力契约会扩大整个 SDK 公共 API 面，必须同步 AiService、AiServiceRegistry 与 FreeAiService 兼容入口，AiServiceFactory 不是 service 插件总线，仅在现有契约无法承载时才值得新增。
 tags: [concept]
 ---
 
-# Service Extension
-
+# 服务扩展
 `service extension` 解决的是：**AI4J 是否要新增一条新的顶层能力契约**。  
 这比 model extension 更重，因为你不是在补某个平台，而是在扩大整个 SDK 的公共能力面。
 

--- a/docs-site/docs/extending/code-level/spi-http-stack.md
+++ b/docs-site/docs/extending/code-level/spi-http-stack.md
@@ -1,11 +1,10 @@
 ---
-title: SPI HTTP Stack
+title: SPI HTTP 栈
 description: 讲清 AI4J HTTP stack SPI：通过 ServiceLoader 把 Dispatcher 与 ConnectionPool 注入 starter 构造的统一 OkHttpClient，默认实现靠 META-INF/services 注册，丢失会导致启动失败，仅 starter 装配链自动生效。
 tags: [concept]
 ---
 
-# SPI HTTP Stack
-
+# SPI HTTP 栈
 这一页讲的是 AI4J 当前少数真正已经 SPI 化的扩展面之一：**底层 `OkHttp` 并发调度与连接池策略**。
 
 它和 provider extension 最大的区别是：这里不是靠 `AiService` 里的 `switch` 接线，而是真的走了 Java `ServiceLoader`。

--- a/docs-site/docs/extending/extend-ai4j.md
+++ b/docs-site/docs/extending/extend-ai4j.md
@@ -32,7 +32,7 @@ tags: [concept]
 
 关键边界是**三段式门禁**：`discover()` 只发现不执行，`enable(...)` 注册资源但不暴露给模型，`exposeTool(...)` 才把指定工具交给 agent tool registry。这个设计刻意不做"安装即自动可用"。
 
-→ [Plugin Packages](/docs/extending/plugins/plugin-packages)（概念与门禁）｜[Plugin Recipes](/docs/extending/plugins/plugin-recipes)（可复制接入配方）
+→ [插件包](/docs/extending/plugins/plugin-packages)（概念与门禁）｜[插件配方](/docs/extending/plugins/plugin-recipes)（可复制接入配方）
 
 ---
 
@@ -42,7 +42,7 @@ tags: [concept]
 
 最常见的载体就是 `SKILL.md`。它解决"方法论如何复用"，而不是"动作如何执行"——所以它不直接承担执行，也不会自动塞满上下文。
 
-→ [Skills 总览](/docs/capabilities/skills/overview)｜[Discovery and Loading](/docs/capabilities/skills/discovery)｜[Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)｜[Coding Agent Skills 使用与组织](/docs/products/coding-agent/skills)
+→ [Skills 总览](/docs/capabilities/skills/overview)｜[Discovery and Loading](/docs/capabilities/skills/discovery)｜[Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)｜[Coding Agent Skills 使用与组织](/docs/products/coding-agent/skills)
 
 ---
 
@@ -53,9 +53,9 @@ ai4j 没有独立的"slash 提示模板引擎"。**Prompt 是插件资源的一�
 也就是说，ai4j 的 Prompt 和 Skill 共享同一套"摘要先行、按需读取"的上下文治理思路，区别在资源类型。ai4j 有**两个官方参考插件**，各有侧重：
 
 - **`ask-user`**——最小插件（host-mediated 用户澄清 tool + command + Skill + Prompt），适合学习扩展的基本骨架。
-- **`dynamic-workflow`**——🚀 **生产级旗舰参考**（同时贡献 4 种能力 + host-mediated workflow 信封 + 零运行时依赖 + live 闭环测试）。适合学习如何构建一个完整的、安全的、可发布的 ai4j 插件。详见 [Dynamic Workflow Plugin](/docs/extending/plugins/dynamic-workflow-plugin)。
+- **`dynamic-workflow`**——🚀 **生产级旗舰参考**（同时贡献 4 种能力 + host-mediated workflow 信封 + 零运行时依赖 + live 闭环测试）。适合学习如何构建一个完整的、安全的、可发布的 ai4j 插件。详见 [动态工作流插件](/docs/extending/plugins/dynamic-workflow-plugin)。
 
-→ [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)（同时贡献 Prompt 的样板）｜[Dynamic Workflow Plugin](/docs/extending/plugins/dynamic-workflow-plugin)（脚本化 Prompt + Skill 样板）
+→ [Ask User 插件](/docs/extending/plugins/ask-user-plugin)（同时贡献 Prompt 的样板）｜[动态工作流插件](/docs/extending/plugins/dynamic-workflow-plugin)（脚本化 Prompt + Skill 样板）
 
 ---
 
@@ -73,7 +73,7 @@ ai4j 没有独立的"slash 提示模板引擎"。**Prompt 是插件资源的一�
 插件包**不能**用来新增 provider。要接一个新 LLM 后端，仍然走代码主链；插件包只负责给 agent 暴露运行时资源（工具 / 命令 / Skill / Prompt / Guardrail）。
 :::
 
-→ [Provider Extension](/docs/extending/code-level/provider-extension)｜[Model Extension](/docs/extending/code-level/model-extension)｜[Service Extension](/docs/extending/code-level/service-extension)｜[Extension 总览](/docs/extending/overview)
+→ [Provider 扩展](/docs/extending/code-level/provider-extension)｜[模型扩展](/docs/extending/code-level/model-extension)｜[服务扩展](/docs/extending/code-level/service-extension)｜[Extension 总览](/docs/extending/overview)
 
 ---
 
@@ -115,7 +115,7 @@ Agent agent = Agents.react()
 运行时会把暴露出的 `ExtensionToolSpec` 转成普通 `Tool`，把 `ExtensionToolExecutor` 路由到现有 `ToolExecutor`——Agent 主循环不用认识插件实现类。
 
 :::note Spring Boot
-Spring Boot 项目可以用配置完成同一件事：`ai.extensions.enabled` + `ai.extensions.tools.expose`，starter 会自动装配 `ExtensionRegistry` / `ExtensionRuntimeSnapshot`，但不会自动创建 Agent。详见 [Plugin Recipes](/docs/extending/plugins/plugin-recipes)。
+Spring Boot 项目可以用配置完成同一件事：`ai.extensions.enabled` + `ai.extensions.tools.expose`，starter 会自动装配 `ExtensionRegistry` / `ExtensionRuntimeSnapshot`，但不会自动创建 Agent。详见 [插件配方](/docs/extending/plugins/plugin-recipes)。
 :::
 
 ---
@@ -134,8 +134,8 @@ Spring Boot 项目可以用配置完成同一件事：`ai.extensions.enabled` + 
 ## 继续阅读
 
 - [Extension 总览](/docs/extending/overview)——四条扩展线的全景与决策顺序
-- [Plugin Packages](/docs/extending/plugins/plugin-packages)——插件包概念与三段式门禁
+- [插件包](/docs/extending/plugins/plugin-packages)——插件包概念与三段式门禁
 - [Skills 总览](/docs/capabilities/skills/overview)——Skill 作为上下文治理层
-- [Tools](/docs/capabilities/tools/overview)——工具是模型在宿主内的执行能力（Skill / Tool / MCP 三者对比见 [Skill vs Tool vs MCP](/docs/capabilities/skills/skill-vs-tool-vs-mcp)）
+- [Tools](/docs/capabilities/tools/overview)——工具是模型在宿主内的执行能力（Skill / Tool / MCP 三者对比见 [Skill、Tool 与 MCP 对比](/docs/capabilities/skills/skill-vs-tool-vs-mcp)）
 - [Agent Runtime](/docs/agent/overview)——插件工具接入通用 Agent loop 的宿主
 - [Coding Agent](/docs/products/coding-agent/overview)——插件工具 + Skill + Prompt 在 coding session 里的使用

--- a/docs-site/docs/extending/overview.md
+++ b/docs-site/docs/extending/overview.md
@@ -95,7 +95,7 @@ AI4J 当前的扩展链路，大体上是下面这条：
 
 插件作者和使用者可以用 `ExtensionValidator` 或 `ai4j-cli extension validate <id>|--all` 做本地校验。校验会调用插件 `apply(...)` 收集运行时贡献，只报告 manifest、runtime resource、tool schema 和 classpath 资源问题，不会暴露工具给模型，也不会执行 command。接入前还可以用 `ai4j-cli extension plan <id> --enable ... --strict` 查看本次计划启用、授权和暴露后的 activation state；recipe 固定后，用 `ai4j-cli extension check <id> --enable ... --strict` 作为 CI 或发布前门禁。`check` 会在 validation 失败或显式请求的资源没有 active 时返回非零，但不会强制启用未请求资源。
 
-官方 `ai4j-plugin-ask-user` 是第一个随 SDK 发布的样板插件，展示如何把 Agent 需要的用户确认表达成 host-mediated JSON envelope；独立仓库 `ai4j-plugin-dynamic-workflow` 展示如何把动态工作流请求表达成同样受宿主管控的 plugin envelope。已经准备接入插件时，优先看 [Plugin Recipes](/docs/extending/plugins/plugin-recipes)，它把依赖、检查、启用、授权、暴露和 Spring Boot / CLI 配置串成可复制配方。
+官方 `ai4j-plugin-ask-user` 是第一个随 SDK 发布的样板插件，展示如何把 Agent 需要的用户确认表达成 host-mediated JSON envelope；独立仓库 `ai4j-plugin-dynamic-workflow` 展示如何把动态工作流请求表达成同样受宿主管控的 plugin envelope。已经准备接入插件时，优先看 [插件配方](/docs/extending/plugins/plugin-recipes)，它把依赖、检查、启用、授权、暴露和 Spring Boot / CLI 配置串成可复制配方。
 
 #### 3.1 插件能力清单（六种）
 
@@ -112,7 +112,7 @@ AI4J 当前的扩展链路，大体上是下面这条：
 
 前五种能力覆盖“插件贡献什么资源”。`LIFECYCLE` 是第六种，覆盖的是另一类需求：**插件想在 agent 执行的关键节点（会话开始结束、每轮前后、模型请求前后、工具调用前后、上下文压缩前后）收到通知**，而不是贡献工具或资源。它解决的是观察/遥测/审计类扩展，而不是新增能力。
 
-声明 `LIFECYCLE` 后，插件在 `apply(...)` 里通过 `context.lifecycle().register(hook)` 注册 `AgentLifecycleHook`，agent 运行时会通过 `AgentLifecycleHookDispatcher` 把 `AgentLifecycleEvent` 分发给每个 hook。详见 [Lifecycle Extensions](/docs/extending/plugins/lifecycle-extensions)。
+声明 `LIFECYCLE` 后，插件在 `apply(...)` 里通过 `context.lifecycle().register(hook)` 注册 `AgentLifecycleHook`，agent 运行时会通过 `AgentLifecycleHookDispatcher` 把 `AgentLifecycleEvent` 分发给每个 hook。详见 [生命周期扩展](/docs/extending/plugins/lifecycle-extensions)。
 
 #### 3.2 插件 SPI 的稳定性矩阵
 
@@ -164,7 +164,7 @@ Spring Boot starter 在 `AiConfigAutoConfiguration.initOkHttp()` 里通过 `Serv
 
 `Ai4jExtension` 也通过 `ServiceLoader` 发现，但它服务的是插件包资源注册，不会自动改变 provider 工厂分发。
 
-插件发现本身也有一层小 SPI：`ExtensionLoader` 接口（默认实现是 `@Internal` 的 `ServiceLoaderExtensionLoader`）。`ExtensionRegistry.discover()` 默认走 ServiceLoader，但你可以传一个自定义 `ExtensionLoader` 实现非 ServiceLoader 发现（例如固定列表、运行时扫描）。读取插件 jar 内的 Skill / Prompt 文本资源时，公共助手 `ExtensionResourceResolver` 会按“插件 classloader → TCCL → resolver classloader”的顺序解析，并把解析约束在插件自己的 classloader 上，避免同名资源被别的 jar 串读。这两者属于运行时接线细节，详见 [Extension SPI Internals](/docs/extending/plugins/extension-spi)。
+插件发现本身也有一层小 SPI：`ExtensionLoader` 接口（默认实现是 `@Internal` 的 `ServiceLoaderExtensionLoader`）。`ExtensionRegistry.discover()` 默认走 ServiceLoader，但你可以传一个自定义 `ExtensionLoader` 实现非 ServiceLoader 发现（例如固定列表、运行时扫描）。读取插件 jar 内的 Skill / Prompt 文本资源时，公共助手 `ExtensionResourceResolver` 会按“插件 classloader → TCCL → resolver classloader”的顺序解析，并把解析约束在插件自己的 classloader 上，避免同名资源被别的 jar 串读。这两者属于运行时接线细节，详见 [扩展 SPI 内部机制](/docs/extending/plugins/extension-spi)。
 
 ## 5. 扩展决策顺序
 
@@ -208,17 +208,17 @@ Spring Boot starter 在 `AiConfigAutoConfiguration.initOkHttp()` 里通过 `Serv
 
 ## 8. 推荐阅读顺序
 
-1. [Provider Extension](/docs/extending/code-level/provider-extension)
-2. [Model Extension](/docs/extending/code-level/model-extension)
-3. [Service Extension](/docs/extending/code-level/service-extension)
-4. [SPI HTTP Stack](/docs/extending/code-level/spi-http-stack)
-5. [Plugin Packages](/docs/extending/plugins/plugin-packages)
-6. [Plugin Recipes](/docs/extending/plugins/plugin-recipes)
-7. [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)
-8. [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)
-9. [Dynamic Workflow Plugin](/docs/extending/plugins/dynamic-workflow-plugin)
-10. [Lifecycle Extensions](/docs/extending/plugins/lifecycle-extensions)
-11. [Extension SPI Internals](/docs/extending/plugins/extension-spi)
+1. [Provider 扩展](/docs/extending/code-level/provider-extension)
+2. [模型扩展](/docs/extending/code-level/model-extension)
+3. [服务扩展](/docs/extending/code-level/service-extension)
+4. [SPI HTTP 栈](/docs/extending/code-level/spi-http-stack)
+5. [插件包](/docs/extending/plugins/plugin-packages)
+6. [插件配方](/docs/extending/plugins/plugin-recipes)
+7. [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)
+8. [Ask User 插件](/docs/extending/plugins/ask-user-plugin)
+9. [动态工作流插件](/docs/extending/plugins/dynamic-workflow-plugin)
+10. [生命周期扩展](/docs/extending/plugins/lifecycle-extensions)
+11. [扩展 SPI 内部机制](/docs/extending/plugins/extension-spi)
 
 ## 9. 这一页的结论
 

--- a/docs-site/docs/extending/plugins/ask-user-plugin.md
+++ b/docs-site/docs/extending/plugins/ask-user-plugin.md
@@ -1,11 +1,10 @@
 ---
-title: Ask User Plugin
+title: Ask User 插件
 description: 讲清 ai4j-plugin-ask-user 样板插件：它把 Agent 需要的人类确认表达成 host-mediated JSON envelope，贡献 ask_user tool 与 command/Skill/Prompt 资源，本身不打开 UI、不读 stdin、不阻塞，由宿主决定展示与恢复。
 tags: [integration]
 ---
 
-# Ask User Plugin
-
+# Ask User 插件
 `ai4j-plugin-ask-user` 是 AI4J 的官方样板插件。它展示一件事：**插件可以把 Agent 需要的人类确认或补充信息，表达成结构化请求，由宿主应用负责展示、收集答案和恢复执行**。
 
 它不是 UI 组件，也不会阻塞读取 stdin。它只贡献 tool、command、Skill 和 Prompt 资源。
@@ -289,4 +288,4 @@ mvn -pl ai4j-plugin-ask-user -am -DskipTests=false test
 
 ## 11. 继续组装
 
-如果你要把 `ask-user` 和其他第三方插件一起接入，继续看 [Plugin Recipes](/docs/extending/plugins/plugin-recipes)。那里给出了普通 Java、Spring Boot、CLI 检查和多插件组合的完整配置形态。
+如果你要把 `ask-user` 和其他第三方插件一起接入，继续看 [插件配方](/docs/extending/plugins/plugin-recipes)。那里给出了普通 Java、Spring Boot、CLI 检查和多插件组合的完整配置形态。

--- a/docs-site/docs/extending/plugins/dynamic-workflow-plugin.md
+++ b/docs-site/docs/extending/plugins/dynamic-workflow-plugin.md
@@ -1,11 +1,10 @@
 ---
-title: Dynamic Workflow Plugin
+title: 动态工作流插件
 description: 讲清 ai4j-plugin-dynamic-workflow 样板插件：模型把复杂任务写成确定性 workflow script，插件只返回 host-mediated 请求 envelope，实际执行由 ai4j-agent runtime 可选接管，内置 Nashorn 执行器默认关闭 Java interop。
 tags: [integration]
 ---
 
-# Dynamic Workflow Plugin
-
+# 动态工作流插件
 :::tip 🚀 生产级参考插件
 `ai4j-plugin-dynamic-workflow` 是 ai4j 的**旗舰参考插件**——同时展示全部 4 种扩展能力（Tool + Command + Skill + Prompt），零运行时依赖（仅 `ai4j-extension-api`），安全设计（host-mediated 请求信封，不执行 JS / 不 spawn agent / 不碰文件），含 9 个单元测试 + 3 个 live 闭环烟测（MiniMax M3 → 脚本 → 信封 → agent 执行 → E2B 沙箱），Java 8 兼容，GitHub Actions CI。
 
@@ -342,8 +341,8 @@ ai4j-cli extension run --enable dynamic-workflow --allow-command workflow workfl
 
 ## 10. 推荐阅读
 
-- [Plugin Packages](/docs/extending/plugins/plugin-packages)
-- [Plugin Recipes](/docs/extending/plugins/plugin-recipes)
-- [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)
+- [插件包](/docs/extending/plugins/plugin-packages)
+- [插件配方](/docs/extending/plugins/plugin-recipes)
+- [Ask User 插件](/docs/extending/plugins/ask-user-plugin)
 - [Agent / Orchestration](/docs/agent/runtimes/workflow-stategraph)
 - [Coding Agent / Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)

--- a/docs-site/docs/extending/plugins/extension-spi.md
+++ b/docs-site/docs/extending/plugins/extension-spi.md
@@ -1,14 +1,13 @@
 ---
-title: Extension SPI Internals
+title: 扩展 SPI 内部机制
 description: 讲清插件发现与资源读取的两层内部 SPI：ExtensionLoader 接口允许用非 ServiceLoader 方式发现插件（默认 ServiceLoaderExtensionLoader 标注 Internal），ExtensionResourceResolver 公共助手按插件 classloader -> TCCL -> resolver classloader 顺序读取 classpath 文本资源并隔离各插件 jar，以及发现之后 ExtensionRegistry.list() 返回的检视投影 DiscoveredExtension（manifest + extension + enabled）。
 tags: [reference]
 ---
 
-# Extension SPI Internals
-
+# 扩展 SPI 内部机制
 这一页覆盖插件机制里两个底层接线点：**怎么发现插件**，以及**怎么从插件 jar 里读 classpath 文本资源**。它们不是日常写插件会碰到的东西，只有在自定义发现方式、排查资源读取问题或构建宿主框架时才需要。
 
-如果你只是写一个普通插件，看 [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook) 就够了。
+如果你只是写一个普通插件，看 [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook) 就够了。
 
 ## 1. 插件发现：`ExtensionLoader`
 
@@ -190,6 +189,6 @@ String markdown = ExtensionResourceResolver.readTextStrict(
 
 ## 4. 下一步阅读
 
-1. [Plugin Packages](/docs/extending/plugins/plugin-packages)
-2. [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)
-3. [Lifecycle Extensions](/docs/extending/plugins/lifecycle-extensions)
+1. [插件包](/docs/extending/plugins/plugin-packages)
+2. [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)
+3. [生命周期扩展](/docs/extending/plugins/lifecycle-extensions)

--- a/docs-site/docs/extending/plugins/lifecycle-extensions.md
+++ b/docs-site/docs/extending/plugins/lifecycle-extensions.md
@@ -1,11 +1,10 @@
 ---
-title: Lifecycle Extensions
+title: 生命周期扩展
 description: 讲清第六种插件能力 ExtensionCapability.LIFECYCLE：插件通过 context.lifecycle().register(hook) 注册 AgentLifecycleHook，在 session/turn/model/tool/compact 事件点接收 AgentLifecycleEvent，用于观察、遥测与审计，不贡献工具或资源。
 tags: [how-to]
 ---
 
-# Lifecycle Extensions
-
+# 生命周期扩展
 `LIFECYCLE` 是 `ExtensionCapability` 的第六种能力，和前五种（`TOOL` / `COMMAND` / `SKILL` / `PROMPT` / `GUARDRAIL`）不同：它不贡献工具或资源，而是让插件在 agent 执行的关键节点**收到通知**。它解决的是观察、遥测、审计、外部状态同步这类需求。
 
 适用场景：
@@ -145,7 +144,7 @@ Agent agent = Agent.builder()
 
 ## 7. 下一步阅读
 
-1. [Plugin Packages](/docs/extending/plugins/plugin-packages)
-2. [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)
-3. [Extension SPI Internals](/docs/extending/plugins/extension-spi)
+1. [插件包](/docs/extending/plugins/plugin-packages)
+2. [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)
+3. [扩展 SPI 内部机制](/docs/extending/plugins/extension-spi)
 4. [Agent Tools and Registry](/docs/agent/tools-and-registry)

--- a/docs-site/docs/extending/plugins/plugin-author-cookbook.md
+++ b/docs-site/docs/extending/plugins/plugin-author-cookbook.md
@@ -1,11 +1,10 @@
 ---
-title: Plugin Author Cookbook
+title: 插件作者实战指南
 description: 面向第三方插件作者的动手指南：用 CLI 生成最小插件项目，稳定 manifest 与公共 ID 命名规则，写结构化 tool input schema，把 apply() 保持为轻量注册函数，完成 manifest/资源/schema 校验与发布前声明。
 tags: [how-to]
 ---
 
-# Plugin Author Cookbook
-
+# 插件作者实战指南
 这一页面向第三方插件作者：你想把一组工具、命令、Skill、Prompt 或 Guardrail 打成一个普通 Java jar，让使用者通过 Maven / Gradle 引入，再由宿主显式启用和暴露。
 
 先明确边界：AI4J 插件不是远程 marketplace，不会替使用者自动改 `pom.xml`，也不会在运行时热加载未知 jar。作者负责发布普通 Java 包；使用者负责把包放进 classpath；宿主应用负责 `discover -> enable -> exposeTool`。
@@ -311,7 +310,7 @@ ai:
 
 ## 8. 下一步阅读
 
-1. [Plugin Packages](/docs/extending/plugins/plugin-packages)
-2. [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)
+1. [插件包](/docs/extending/plugins/plugin-packages)
+2. [Ask User 插件](/docs/extending/plugins/ask-user-plugin)
 3. [Agent Tools and Registry](/docs/agent/tools-and-registry)
 4. [Coding Agent Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)

--- a/docs-site/docs/extending/plugins/plugin-packages.md
+++ b/docs-site/docs/extending/plugins/plugin-packages.md
@@ -1,11 +1,10 @@
 ---
-title: Plugin Packages
+title: 插件包
 description: 讲清 AI4J plugin package：第三方 jar + ServiceLoader 发现 + ExtensionRegistry 三段式门禁 discover/enable/exposeTool，区分 tool/command/Skill/Prompt/Guardrail 资源进入方式，默认不自动暴露工具给模型。
 tags: [concept]
 ---
 
-# Plugin Packages
-
+# 插件包
 AI4J 的 plugin package 解决的是：**第三方开发者把工具、命令、Skill、Prompt、Guardrail 等运行时资源打包成一个普通 Java 依赖，使用者通过 classpath 引入后再检查、启用、授权和暴露**。
 
 它不是应用商店，也不是远程下载安装器。当前稳定路径是 Maven / Gradle 依赖 + `ServiceLoader` 发现 + `ExtensionRegistry` 安全门禁。
@@ -19,7 +18,7 @@ AI4J 现在有两类容易混淆的扩展：
 | Provider / model / service extension | 把新平台、新模型字段或新顶层服务接进核心 SDK | 修改核心工厂、配置和 starter 主链 | 显式代码接线 |
 | Plugin package | 把工具、命令、Skill、Prompt、Guardrail 等资源交给 runtime 使用 | 第三方 jar + `ServiceLoader` + 显式 enable/expose | 独立扩展 API |
 
-如果你要新增一个模型平台，仍然看 [Provider Extension](/docs/extending/code-level/provider-extension)。
+如果你要新增一个模型平台，仍然看 [Provider 扩展](/docs/extending/code-level/provider-extension)。
 如果你要给 agent 或 coding agent 增加一组可复用工具、提示词或规则，才看这一页。
 
 ## 2. 使用者路径
@@ -297,7 +296,7 @@ ai4j-cli extension init weather-ai4j-plugin \
   --name "Weather Pack"
 ```
 
-如果你是使用者，建议接着看 [Plugin Recipes](/docs/extending/plugins/plugin-recipes)，那里把 Java、Spring Boot、CLI 和多插件组合写成可复制接入路径。如果你是第三方插件作者，建议完整走一遍 [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)。那里按 scaffold、替换业务逻辑、校验、发布说明和常见错误组织，比本页更适合作为动手流程。
+如果你是使用者，建议接着看 [插件配方](/docs/extending/plugins/plugin-recipes)，那里把 Java、Spring Boot、CLI 和多插件组合写成可复制接入路径。如果你是第三方插件作者，建议完整走一遍 [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)。那里按 scaffold、替换业务逻辑、校验、发布说明和常见错误组织，比本页更适合作为动手流程。
 
 这个命令只写入一个不存在或空的本地目录。它不会把插件依赖安装到宿主应用，不会拉取远程插件，也不会启用插件。生成后目录结构类似：
 
@@ -515,8 +514,8 @@ AI4J 当前提供一个随 SDK 发布的样板插件，并维护一个独立仓�
 
 | Artifact | 发布边界 | Extension id | 能力 | 文档 |
 | --- | --- | --- | --- | --- |
-| `ai4j-plugin-ask-user` | ai4j-sdk reactor / BOM | `ask-user` | tool + command + Skill + Prompt | [Ask User Plugin](/docs/extending/plugins/ask-user-plugin) |
-| `ai4j-plugin-dynamic-workflow` | 独立仓库，单独发布 | `dynamic-workflow` | tool + command + Skill + Prompt | [Dynamic Workflow Plugin](/docs/extending/plugins/dynamic-workflow-plugin) |
+| `ai4j-plugin-ask-user` | ai4j-sdk reactor / BOM | `ask-user` | tool + command + Skill + Prompt | [Ask User 插件](/docs/extending/plugins/ask-user-plugin) |
+| `ai4j-plugin-dynamic-workflow` | 独立仓库，单独发布 | `dynamic-workflow` | tool + command + Skill + Prompt | [动态工作流插件](/docs/extending/plugins/dynamic-workflow-plugin) |
 
 这些样板的作用不是替代第三方插件，而是给插件作者一个可编译、可测试、可通过 `ServiceLoader` 发现的参考实现。它们展示的重点是：
 
@@ -570,10 +569,10 @@ AI4J 当前不维护远程插件市场。推荐做法是让插件作者用自己
 
 1. [Extension 总览](/docs/extending/overview)
 2. 本页：Plugin Packages
-3. [Plugin Recipes](/docs/extending/plugins/plugin-recipes)
-4. [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)
-5. [Dynamic Workflow Plugin](/docs/extending/plugins/dynamic-workflow-plugin)
-6. [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)
+3. [插件配方](/docs/extending/plugins/plugin-recipes)
+4. [Ask User 插件](/docs/extending/plugins/ask-user-plugin)
+5. [动态工作流插件](/docs/extending/plugins/dynamic-workflow-plugin)
+6. [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)
 7. [Tools](/docs/capabilities/tools/overview)
 8. [Agent Tools and Registry](/docs/agent/tools-and-registry)
 9. [Coding Agent Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)

--- a/docs-site/docs/extending/plugins/plugin-recipes.md
+++ b/docs-site/docs/extending/plugins/plugin-recipes.md
@@ -1,14 +1,13 @@
 ---
-title: Plugin Recipes
+title: 插件配方
 description: 插件使用者的组装配方：jar 进 classpath 后如何用 CLI plan/check 做接入前检查，按 Java、Spring Boot、Agent、Coding Agent、多插件组合分别给出 enable/allow/expose 配置，区分 command 与 tool 暴露语义。
 tags: [how-to]
 ---
 
-# Plugin Recipes
-
+# 插件配方
 这一页解决插件使用者的组装问题：**插件 jar 已经进入 classpath 以后，应该怎么检查、启用、授权、暴露，并接进 Java、Spring Boot、Agent、Coding Agent 或 CLI。**
 
-如果你还不知道插件包是什么，先看 [Plugin Packages](/docs/extending/plugins/plugin-packages)。如果你要写第三方插件，再看 [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)。
+如果你还不知道插件包是什么，先看 [插件包](/docs/extending/plugins/plugin-packages)。如果你要写第三方插件，再看 [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)。
 
 ## 1. 先按资源类型拆开
 
@@ -411,18 +410,18 @@ ai:
 
 下面几类需求不适合用 plugin package 解决：
 
-- 新增模型平台：看 [Provider Extension](/docs/extending/code-level/provider-extension)。
-- 给已有 provider 补请求字段：看 [Model Extension](/docs/extending/code-level/model-extension)。
-- 新增顶层 SDK 能力面：看 [Service Extension](/docs/extending/code-level/service-extension)。
-- 只调整 HTTP dispatcher 或 connection pool：看 [SPI HTTP Stack](/docs/extending/code-level/spi-http-stack)。
+- 新增模型平台：看 [Provider 扩展](/docs/extending/code-level/provider-extension)。
+- 给已有 provider 补请求字段：看 [模型扩展](/docs/extending/code-level/model-extension)。
+- 新增顶层 SDK 能力面：看 [服务扩展](/docs/extending/code-level/service-extension)。
+- 只调整 HTTP dispatcher 或 connection pool：看 [SPI HTTP 栈](/docs/extending/code-level/spi-http-stack)。
 
 插件适合交付运行时资源，不适合替核心 SDK 做 provider 自动注册。
 
 ## 10. 推荐阅读顺序
 
-1. [Plugin Packages](/docs/extending/plugins/plugin-packages)
+1. [插件包](/docs/extending/plugins/plugin-packages)
 2. 本页：Plugin Recipes
-3. [Ask User Plugin](/docs/extending/plugins/ask-user-plugin)
-4. [Plugin Author Cookbook](/docs/extending/plugins/plugin-author-cookbook)
+3. [Ask User 插件](/docs/extending/plugins/ask-user-plugin)
+4. [插件作者实战指南](/docs/extending/plugins/plugin-author-cookbook)
 5. [Agent Tools and Registry](/docs/agent/tools-and-registry)
 6. [Coding Agent Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)

--- a/docs-site/docs/getting-started/choose-your-path.md
+++ b/docs-site/docs/getting-started/choose-your-path.md
@@ -1,11 +1,10 @@
 ---
-title: Choose Your Path
+title: 入门路径选择
 description: 按目标选择进入 AI4J 的主线：默认阅读顺序，以及快速发起模型请求、Spring Boot 接入、Tool/MCP/Agent/Coding Agent/FlowGram 各自的推荐起点与切深时机。
 tags: [concept]
 ---
 
-# Choose Your Path
-
+# 入门路径选择
 不同读者不该从同一页开始。
 
 这页的作用不是替你讲完所有模块，而是先帮你决定：
@@ -18,10 +17,10 @@ tags: [concept]
 
 推荐的默认顺序是：
 
-1. [Why AI4J](/docs/getting-started/why-ai4j)
-2. [Architecture at a Glance](/docs/reference/maps/architecture-at-a-glance)
-3. [Quickstart for Java](/docs/getting-started/quickstart-java) 或 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
-4. [First Tool Call](/docs/getting-started/first-tool-call)
+1. [为什么选 AI4J](/docs/getting-started/why-ai4j)
+2. [架构一览](/docs/reference/maps/architecture-at-a-glance)
+3. [Java 快速开始](/docs/getting-started/quickstart-java) 或 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
+4. [第一次工具调用](/docs/getting-started/first-tool-call)
 5. [Core SDK / Overview](/docs/capabilities/overview)
 
 这条线最适合：
@@ -36,7 +35,7 @@ tags: [concept]
 
 从这里开始：
 
-1. [Quickstart for Java](/docs/getting-started/quickstart-java)
+1. [Java 快速开始](/docs/getting-started/quickstart-java)
 2. [Core SDK / Model Access](/docs/capabilities/models/overview)
 
 这条线会先让你确认三件事：
@@ -49,7 +48,7 @@ tags: [concept]
 
 从这里开始：
 
-1. [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+1. [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 2. [Spring Boot / 总览](/docs/integrations/spring-boot/overview)
 3. [Spring Boot / Auto Configuration](/docs/integrations/spring-boot/auto-configuration)
 
@@ -63,7 +62,7 @@ tags: [concept]
 
 从这里开始：
 
-1. [First Tool Call](/docs/getting-started/first-tool-call)
+1. [第一次工具调用](/docs/getting-started/first-tool-call)
 2. [Core SDK / Tools](/docs/capabilities/tools/overview)
 3. [Core SDK / Skills](/docs/capabilities/skills/overview)
 4. [MCP](/docs/capabilities/mcp/overview)
@@ -130,8 +129,8 @@ tags: [concept]
 
 建议按这个顺序读：
 
-1. [Why AI4J](/docs/getting-started/why-ai4j)
-2. [Architecture at a Glance](/docs/reference/maps/architecture-at-a-glance)
+1. [为什么选 AI4J](/docs/getting-started/why-ai4j)
+2. [架构一览](/docs/reference/maps/architecture-at-a-glance)
 3. [Core SDK / Overview](/docs/capabilities/overview)
 4. [Core SDK / Strengths and Differentiators](/docs/reference/about/strengths-and-differentiators)
 5. 再按你的重点补 `Spring Boot / Agent / Coding Agent / FlowGram`

--- a/docs-site/docs/getting-started/feature-map.md
+++ b/docs-site/docs/getting-started/feature-map.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 4
-title: Feature Map
+title: 功能地图
 description: AI4J 功能地图：用成熟度标记（stable/advanced/preview/experimental）列出每个能力的状态、所属模块、适合场景与继续阅读入口，帮助按需取用最小模块。
 tags: [reference]
 ---
 
-# Feature Map
-
+# 功能地图
 这页是 AI4J 的功能地图。它不替代每个专题页，只负责告诉你：
 
 - 当前有哪些能力。
@@ -27,13 +26,13 @@ tags: [reference]
 
 | 能力 | 状态 | 模块 | 适合你在什么时候用 | 从这里开始 |
 | --- | --- | --- | --- | --- |
-| Java 首次调用 | `stable` | `ai4j` | 第一次接入，想用最短路径跑通一条模型请求 | [Quickstart for Java](/docs/getting-started/quickstart-java) |
-| 普通 Java 快速开始 | `stable` | `ai4j` | 想先验证依赖、配置和一次模型调用 | [Quickstart for Java](/docs/getting-started/quickstart-java) |
-| Spring Boot 快速开始 | `stable` | `ai4j-spring-boot-starter` | 已有 Spring Boot 项目，希望用配置和 Bean 接入 | [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot) |
+| Java 首次调用 | `stable` | `ai4j` | 第一次接入，想用最短路径跑通一条模型请求 | [Java 快速开始](/docs/getting-started/quickstart-java) |
+| 普通 Java 快速开始 | `stable` | `ai4j` | 想先验证依赖、配置和一次模型调用 | [Java 快速开始](/docs/getting-started/quickstart-java) |
+| Spring Boot 快速开始 | `stable` | `ai4j-spring-boot-starter` | 已有 Spring Boot 项目，希望用配置和 Bean 接入 | [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot) |
 | Chat 调用语义 | `stable` | `ai4j` | 已跑通首次调用，想理解消息模型和调用细节 | [Model Access / Chat](/docs/capabilities/models/chat) |
-| 第一次工具调用 | `stable` | `ai4j` | 想让模型调用本地函数或工具 | [First Tool Call](/docs/getting-started/first-tool-call) |
-| 路径选择 | `stable` | docs | 不确定该走 SDK、Spring、Agent 还是 FlowGram | [Choose Your Path](/docs/getting-started/choose-your-path) |
-| 文档地图 | `stable` | docs | 想确认 canonical 主线和旧路径去向 | [Documentation Map](/docs/reference/maps/documentation-map) |
+| 第一次工具调用 | `stable` | `ai4j` | 想让模型调用本地函数或工具 | [第一次工具调用](/docs/getting-started/first-tool-call) |
+| 路径选择 | `stable` | docs | 不确定该走 SDK、Spring、Agent 还是 FlowGram | [入门路径选择](/docs/getting-started/choose-your-path) |
+| 文档地图 | `stable` | docs | 想确认 canonical 主线和旧路径去向 | [文档地图](/docs/reference/maps/documentation-map) |
 
 ## 按模块取用
 
@@ -57,10 +56,10 @@ AI4J 的模块关系是从底座向上叠加，而不是一个必须全量采用
 | 能力 | 状态 | 模块 | 解决什么问题 | 深入阅读 |
 | --- | --- | --- | --- | --- |
 | Model Access | `stable` | `ai4j` | 统一模型接入主线 | [Overview](/docs/capabilities/models/overview) |
-| Chat | `stable` | `ai4j` | 对话式模型调用 | [Chat](/docs/capabilities/models/chat) |
-| Responses | `stable` | `ai4j` | 面向 Responses 风格的统一调用 | [Responses](/docs/capabilities/models/responses) |
-| Streaming | `stable` | `ai4j` | 流式输出、增量结果和前端展示 | [Streaming](/docs/capabilities/models/streaming) |
-| Multimodal | `advanced` | `ai4j` | 文本、图像等多模态输入输出 | [Multimodal](/docs/capabilities/models/multimodal) |
+| Chat | `stable` | `ai4j` | 对话式模型调用 | [Chat 主线](/docs/capabilities/models/chat) |
+| Responses | `stable` | `ai4j` | 面向 Responses 风格的统一调用 | [Responses 主线](/docs/capabilities/models/responses) |
+| Streaming | `stable` | `ai4j` | 流式输出、增量结果和前端展示 | [流式语义](/docs/capabilities/models/streaming) |
+| Multimodal | `advanced` | `ai4j` | 文本、图像等多模态输入输出 | [多模态](/docs/capabilities/models/multimodal) |
 | Tools / Function Call | `stable` | `ai4j` | 本地函数声明、执行和安全边界 | [Tools](/docs/capabilities/tools/overview) |
 | Skills | `advanced` | `ai4j` | 给模型按需读取说明、模板和工作流资产 | [Skills](/docs/capabilities/skills/overview) |
 
@@ -69,9 +68,9 @@ AI4J 的模块关系是从底座向上叠加，而不是一个必须全量采用
 | 能力 | 状态 | 模块 | 解决什么问题 | 深入阅读 |
 | --- | --- | --- | --- | --- |
 | Search & RAG | `advanced` | `ai4j` | 从外部知识中检索、增强回答和保留引用线索 | [Overview](/docs/capabilities/rag/overview) |
-| Ingestion Pipeline | `advanced` | `ai4j` | 文档入库、切分和索引前处理 | [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline) |
-| Hybrid Retrieval | `advanced` | `ai4j` | 组合关键词、向量和其他召回策略 | [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval) |
-| Rerank | `advanced` | `ai4j` | 对候选结果重排，提高检索质量 | [Rerank](/docs/capabilities/rag/rerank) |
+| Ingestion Pipeline | `advanced` | `ai4j` | 文档入库、切分和索引前处理 | [摄取管线](/docs/capabilities/rag/ingestion-pipeline) |
+| Hybrid Retrieval | `advanced` | `ai4j` | 组合关键词、向量和其他召回策略 | [混合检索](/docs/capabilities/rag/hybrid-retrieval) |
+| Rerank | `advanced` | `ai4j` | 对候选结果重排，提高检索质量 | [重排](/docs/capabilities/rag/rerank) |
 | MCP | `advanced` | `ai4j` | 通过协议接入外部工具、服务和能力网关 | [MCP Overview](/docs/capabilities/mcp/overview) |
 | MCP Client Integration | `advanced` | `ai4j` | 在客户端侧连接和使用 MCP 能力 | [Client Integration](/docs/capabilities/mcp/client-integration) |
 
@@ -80,9 +79,9 @@ AI4J 的模块关系是从底座向上叠加，而不是一个必须全量采用
 | 能力 | 状态 | 模块 | 适合场景 | 从这里开始 |
 | --- | --- | --- | --- | --- |
 | Spring Boot Starter | `stable` | `ai4j-spring-boot-starter` | Spring 应用配置化接入、自动装配和 Bean 扩展 | [Spring Boot Overview](/docs/integrations/spring-boot/overview) |
-| Agent Runtime | `preview` | `ai4j-agent` | 需要 memory、state、tool registry、workflow 或 team orchestration | [Agent Overview](/docs/agent/overview) |
-| Agent Quickstart | `preview` | `ai4j-agent` | 想先跑一个最小 Agent | [Agent Quickstart](/docs/agent/quickstart) |
-| Agent Teams | `preview` | `ai4j-agent` | 多 agent 协作和分工编排 | [Agent Teams](/docs/agent/orchestration/agent-teams) |
+| Agent Runtime | `preview` | `ai4j-agent` | 需要 memory、state、tool registry、workflow 或 team orchestration | [Agent 总览](/docs/agent/overview) |
+| Agent Quickstart | `preview` | `ai4j-agent` | 想先跑一个最小 Agent | [Agent 快速开始](/docs/agent/quickstart) |
+| Agent Teams | `preview` | `ai4j-agent` | 多 agent 协作和分工编排 | [Agent 团队](/docs/agent/orchestration/agent-teams) |
 | Coding Agent | `preview` | `ai4j-coding`、`ai4j-cli` | 面向本地代码仓的任务执行、workspace 工具和 CLI/TUI | [Coding Agent Overview](/docs/products/coding-agent/overview) |
 | Coding Agent Quickstart | `preview` | `ai4j-coding`、`ai4j-cli` | 想体验本地 Coding Agent 产品入口 | [Coding Agent Quickstart](/docs/products/coding-agent/quickstart) |
 | FlowGram | `preview` | `ai4j-flowgram-spring-boot-starter` | 可视化工作流平台后端、节点运行和 trace bridge | [FlowGram Overview](/docs/products/flowgram/overview) |
@@ -93,12 +92,12 @@ AI4J 的模块关系是从底座向上叠加，而不是一个必须全量采用
 
 | 能力 | 状态 | 模块 | 解决什么问题 | 深入阅读 |
 | --- | --- | --- | --- | --- |
-| Version Compatibility | `stable` | docs | Java、Maven、模块和 provider 能力边界 | [Version Compatibility](/docs/reference/version-compatibility) |
-| Release and Artifacts | `stable` | docs | Maven artifact、BOM、模块引入顺序 | [Release and Artifacts](/docs/reference/release-and-artifacts) |
-| Security | `stable` | docs | 密钥、Tool、MCP、RAG、Agent、FlowGram 安全边界 | [Security Overview](/docs/production/security) |
-| Production Checklist | `stable` | docs | 上线前配置、权限、观测和回归检查 | [Production Checklist](/docs/production/production-checklist) |
-| Migration | `stable` | docs | 旧路径、旧示例和旧 API 心智迁移 | [Migration Guide](/docs/reference/migration) |
-| Troubleshooting | `stable` | docs | provider、Tool、MCP、RAG、Agent、FlowGram 排障入口 | [Troubleshooting](/docs/production/troubleshooting) |
+| Version Compatibility | `stable` | docs | Java、Maven、模块和 provider 能力边界 | [版本兼容性](/docs/reference/version-compatibility) |
+| Release and Artifacts | `stable` | docs | Maven artifact、BOM、模块引入顺序 | [发布与制品](/docs/reference/release-and-artifacts) |
+| Security | `stable` | docs | 密钥、Tool、MCP、RAG、Agent、FlowGram 安全边界 | [安全总览](/docs/production/security) |
+| Production Checklist | `stable` | docs | 上线前配置、权限、观测和回归检查 | [生产检查清单](/docs/production/production-checklist) |
+| Migration | `stable` | docs | 旧路径、旧示例和旧 API 心智迁移 | [迁移指南](/docs/reference/migration) |
+| Troubleshooting | `stable` | docs | provider、Tool、MCP、RAG、Agent、FlowGram 排障入口 | [排障指南](/docs/production/troubleshooting) |
 | Comparison | `stable` | docs | 与 Spring AI、LangChain4j、AgentScope Java、Pi Agent 的选型边界 | [Comparison](/docs/reference/about/comparison) |
 
 ## 还没有独立页的集成
@@ -122,10 +121,10 @@ AgentFlow 或其他外部平台，应先按能力归类阅读：
 
 第一次接入建议走：
 
-1. [Why AI4J](/docs/getting-started/why-ai4j)
-2. [Quickstart for Java](/docs/getting-started/quickstart-java)
-3. [Quickstart for Java](/docs/getting-started/quickstart-java) 或 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+1. [为什么选 AI4J](/docs/getting-started/why-ai4j)
+2. [Java 快速开始](/docs/getting-started/quickstart-java)
+3. [Java 快速开始](/docs/getting-started/quickstart-java) 或 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 4. [Core SDK / Model Access / Chat](/docs/capabilities/models/chat)
-5. [First Tool Call](/docs/getting-started/first-tool-call)
+5. [第一次工具调用](/docs/getting-started/first-tool-call)
 6. 按需进入 [Core SDK](/docs/capabilities/overview)、[Spring Boot](/docs/integrations/spring-boot/overview)、[Agent](/docs/agent/overview) 或 [FlowGram](/docs/products/flowgram/overview)
-7. 上线前检查 [Production Checklist](/docs/production/production-checklist) 和 [Security](/docs/production/security)
+7. 上线前检查 [生产检查清单](/docs/production/production-checklist) 和 [Security](/docs/production/security)

--- a/docs-site/docs/getting-started/first-tool-call.md
+++ b/docs-site/docs/getting-started/first-tool-call.md
@@ -1,11 +1,10 @@
 ---
-title: First Tool Call
+title: 第一次工具调用
 description: 讲清 AI4J 里“第一次工具调用”的真正含义：本地 Function Call 的最短示例，以及 Function Call、Skill、MCP 为什么必须分开理解，并给出下一步专题树。
 tags: [concept]
 ---
 
-# First Tool Call
-
+# 第一次工具调用
 这一步的目标不是讲完全部工具体系，而是先让你知道：
 
 - AI4J 里的“第一次工具调用”到底在讲什么
@@ -111,4 +110,4 @@ ChatCompletionResponse resp = chatService.chatCompletion(req);
 
 如果这里的 first tool call 没有触发，优先回看：
 
-- [Troubleshooting](/docs/production/troubleshooting)
+- [排障指南](/docs/production/troubleshooting)

--- a/docs-site/docs/getting-started/programmatic-integration.md
+++ b/docs-site/docs/getting-started/programmatic-integration.md
@@ -24,7 +24,7 @@ ai4j 是 Java，集成面的划分和 Pi（Node / TypeScript）不同，但能�
 | RPC（stdin / stdout JSON-RPC 子进程协议） | ACP headless host（换行分隔 JSON-RPC） | [ACP 集成](/docs/products/coding-agent/acp-integration) |
 | JSON event stream（`--mode json` 一次性事件流→stdout） | **无 turnkey 等价**（构建块见下文①） | — |
 | TUI（交互终端） | `ai4j-cli` 的 `code` / `tui` 宿主 | [CLI / TUI 使用指南](/docs/products/coding-agent/cli-and-tui) |
-| —（Pi 无对应，ai4j 独有） | Spring Boot 自动装配 | [Spring Boot Auto Configuration](/docs/integrations/spring-boot/auto-configuration) |
+| —（Pi 无对应，ai4j 独有） | Spring Boot 自动装配 | [Spring Boot 自动配置](/docs/integrations/spring-boot/auto-configuration) |
 
 最关键的差别：ai4j 没有"一个 SDK 对象包办一切"的单一 session 工厂。能力工厂（`AiService`）和会话协议（ACP）是分开的两层——前者是程序内调用，后者是跨进程协议。
 
@@ -36,7 +36,7 @@ ai4j 是 Java，集成面的划分和 Pi（Node / TypeScript）不同，但能�
 
 `AiService` 是把模型访问、检索增强和组合能力统一收束在一个入口对象下的显式工厂（`getChatService` / `getResponsesService` / `getEmbeddingService` / `getRagService` 等），内部用一组 `switch(platform)` 决定创建哪个实现类。这是普通 Java 应用嵌 ai4j 的第一条链。
 
-→ [服务入口与注册表](/docs/capabilities/service-entry) · 首聊代码见 [Quickstart for Java](/docs/getting-started/quickstart-java)
+→ [服务入口与注册表](/docs/capabilities/service-entry) · 首聊代码见 [Java 快速开始](/docs/getting-started/quickstart-java)
 
 ### 2. AiServiceRegistry —— 多实例 / 多 profile
 
@@ -48,7 +48,7 @@ ai4j 是 Java，集成面的划分和 Pi（Node / TypeScript）不同，但能�
 
 ACP 是 ai4j 面向 IDE / 桌面壳的标准接入面：换行分隔 JSON-RPC（不是 LSP 的 `Content-Length` framing），暴露 session 创建 / 加载、prompt 执行、权限确认和结构化事件；权限确认是服务端反向发起的 `session/request_permission` RPC。它是 Pi RPC 模式在 ai4j 里的等价物，但底层和 `code` 命令共用同一套 coding runtime。
 
-→ [ACP 集成](/docs/products/coding-agent/acp-integration) · 与 MCP 的边界见 [MCP and ACP](/docs/products/coding-agent/mcp-and-acp)
+→ [ACP 集成](/docs/products/coding-agent/acp-integration) · 与 MCP 的边界见 [MCP 与 ACP](/docs/products/coding-agent/mcp-and-acp)
 
 ### 4. trace / replay —— 可观测性与恢复
 
@@ -58,7 +58,7 @@ runtime 已经发布统一事件（`MODEL_REQUEST` / `MODEL_RESPONSE` / `TOOL_CA
 trace / replay 是 ai4j 的**可观测性与可靠性**层（进程内 tracing、节点重放、崩溃续跑、防篡改审计），不是"把 agent 事件流一次性打到 stdout"的集成模式。它消费的事件类型与 Pi 的事件流同源，但**定位不同**——见上表①。Pi JSON 模式的"管道消费"用法在 ai4j 里需要自己用 runtime 事件流加一个发射器。
 :::
 
-→ [Trace 与可观测性](/docs/agent/observability/trace-observability) · 续跑 / 重放 / 审计见 [Replay, Recovery & Audit](/docs/agent/observability/replay-recovery-audit)
+→ [Trace 与可观测性](/docs/agent/observability/trace-observability) · 续跑 / 重放 / 审计见 [重放、恢复与审计](/docs/agent/observability/replay-recovery-audit)
 
 ### 5. CLI / TUI —— 嵌入终端宿主
 
@@ -70,7 +70,7 @@ trace / replay 是 ai4j 的**可观测性与可靠性**层（进程内 tracing�
 
 `ai4j-spring-boot-starter` 用 `AiConfigAutoConfiguration` 把 `ai.*` 属性绑成统一 `Configuration`，按固定顺序组装 OkHttpClient → provider → `AiService` / `AiServiceRegistry` / `FreeAiService` → 条件性创建 VectorStore / RAG / Reranker，关键 Bean 都是 `@ConditionalOnMissingBean`，可被业务实现接管。
 
-→ [Spring Boot Auto Configuration](/docs/integrations/spring-boot/auto-configuration) · 快速接入见 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+→ [Spring Boot 自动配置](/docs/integrations/spring-boot/auto-configuration) · 快速接入见 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 
 ## 最小可运行示例：编程式首聊
 
@@ -146,10 +146,10 @@ AI4J 是一个统一多家大模型、屏蔽 provider 差异的 Java AI SDK。
 
 ## 继续阅读
 
-- [Quickstart for Java](/docs/getting-started/quickstart-java) · [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+- [Java 快速开始](/docs/getting-started/quickstart-java) · [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 - [服务入口与注册表](/docs/capabilities/service-entry)
-- [ACP 集成](/docs/products/coding-agent/acp-integration) · [MCP and ACP](/docs/products/coding-agent/mcp-and-acp)
-- [Trace 与可观测性](/docs/agent/observability/trace-observability) · [Replay, Recovery & Audit](/docs/agent/observability/replay-recovery-audit)
+- [ACP 集成](/docs/products/coding-agent/acp-integration) · [MCP 与 ACP](/docs/products/coding-agent/mcp-and-acp)
+- [Trace 与可观测性](/docs/agent/observability/trace-observability) · [重放、恢复与审计](/docs/agent/observability/replay-recovery-audit)
 - [CLI / TUI 使用指南](/docs/products/coding-agent/cli-and-tui) · [TUI 定制与主题](/docs/products/coding-agent/tui-customization)
-- [Spring Boot Auto Configuration](/docs/integrations/spring-boot/auto-configuration)
-- 想看完整能力地图：[Feature Map](/docs/getting-started/feature-map)
+- [Spring Boot 自动配置](/docs/integrations/spring-boot/auto-configuration)
+- 想看完整能力地图：[功能地图](/docs/getting-started/feature-map)

--- a/docs-site/docs/getting-started/quickstart-java.md
+++ b/docs-site/docs/getting-started/quickstart-java.md
@@ -1,11 +1,10 @@
 ---
-title: Quickstart for Java
+title: Java 快速开始
 description: 普通 Java / Maven 项目接入 AI4J 的最短路径：从依赖、环境变量到第一条同步 Chat 请求，给出可复制的 Configuration→AiService→IChatService 闭环代码与成功标准。
 tags: [how-to]
 ---
 
-# Quickstart for Java
-
+# Java 快速开始
 这页是普通 Java / Maven 项目的正式最短接入路径。它从依赖、密钥到第一条模型调用给出一个完整的最小闭环。
 
 本页对应的主模块是：
@@ -189,10 +188,10 @@ openAiConfig.setApiHost("https://codex.trovebox.online/");
 
 ## 11. 跑通之后
 
-- 想接入 Spring Boot：看 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+- 想接入 Spring Boot：看 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 - 想接 TroveBox 或其他中转平台：看 [OpenAI-compatible 与 TroveBox](/docs/capabilities/models/openai-compatible-and-trovebox)
 - 想理解 `Chat` 细节：看 [Core SDK / Model Access / Chat](/docs/capabilities/models/chat)
-- 想让模型调用本地函数：看 [First Tool Call](/docs/getting-started/first-tool-call)
-- 想继续看完整能力：看 [Feature Map](/docs/getting-started/feature-map)
+- 想让模型调用本地函数：看 [第一次工具调用](/docs/getting-started/first-tool-call)
+- 想继续看完整能力：看 [功能地图](/docs/getting-started/feature-map)
 
 → API Javadoc：[`AiService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/factory/AiService.html) · [`IChatService`](https://javadoc.io/doc/io.github.lnyo-cly/ai4j/2.4.2/io/github/lnyocly/ai4j/service/IChatService.html)

--- a/docs-site/docs/getting-started/quickstart-spring-boot.md
+++ b/docs-site/docs/getting-started/quickstart-spring-boot.md
@@ -1,12 +1,11 @@
 ---
-title: Quickstart for Spring Boot
+title: Spring Boot 快速开始
 description: Spring Boot 项目接入 AI4J 的最短路径：引入 starter、最小 application.yml 配置、AiService Bean 注入，并给出 controller 发出第一条模型请求的完整示例。
 tags: [how-to]
 ---
 
-# Quickstart for Spring Boot
-
-这页给 Spring Boot 项目一条最短成功路径。普通 Java 项目请直接使用 [Quickstart for Java](/docs/getting-started/quickstart-java)。
+# Spring Boot 快速开始
+这页给 Spring Boot 项目一条最短成功路径。普通 Java 项目请直接使用 [Java 快速开始](/docs/getting-started/quickstart-java)。
 
 本页对应的主模块是：
 
@@ -219,4 +218,4 @@ IChatService chatService = aiServiceRegistry.getChatService("trovebox-low-cost")
 - 想看底层 `Chat` 调用语义：看 [Core SDK / Model Access / Chat](/docs/capabilities/models/chat)
 - 想配置更多 provider：看 [Spring Boot / Configuration Reference](/docs/integrations/spring-boot/configuration-reference)
 - 想扩展 Bean 或复用业务服务：看 [Spring Boot / Bean Extension](/docs/integrations/spring-boot/bean-extension)
-- 想做 Tool / Function Call：看 [First Tool Call](/docs/getting-started/first-tool-call)
+- 想做 Tool / Function Call：看 [第一次工具调用](/docs/getting-started/first-tool-call)

--- a/docs-site/docs/getting-started/why-ai4j.md
+++ b/docs-site/docs/getting-started/why-ai4j.md
@@ -1,10 +1,10 @@
 ---
-title: Why AI4J
+title: 为什么选 AI4J
 description: 回答在 Java 项目里为什么可以考虑 AI4J：面向 Java 8+ 的渐进式 AI SDK 取舍、可按阶段取用的模块分层，以及与 Spring AI、LangChain4j 的差异和适合场景。
 tags: [concept]
 ---
 
-# Why AI4J
+# 为什么选 AI4J
 
 AI4J 是一套面向 `Java 8+` 的 AI SDK。它最核心的目标是降低 Java 项目接入 AI 的成本：
 少引概念、少写胶水代码、少被 provider 差异拖住，同时保留向 RAG、MCP、Spring Boot、
@@ -66,19 +66,19 @@ AI4J 更适合把差异放在这些地方：
 ### 1. 普通 Java 也能先接入
 
 你不需要先把项目改造成某个完整应用框架，也不需要一开始就理解 Agent、workflow 或复杂编排。
-从 [Quickstart for Java](/docs/getting-started/quickstart-java) 开始，可以先验证模型配置和一次调用。
+从 [Java 快速开始](/docs/getting-started/quickstart-java) 开始，可以先验证模型配置和一次调用。
 
-如果项目已经是 Spring Boot，再走 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)，
+如果项目已经是 Spring Boot，再走 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)，
 用 starter 管理配置和 Bean。
 
 ### 2. 模型能力不是孤立 wrapper
 
 Core SDK 覆盖的不只是 `chat()`：
 
-- [Chat](/docs/capabilities/models/chat)
-- [Responses](/docs/capabilities/models/responses)
-- [Streaming](/docs/capabilities/models/streaming)
-- [Multimodal](/docs/capabilities/models/multimodal)
+- [Chat 主线](/docs/capabilities/models/chat)
+- [Responses 主线](/docs/capabilities/models/responses)
+- [流式语义](/docs/capabilities/models/streaming)
+- [多模态](/docs/capabilities/models/multimodal)
 - Embedding、Rerank、Image、Audio、Realtime 等扩展能力
 
 这些能力应该共享配置、provider 接入和工程约束，而不是每个能力都重新写一套入口。
@@ -144,11 +144,11 @@ AI4J 不太适合：
 
 | 你现在想做什么 | 下一页 |
 | --- | --- |
-| 跑通第一条请求 | [Quickstart for Java](/docs/getting-started/quickstart-java) |
-| 普通 Java 先跑通 | [Quickstart for Java](/docs/getting-started/quickstart-java) |
-| Spring Boot 接入 | [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot) |
-| 看完整功能地图 | [Feature Map](/docs/getting-started/feature-map) |
+| 跑通第一条请求 | [Java 快速开始](/docs/getting-started/quickstart-java) |
+| 普通 Java 先跑通 | [Java 快速开始](/docs/getting-started/quickstart-java) |
+| Spring Boot 接入 | [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot) |
+| 看完整功能地图 | [功能地图](/docs/getting-started/feature-map) |
 | 理解 Chat 调用 | [Model Access / Chat](/docs/capabilities/models/chat) |
-| 让模型调用本地工具 | [First Tool Call](/docs/getting-started/first-tool-call) |
+| 让模型调用本地工具 | [第一次工具调用](/docs/getting-started/first-tool-call) |
 
-如果你还不确定该走哪条线，先看 [Feature Map](/docs/getting-started/feature-map)。
+如果你还不确定该走哪条线，先看 [功能地图](/docs/getting-started/feature-map)。

--- a/docs-site/docs/integrations/solutions/deepseek-stream-search-rag.md
+++ b/docs-site/docs/integrations/solutions/deepseek-stream-search-rag.md
@@ -1,11 +1,10 @@
 ---
-title: DeepSeek Stream Search RAG
+title: DeepSeek 流式搜索 RAG 方案
 description: 组合流式输出、公网搜索与私域 RAG 的回答链方案，讲解职责分层、引用证据策略与升级判断。
 tags: [concept]
 ---
 
-# DeepSeek Stream Search RAG
-
+# DeepSeek 流式搜索 RAG 方案
 这个方案关注的不是单一能力，而是“流式输出 + 联网搜索 + 私域 RAG”三者的组合链路。
 
 ## 1. 适合什么场景
@@ -41,14 +40,14 @@ tags: [concept]
 
 如果你只有一种需求：
 
-- 只做私域知识库：先看 [RAG Ingestion Vector Store](/docs/integrations/solutions/rag-ingestion-vector-store)
-- 只做公网搜索增强：先看 [SearXNG Web Search](/docs/integrations/solutions/searxng-web-search)
+- 只做私域知识库：先看 [RAG 摄取与向量存储](/docs/integrations/solutions/rag-ingestion-vector-store)
+- 只做公网搜索增强：先看 [SearXNG 联网搜索](/docs/integrations/solutions/searxng-web-search)
 
 ## 5. 先补哪些主线页
 
 1. [Core SDK / Search & RAG](/docs/capabilities/rag/overview)
 2. [Core SDK / Model Access](/docs/capabilities/models/overview)
-3. [SearXNG Web Search](/docs/integrations/solutions/searxng-web-search)
+3. [SearXNG 联网搜索](/docs/integrations/solutions/searxng-web-search)
 
 ## 6. 继续看实现细节
 

--- a/docs-site/docs/integrations/solutions/flowgram-mysql-taskstore.md
+++ b/docs-site/docs/integrations/solutions/flowgram-mysql-taskstore.md
@@ -1,11 +1,10 @@
 ---
-title: Flowgram MySQL Task Store
+title: Flowgram MySQL 任务存储
 description: 把 FlowGram 从单进程 demo 提升到平台后端的 JDBC 持久化方案，讲解任务生命周期与 task store 边界。
 tags: [integration]
 ---
 
-# Flowgram MySQL Task Store
-
+# Flowgram MySQL 任务存储
 这个方案解决的是“把 Flowgram 从单进程 demo 提升到可持久化的平台后端”。
 
 ## 1. 适合什么场景

--- a/docs-site/docs/integrations/solutions/legal-assistant.md
+++ b/docs-site/docs/integrations/solutions/legal-assistant.md
@@ -1,11 +1,10 @@
 ---
-title: Legal Assistant
+title: 法律助手
 description: 高证据要求法律助手的 RAG 方案，强调元数据治理、证据引用与人工复核，区别于普通聊天加长 prompt。
 tags: [concept]
 ---
 
-# Legal Assistant
-
+# 法律助手
 这个方案解决的是“高证据要求的法律助手 RAG”，重点不是把回答说得更像人，而是把依据链做得更可追溯。
 
 ## 1. 适合什么场景
@@ -56,7 +55,7 @@ tags: [concept]
 
 1. [Core SDK / Search & RAG](/docs/capabilities/rag/overview)
 2. [Core SDK / Citations and Trace](/docs/capabilities/rag/citations-and-trace)
-3. [RAG Ingestion Vector Store](/docs/integrations/solutions/rag-ingestion-vector-store)
+3. [RAG 摄取与向量存储](/docs/integrations/solutions/rag-ingestion-vector-store)
 
 ## 6. 继续看实现细节
 

--- a/docs-site/docs/integrations/solutions/overview.md
+++ b/docs-site/docs/integrations/solutions/overview.md
@@ -8,7 +8,7 @@ tags: [concept]
 
 `Solutions` 是 AI4J 的场景组合入口。它不重新定义 SDK 能力，而是把 Core SDK、Spring Boot、RAG、MCP、Agent、FlowGram 等能力按常见问题组合成可复制路径。
 
-如果你还没理解基础概念，先看 [Start Here](/docs/intro) 和 [Feature Map](/docs/getting-started/feature-map)。如果你已经知道要解决什么业务问题，再从本章选方案。
+如果你还没理解基础概念，先看 [Start Here](/docs/intro) 和 [功能地图](/docs/getting-started/feature-map)。如果你已经知道要解决什么业务问题，再从本章选方案。
 
 ## 一句话定位
 
@@ -24,13 +24,13 @@ Solutions 解决的是：
 | --- | --- | --- |
 | 多轮聊天并持久化会话 | [Spring Boot + MySQL Chat Memory](/docs/integrations/solutions/springboot-mysql-chat-memory) | Spring Boot、Chat Memory、MySQL |
 | 持久化 Agent 会话 | [Spring Boot + JDBC Agent Memory](/docs/integrations/solutions/springboot-jdbc-agent-memory) | Spring Boot、Agent、JDBC Memory |
-| 搭建 RAG 入库和检索流水线 | [RAG Ingestion Vector Store](/docs/integrations/solutions/rag-ingestion-vector-store) | Ingestion、Embedding、Vector Store、Retrieval |
-| 使用 Pinecone | [Pinecone Vector Workflow](/docs/integrations/solutions/pinecone-vector-workflow) | Vector Store、Pinecone、RAG |
-| 接入联网搜索 | [SearXNG Web Search](/docs/integrations/solutions/searxng-web-search) | Online Search、SearXNG |
-| 组合流式输出、搜索和 RAG | [DeepSeek Stream Search RAG](/docs/integrations/solutions/deepseek-stream-search-rag) | Streaming、Search、RAG |
-| 做高证据要求问答 | [Legal Assistant](/docs/integrations/solutions/legal-assistant) | RAG、Citation、Trace |
+| 搭建 RAG 入库和检索流水线 | [RAG 摄取与向量存储](/docs/integrations/solutions/rag-ingestion-vector-store) | Ingestion、Embedding、Vector Store、Retrieval |
+| 使用 Pinecone | [Pinecone 向量工作流](/docs/integrations/solutions/pinecone-vector-workflow) | Vector Store、Pinecone、RAG |
+| 接入联网搜索 | [SearXNG 联网搜索](/docs/integrations/solutions/searxng-web-search) | Online Search、SearXNG |
+| 组合流式输出、搜索和 RAG | [DeepSeek 流式搜索 RAG 方案](/docs/integrations/solutions/deepseek-stream-search-rag) | Streaming、Search、RAG |
+| 做高证据要求问答 | [法律助手](/docs/integrations/solutions/legal-assistant) | RAG、Citation、Trace |
 | 持久化 FlowGram task | [FlowGram MySQL Task Store](/docs/integrations/solutions/flowgram-mysql-taskstore) | FlowGram、Task Store、MySQL |
-| 调整 HTTP 并发和连接池 | [SPI Dispatcher ConnectionPool](/docs/integrations/solutions/spi-dispatcher-connectionpool) | HTTP Stack、SPI、OkHttp |
+| 调整 HTTP 并发和连接池 | [SPI 调度器与连接池](/docs/integrations/solutions/spi-dispatcher-connectionpool) | HTTP Stack、SPI、OkHttp |
 
 ## 怎么读方案页
 
@@ -66,6 +66,6 @@ Solutions 解决的是：
 | 多步推理、workflow、trace | [Agent](/docs/agent/overview) |
 | 本地代码仓任务、CLI、ACP | [Coding Agent](/docs/products/coding-agent/overview) |
 | 可视化工作流后端 | [FlowGram](/docs/products/flowgram/overview) |
-| 版本、安全、生产检查和排障 | [Production Checklist](/docs/production/production-checklist) |
+| 版本、安全、生产检查和排障 | [生产检查清单](/docs/production/production-checklist) |
 
 如果一个方案页没有把这些路径讲清楚，它就还没有达到本章应有的质量。

--- a/docs-site/docs/integrations/solutions/pinecone-vector-workflow.md
+++ b/docs-site/docs/integrations/solutions/pinecone-vector-workflow.md
@@ -1,11 +1,10 @@
 ---
-title: Pinecone Vector Workflow
+title: Pinecone 向量工作流
 description: 在 Pinecone 后端上搭建入库、检索、rerank 工作流的标准方案，讲解 namespace 知识隔离与统一抽象边界。
 tags: [integration]
 ---
 
-# Pinecone Vector Workflow
-
+# Pinecone 向量工作流
 这个方案回答的是：当你已经确定底层向量库就是 Pinecone，AI4J 里最自然的工作流应该怎么搭。
 
 ## 1. 适合什么场景
@@ -45,13 +44,13 @@ tags: [integration]
 
 如果你还没确定向量库，先回到：
 
-- [RAG Ingestion Vector Store](/docs/integrations/solutions/rag-ingestion-vector-store)
+- [RAG 摄取与向量存储](/docs/integrations/solutions/rag-ingestion-vector-store)
 
 ## 5. 先补哪些主线页
 
 1. [Core SDK / Search & RAG](/docs/capabilities/rag/overview)
 2. [Spring Boot / Auto Configuration](/docs/integrations/spring-boot/auto-configuration)
-3. [RAG Ingestion Vector Store](/docs/integrations/solutions/rag-ingestion-vector-store)
+3. [RAG 摄取与向量存储](/docs/integrations/solutions/rag-ingestion-vector-store)
 
 ## 6. 继续看实现细节
 

--- a/docs-site/docs/integrations/solutions/rag-ingestion-vector-store.md
+++ b/docs-site/docs/integrations/solutions/rag-ingestion-vector-store.md
@@ -1,11 +1,10 @@
 ---
-title: RAG Ingestion Vector Store
+title: RAG 摄取与向量存储
 description: AI4J 的标准 RAG 工程基线方案，串联文档入库、embedding、向量存储与检索链，不绑定特定向量库品牌。
 tags: [concept]
 ---
 
-# RAG Ingestion Vector Store
-
+# RAG 摄取与向量存储
 这个方案回答的是：当你已经决定做 RAG，第一条标准工程路径应该是什么。
 
 ## 1. 适合什么场景
@@ -45,9 +44,9 @@ tags: [concept]
 
 这时继续看：
 
-- [Pinecone Vector Workflow](/docs/integrations/solutions/pinecone-vector-workflow)
-- [SearXNG Web Search](/docs/integrations/solutions/searxng-web-search)
-- [Legal Assistant](/docs/integrations/solutions/legal-assistant)
+- [Pinecone 向量工作流](/docs/integrations/solutions/pinecone-vector-workflow)
+- [SearXNG 联网搜索](/docs/integrations/solutions/searxng-web-search)
+- [法律助手](/docs/integrations/solutions/legal-assistant)
 
 ## 5. 先补哪些主线页
 

--- a/docs-site/docs/integrations/solutions/searxng-web-search.md
+++ b/docs-site/docs/integrations/solutions/searxng-web-search.md
@@ -1,11 +1,10 @@
 ---
-title: SearXNG Web Search
+title: SearXNG 联网搜索
 description: 给回答链补上公网实时搜索能力的增强方案，讲解 SearXNG 配置、与 RAG 的边界及降级策略。
 tags: [integration]
 ---
 
-# SearXNG Web Search
-
+# SearXNG 联网搜索
 这个方案解决的是“如何给回答链补上一条公网实时搜索能力”，而不是替代私域知识库。
 
 ## 1. 适合什么场景
@@ -46,7 +45,7 @@ tags: [integration]
 
 1. [Core SDK / Search & RAG](/docs/capabilities/rag/overview)
 2. [Core SDK / Extension](/docs/extending/overview)
-3. [DeepSeek Stream Search RAG](/docs/integrations/solutions/deepseek-stream-search-rag)
+3. [DeepSeek 流式搜索 RAG 方案](/docs/integrations/solutions/deepseek-stream-search-rag)
 
 ## 6. 继续看实现细节
 

--- a/docs-site/docs/integrations/solutions/spi-dispatcher-connectionpool.md
+++ b/docs-site/docs/integrations/solutions/spi-dispatcher-connectionpool.md
@@ -1,11 +1,10 @@
 ---
-title: SPI Dispatcher ConnectionPool
+title: SPI 调度器与连接池
 description: AI4J 的 HTTP 栈扩展方案，通过 DispatcherProvider 与 ConnectionPoolProvider SPI 治理生产并发、连接池与网络隔离。
 tags: [integration]
 ---
 
-# SPI Dispatcher ConnectionPool
-
+# SPI 调度器与连接池
 这个方案讲的不是模型能力，而是当你已经进入生产并发和网络治理阶段时，AI4J 的 HTTP 栈该怎么扩展。
 
 ## 1. 适合什么场景

--- a/docs-site/docs/integrations/solutions/springboot-jdbc-agent-memory.md
+++ b/docs-site/docs/integrations/solutions/springboot-jdbc-agent-memory.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot JDBC Agent Memory
+title: Spring Boot JDBC Agent 记忆
 description: 把 Agent 会话持久化到 JDBC 的方案，覆盖工具结果、runtime state 与压缩摘要的跨实例恢复。
 tags: [integration]
 ---
 
-# Spring Boot + JDBC Agent Memory
-
+# Spring Boot + JDBC Agent 记忆
 这个方案解决的是“普通多轮聊天已经不够，需要把 Agent 会话本身持久化下来”。
 
 ## 1. 适合什么场景

--- a/docs-site/docs/integrations/solutions/springboot-mysql-chat-memory.md
+++ b/docs-site/docs/integrations/solutions/springboot-mysql-chat-memory.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot MySQL Chat Memory
+title: Spring Boot MySQL 聊天记忆
 description: 基于 Spring Boot + MySQL 的多轮聊天会话持久化方案，讲解 JdbcChatMemory 接入、sessionId 绑定与裁剪策略。
 tags: [integration]
 ---
 
-# Spring Boot + MySQL Chat Memory
-
+# Spring Boot + MySQL 聊天记忆
 这个方案解决的是“先把多轮聊天和会话持久化做好”，而不是一上来就引入更重的 `Agent runtime`。
 
 ## 1. 适合什么场景

--- a/docs-site/docs/integrations/spring-boot/agentflow-integration.md
+++ b/docs-site/docs/integrations/spring-boot/agentflow-integration.md
@@ -1,11 +1,10 @@
 ---
-title: AgentFlow Auto-Configuration
+title: AgentFlow 自动配置
 description: 讲解 ai.agentflow.* 如何在 Spring Boot 下自动装配多 profile 的 AgentFlow 注册表（AgentFlowRegistry），把 Coze / Dify / N8N 等外部工作流平台接进 ai4j，以及 default-name、条件 Bean 与默认 AgentFlow 的解析规则。
 tags: [integration]
 ---
 
-# AgentFlow Auto-Configuration
-
+# AgentFlow 自动配置
 `AgentFlow` 是 ai4j 对接外部工作流平台（Coze、Dify、N8N 等）的薄封装。这一页只讲它在 Spring Boot 下是怎么自动装配的，不讲单个平台的调用细节。
 
 ## 1. 配置入口：`ai.agentflow.*`
@@ -121,4 +120,4 @@ public class DefaultWorkflowService {
 ## 6. 继续阅读
 
 - 配置分层与其它 `ai.*` 前缀：见 [Configuration Reference](/docs/integrations/spring-boot/configuration-reference)
-- 装配链与失败传播：见 [Spring Boot Auto Configuration](/docs/integrations/spring-boot/auto-configuration)
+- 装配链与失败传播：见 [Spring Boot 自动配置](/docs/integrations/spring-boot/auto-configuration)

--- a/docs-site/docs/integrations/spring-boot/auto-configuration.md
+++ b/docs-site/docs/integrations/spring-boot/auto-configuration.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot Auto Configuration
+title: Spring Boot 自动配置
 description: 深入解析 ai4j-spring-boot-starter 的真实装配链、初始化顺序与条件装配边界，理解统一 Configuration 与失败传播路径。
 tags: [integration]
 ---
 
-# Spring Boot Auto Configuration
-
+# Spring Boot 自动配置
 这一页讲的是 starter 的真实装配链，而不是泛泛地说“它会自动配置一些 Bean”。
 
 ## 1. 真实入口类

--- a/docs-site/docs/integrations/spring-boot/bean-extension.md
+++ b/docs-site/docs/integrations/spring-boot/bean-extension.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot Bean Extension
+title: Spring Boot Bean 扩展
 description: 讲解在 Spring Boot 中沿 AI4J 抽象层覆盖默认 Bean 的时机、层级选择与典型覆盖点，避免绕开统一容器模型。
 tags: [integration]
 ---
 
-# Spring Boot Bean Extension
-
+# Spring Boot Bean 扩展
 默认自动装配只是起点。真正的业务系统通常会覆盖一部分 Bean，但应该沿着 AI4J 的抽象层去接管。
 
 ## 1. 什么时候该覆盖

--- a/docs-site/docs/integrations/spring-boot/common-patterns.md
+++ b/docs-site/docs/integrations/spring-boot/common-patterns.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot Common Patterns
+title: Spring Boot 常用模式
 description: 归纳 Spring Boot 接入 AI4J 的推荐分层与工程组织模式，明确 Web、AI4J 调用与 Tool、RAG、Workflow 的责任边界。
 tags: [integration]
 ---
 
-# Spring Boot Common Patterns
-
+# Spring Boot 常用模式
 这一页讲高频工程组织方式，不讲 API 语法。
 
 ## 1. 这页真正解决什么

--- a/docs-site/docs/integrations/spring-boot/configuration-reference.md
+++ b/docs-site/docs/integrations/spring-boot/configuration-reference.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot Configuration Reference
+title: Spring Boot 配置参考
 description: 按 ai.* 能力面前缀梳理 AI4J 的 Spring Boot 配置，说明单实例与多实例注册表配置的流向与分层判断。
 tags: [reference]
 ---
 
-# Spring Boot Configuration Reference
-
+# Spring Boot 配置参考
 这一页只讲配置入口，不讲业务调用。
 
 ## 1. 配置分层
@@ -220,6 +219,6 @@ ai4j:
 
 ## 8. 继续阅读
 
-- 首次接入：看 [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+- 首次接入：看 [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 - 中转平台：看 [OpenAI-compatible 与 TroveBox](/docs/capabilities/models/openai-compatible-and-trovebox)
-- 多实例入口：看 [Service Entry and Registry](/docs/capabilities/service-entry)
+- 多实例入口：看 [服务入口与注册表](/docs/capabilities/service-entry)

--- a/docs-site/docs/integrations/spring-boot/overview.md
+++ b/docs-site/docs/integrations/spring-boot/overview.md
@@ -31,8 +31,8 @@ Spring Boot starter 解决的是：
 
 第一次接入建议按这个顺序：
 
-1. [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
-2. [Spring Boot Quickstart](/docs/integrations/spring-boot/quickstart)
+1. [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
+2. [Spring Boot 快速开始](/docs/integrations/spring-boot/quickstart)
 3. [Auto Configuration](/docs/integrations/spring-boot/auto-configuration)
 4. [Configuration Reference](/docs/integrations/spring-boot/configuration-reference)
 5. [Bean Extension](/docs/integrations/spring-boot/bean-extension)
@@ -101,10 +101,10 @@ ai:
 
 相关页面：
 
-- [Version Compatibility](/docs/reference/version-compatibility)
-- [Security Overview](/docs/production/security)
-- [Production Checklist](/docs/production/production-checklist)
-- [Troubleshooting](/docs/production/troubleshooting)
+- [版本兼容性](/docs/reference/version-compatibility)
+- [安全总览](/docs/production/security)
+- [生产检查清单](/docs/production/production-checklist)
+- [排障指南](/docs/production/troubleshooting)
 
 ## 继续阅读
 

--- a/docs-site/docs/integrations/spring-boot/quickstart.md
+++ b/docs-site/docs/integrations/spring-boot/quickstart.md
@@ -1,11 +1,10 @@
 ---
-title: Spring Boot Quickstart
+title: Spring Boot 快速开始
 description: Spring Boot 接入 AI4J 的最短成功路径：引入 starter、配置 ai.*、注入 AiService 并发出第一个 ChatCompletion。
 tags: [how-to]
 ---
 
-# Spring Boot Quickstart
-
+# Spring Boot 快速开始
 如果你还没跑通第一个 Spring Boot 请求，先读这一页。
 
 ## 1. 最短成功路径
@@ -96,5 +95,5 @@ public String chatOnce(String userInput) throws Exception {
 
 如果是入口阶段问题，先回看：
 
-- [Troubleshooting](/docs/production/troubleshooting)
+- [排障指南](/docs/production/troubleshooting)
 - [Configuration Reference](/docs/integrations/spring-boot/configuration-reference)

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -18,13 +18,13 @@ AI4J 是一套面向 `Java 8+` 的 AI SDK。它不是一个要求全量采用的
 
 | 目标 | 推荐入口 | 你会得到什么 |
 | --- | --- | --- |
-| 普通 Java 跑通第一条 AI 请求 | [Quickstart for Java](/docs/getting-started/quickstart-java) | 最小依赖、密钥配置、验证标准和第一条模型调用 |
-| 普通 Java 项目先跑通 | [Quickstart for Java](/docs/getting-started/quickstart-java) | 最小依赖、配置和第一段调用代码 |
-| Spring Boot 项目接入 | [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot) | starter、配置项和 Bean 注入方式 |
-| 先看完整能力边界 | [Feature Map](/docs/getting-started/feature-map) | AI4J 当前能力、成熟度和继续阅读路径 |
-| 查正式文档路径 | [Documentation Map](/docs/reference/maps/documentation-map) | canonical 主线、legacy 来源和迁移方向 |
-| 上线前检查 | [Production Checklist](/docs/production/production-checklist) | 版本、密钥、Tool、MCP、RAG、Agent、FlowGram 的检查项 |
-| 理解为什么做 AI4J | [Why AI4J](/docs/getting-started/why-ai4j) | 项目定位、适合场景和与相邻方案的差异 |
+| 普通 Java 跑通第一条 AI 请求 | [Java 快速开始](/docs/getting-started/quickstart-java) | 最小依赖、密钥配置、验证标准和第一条模型调用 |
+| 普通 Java 项目先跑通 | [Java 快速开始](/docs/getting-started/quickstart-java) | 最小依赖、配置和第一段调用代码 |
+| Spring Boot 项目接入 | [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot) | starter、配置项和 Bean 注入方式 |
+| 先看完整能力边界 | [功能地图](/docs/getting-started/feature-map) | AI4J 当前能力、成熟度和继续阅读路径 |
+| 查正式文档路径 | [文档地图](/docs/reference/maps/documentation-map) | canonical 主线、legacy 来源和迁移方向 |
+| 上线前检查 | [生产检查清单](/docs/production/production-checklist) | 版本、密钥、Tool、MCP、RAG、Agent、FlowGram 的检查项 |
+| 理解为什么做 AI4J | [为什么选 AI4J](/docs/getting-started/why-ai4j) | 项目定位、适合场景和与相邻方案的差异 |
 
 ## 用多少，取多少
 
@@ -52,7 +52,7 @@ AI4J 的能力分为三层。阅读时建议先把 Core SDK 跑通，再按项�
 | 应用集成 | Spring Boot starter、配置治理、自动装配 | [Spring Boot](/docs/integrations/spring-boot/overview) |
 | 上层运行时 | Agent、Coding Agent、FlowGram 工作流 | [Agent](/docs/agent/overview)、[Coding Agent](/docs/products/coding-agent/overview)、[FlowGram](/docs/products/flowgram/overview) |
 | 场景方案 | 常见组合方案和可复制集成路径 | [Solutions](/docs/integrations/solutions/overview) |
-| 生产准备 | 版本兼容、发布 artifact、安全、迁移、排障 | [Version Compatibility](/docs/reference/version-compatibility)、[Security](/docs/production/security)、[Troubleshooting](/docs/production/troubleshooting) |
+| 生产准备 | 版本兼容、发布 artifact、安全、迁移、排障 | [版本兼容性](/docs/reference/version-compatibility)、[Security](/docs/production/security)、[排障指南](/docs/production/troubleshooting) |
 
 ## 三个概念不要混在一起
 
@@ -79,5 +79,5 @@ AI4J 文档会刻意区分三类能力：
 
 这些模块不是为了展示目录规模，而是为了让使用者只引入当下需要的能力，并保留向上升级的空间。
 
-下一步建议：如果你还没跑过代码，直接看 [Quickstart for Java](/docs/getting-started/quickstart-java)；
-如果你想先判断 AI4J 是否适合自己的项目，看 [Why AI4J](/docs/getting-started/why-ai4j)。
+下一步建议：如果你还没跑过代码，直接看 [Java 快速开始](/docs/getting-started/quickstart-java)；
+如果你想先判断 AI4J 是否适合自己的项目，看 [为什么选 AI4J](/docs/getting-started/why-ai4j)。

--- a/docs-site/docs/production/production-checklist.md
+++ b/docs-site/docs/production/production-checklist.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Production Checklist
+title: 生产检查清单
 description: AI4J 接入真实项目前的上线检查清单。不要求一次性启用所有能力，而是按已使用的模块确认风险边界：最小模块选择、密钥管理、网络隔离、Tool 暴露、本地文件边界。
 tags: [reference]
 ---
 
-# Production Checklist
-
+# 生产检查清单
 这页是把 AI4J 接入真实项目之前的上线检查清单。它不是要让每个项目一次性启用所有能力，而是帮助你按已使用的模块确认风险边界。
 
 ## 1. 选择最小模块
@@ -98,7 +97,7 @@ live provider 测试需要真实凭证时，必须走显式 profile 或单独环
 
 ## 10. 发布前确认
 
-- [ ] 使用 [Version Compatibility](/docs/reference/version-compatibility) 检查版本和模块。
-- [ ] 使用 [Security Overview](/docs/production/security) 检查安全边界。
-- [ ] 使用 [Troubleshooting](/docs/production/troubleshooting) 准备排障入口。
-- [ ] 使用 [Migration Guide](/docs/reference/migration) 标记旧 API、旧文档或旧示例的替代路径。
+- [ ] 使用 [版本兼容性](/docs/reference/version-compatibility) 检查版本和模块。
+- [ ] 使用 [安全总览](/docs/production/security) 检查安全边界。
+- [ ] 使用 [排障指南](/docs/production/troubleshooting) 准备排障入口。
+- [ ] 使用 [迁移指南](/docs/reference/migration) 标记旧 API、旧文档或旧示例的替代路径。

--- a/docs-site/docs/production/security.md
+++ b/docs-site/docs/production/security.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Security Overview
+title: 安全总览
 description: AI4J 安全边界由密钥、网络、Tool、MCP、RAG、Agent、Coding Agent 和 FlowGram 多层组成。接入前明确：哪些能力能被模型看见、调用、回写到用户或日志。密钥不入仓、Tool 最小暴露、本地边界约束。
 tags: [concept]
 ---
 
-# Security Overview
-
+# 安全总览
 AI4J 的安全边界不是单个开关，而是由密钥、网络、Tool、MCP、RAG、Agent、Coding Agent 和 FlowGram 多层共同组成。接入前应先明确：哪些能力能被模型看见，哪些能力能被模型调用，哪些结果能回写到用户或日志。
 
 ## 基本原则
@@ -49,7 +48,7 @@ Tool 的安全边界分两层：
 相关页面：
 
 - [Tools Overview](/docs/capabilities/tools/overview)
-- [Tool Whitelist and Security](/docs/capabilities/tools/tool-whitelist-and-security)
+- [工具白名单与安全](/docs/capabilities/tools/tool-whitelist-and-security)
 - [MCP Tool Exposure Semantics](/docs/capabilities/mcp/tool-exposure-semantics)
 
 ## MCP 安全
@@ -81,7 +80,7 @@ RAG 的最大风险通常不是模型，而是索引和权限。
 相关页面：
 
 - [Search & RAG Overview](/docs/capabilities/rag/overview)
-- [Citations and Trace](/docs/capabilities/rag/citations-and-trace)
+- [引用与 Trace](/docs/capabilities/rag/citations-and-trace)
 
 ## Agent 与 Coding Agent 安全
 
@@ -112,7 +111,7 @@ FlowGram starter 默认更偏 demo / 内网集成姿态。正式上线前必须�
 相关页面：
 
 - [FlowGram Overview](/docs/products/flowgram/overview)
-- [Production Checklist](/docs/production/production-checklist)
+- [生产检查清单](/docs/production/production-checklist)
 
 ## 上线前最小安全清单
 

--- a/docs-site/docs/production/troubleshooting.md
+++ b/docs-site/docs/production/troubleshooting.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Troubleshooting
+title: 排障指南
 description: AI4J 生产排障入口。不列出所有异常栈，而是按能力层把问题定位到正确页面和检查项：模型请求失败查 provider key、Chat 能用 Responses 不能用查 provider 支持、Streaming 没增量查消费方式。
 tags: [how-to]
 ---
 
-# Troubleshooting
-
+# 排障指南
 本页是生产排障入口。它不列出所有异常栈，而是按 AI4J 的能力层把问题定位到正确页面和检查项。
 
 ## 先定位是哪一层
@@ -39,7 +38,7 @@ tags: [how-to]
 
 - [Model Access Overview](/docs/capabilities/models/overview)
 - [Platform and Service Matrix](/docs/capabilities/models/platform-service-matrix)
-- [Chat vs Responses](/docs/capabilities/models/chat-vs-responses)
+- [Chat 与 Responses 对比](/docs/capabilities/models/chat-vs-responses)
 
 ## Spring Boot 配置
 
@@ -68,7 +67,7 @@ Tool 问题要分清“模型是否看见工具”和“系统是否执行成功
 相关页面：
 
 - [Tools Overview](/docs/capabilities/tools/overview)
-- [Tool Execution Model](/docs/capabilities/tools/tool-execution-model)
+- [工具执行模型](/docs/capabilities/tools/tool-execution-model)
 - [MCP Overview](/docs/capabilities/mcp/overview)
 - [Gateway Management](/docs/capabilities/mcp/gateway-management)
 
@@ -85,8 +84,8 @@ RAG 排障建议先分成 ingestion、retrieval、generation 三段。
 相关页面：
 
 - [Search & RAG Overview](/docs/capabilities/rag/overview)
-- [Ingestion Pipeline](/docs/capabilities/rag/ingestion-pipeline)
-- [Hybrid Retrieval](/docs/capabilities/rag/hybrid-retrieval)
+- [摄取管线](/docs/capabilities/rag/ingestion-pipeline)
+- [混合检索](/docs/capabilities/rag/hybrid-retrieval)
 
 ## Agent / Coding Agent
 

--- a/docs-site/docs/products/coding-agent/architecture.md
+++ b/docs-site/docs/products/coding-agent/architecture.md
@@ -1,11 +1,10 @@
 ---
-title: Coding Agent Architecture
+title: Coding Agent 架构
 description: 从执行主链拆解 Coding Agent 的分层架构：CodingAgentBuilder 装配点、WorkspaceContext 边界、CodingSession 容器、delegation runtime、审批 decorator 与 host runtime 的职责划分。
 tags: [concept]
 ---
 
-# Coding Agent Architecture
-
+# Coding Agent 架构
 `Coding Agent` 的架构重点不是“在 `AgentBuilder` 外面再包一层 API”，而是把通用 agent 运行时、workspace 语义、长期会话、宿主交互和外部工具接入拼成一条稳定的本地交付链。
 
 如果不从“执行链”看，你会低估很多类存在的必要性。

--- a/docs-site/docs/products/coding-agent/command-reference.md
+++ b/docs-site/docs/products/coding-agent/command-reference.md
@@ -1010,7 +1010,7 @@ classpath 发现（discovery）不会自动启用扩展。执行扩展命令或�
 sandbox 的凭证必须来自环境变量或本地配置，**不接受** slash 命令参数传入——避免在 shell 历史里泄露密钥。
 :::
 
-绑定 sandbox 后，`bash action=exec` 会路由到 `SandboxSession.execute(...)`，并在返回结果里带上 `executionEnvironment`、`sandboxSessionId`、`sandboxProviderId`。完整边界见 [Sandbox Routing](/docs/products/coding-agent/sandbox-routing)。
+绑定 sandbox 后，`bash action=exec` 会路由到 `SandboxSession.execute(...)`，并在返回结果里带上 `executionEnvironment`、`sandboxSessionId`、`sandboxProviderId`。完整边界见 [沙箱路由](/docs/products/coding-agent/sandbox-routing)。
 
 ### `/extension` / `/extensions`
 

--- a/docs-site/docs/products/coding-agent/compact-and-checkpoint.md
+++ b/docs-site/docs/products/coding-agent/compact-and-checkpoint.md
@@ -465,6 +465,6 @@ compact 真正难的地方不是“生成摘要”，而是“摘要生成后还
 ## 12. 推荐连读
 
 1. [会话、流式与进程](/docs/products/coding-agent/session-runtime)
-2. [Coding Agent Architecture](/docs/products/coding-agent/architecture)
+2. [Coding Agent 架构](/docs/products/coding-agent/architecture)
 3. [配置体系](/docs/products/coding-agent/configuration)
 4. [命令参考](/docs/products/coding-agent/command-reference)

--- a/docs-site/docs/products/coding-agent/install-and-release.md
+++ b/docs-site/docs/products/coding-agent/install-and-release.md
@@ -1,11 +1,10 @@
 ---
-title: Install and Release
+title: 安装与发布
 description: 分清 Coding Agent 的构建、Maven 发布与终端 CLI 安装三层，说明当前仓库已提供 fat jar 与平台 launcher，并明确 fat jar 为最稳分发基线及 release 缺口。
 tags: [how-to]
 ---
 
-# Install and Release
-
+# 安装与发布
 这一页讲的不是“怎么配置 provider”，而是另一个更现实的问题：
 
 - 当前仓库里到底产出了什么可分发物

--- a/docs-site/docs/products/coding-agent/mcp-and-acp.md
+++ b/docs-site/docs/products/coding-agent/mcp-and-acp.md
@@ -1,11 +1,10 @@
 ---
-title: MCP and ACP
+title: MCP 与 ACP
 description: 厘清 Coding Agent 里 MCP（把外部能力接进模型工具面）与 ACP（把 coding session 协议化暴露给宿主）两条完全不同的边界，说明它们如何在同一会话里同时生效。
 tags: [concept]
 ---
 
-# MCP and ACP
-
+# MCP 与 ACP
 `MCP` 和 `ACP` 在 Coding Agent 里经常一起出现，所以很容易被误写成“同一套接入机制的两个名字”。  
 从源码看，它们其实分属两侧完全不同的边界：
 

--- a/docs-site/docs/products/coding-agent/overview.md
+++ b/docs-site/docs/products/coding-agent/overview.md
@@ -105,15 +105,15 @@ Coding Agent 的高风险面比普通 Agent 更大，因为它可能接触文件
 
 - [Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)
 - [Session Runtime](/docs/products/coding-agent/session-runtime)
-- [Security Overview](/docs/production/security)
+- [安全总览](/docs/production/security)
 
 ## 推荐阅读顺序
 
 ### 直接使用
 
-1. [Why Coding Agent](/docs/products/coding-agent/why-coding-agent)
+1. [为什么需要 Coding Agent](/docs/products/coding-agent/why-coding-agent)
 2. [Quickstart](/docs/products/coding-agent/quickstart)
-3. [Install and Release](/docs/products/coding-agent/install-and-release)
+3. [安装与发布](/docs/products/coding-agent/install-and-release)
 4. [CLI / TUI](/docs/products/coding-agent/cli-and-tui)
 5. [Provider Profiles](/docs/products/coding-agent/provider-profiles)
 6. [Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)
@@ -124,7 +124,7 @@ Coding Agent 的高风险面比普通 Agent 更大，因为它可能接触文件
 1. [Architecture](/docs/products/coding-agent/architecture)
 2. [Runtime Architecture](/docs/products/coding-agent/runtime-architecture)
 3. [Prompt Assembly](/docs/products/coding-agent/prompt-assembly)
-4. [MCP and ACP](/docs/products/coding-agent/mcp-and-acp)
+4. [MCP 与 ACP](/docs/products/coding-agent/mcp-and-acp)
 5. [Command Reference](/docs/products/coding-agent/command-reference)
 
 如果你要比较 Coding Agent 和 JS/TS 生态里的 agent SDK，看 [Comparison](/docs/reference/about/comparison)。

--- a/docs-site/docs/products/coding-agent/quickstart.md
+++ b/docs-site/docs/products/coding-agent/quickstart.md
@@ -70,7 +70,7 @@ ai4j-cli/target/ai4j-cli-2.4.3-SNAPSHOT-jar-with-dependencies.jar
 - 先构建 fat jar
 - 再直接 `java -jar`
 
-当前源码树的版本是 `2.4.3-SNAPSHOT`，因此上面的产物名使用该版本。使用已发布二进制时，请按实际 release 版本替换文件名；当前发布版依赖坐标见 [Release and Artifacts](/docs/reference/release-and-artifacts)。
+当前源码树的版本是 `2.4.3-SNAPSHOT`，因此上面的产物名使用该版本。使用已发布二进制时，请按实际 release 版本替换文件名；当前发布版依赖坐标见 [发布与制品](/docs/reference/release-and-artifacts)。
 
 ---
 

--- a/docs-site/docs/products/coding-agent/sandbox-routing.md
+++ b/docs-site/docs/products/coding-agent/sandbox-routing.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 11
-title: Sandbox Routing
+title: 沙箱路由
 description: 说明 ai4j-coding 如何把 Coding Agent 的 bash exec 路由到 live SandboxSession（P3 首切片），覆盖当前 API、未路由的工具、与审批的关系以及非敏感 sandbox 摘要的安全边界。
 tags: [integration]
 ---
 
-# Sandbox Routing
-
+# 沙箱路由
 这一页说明 `ai4j-coding` 如何把 Coding Agent 的执行型工具接到 `ai4j-agent` 的 Sandbox SPI。
 
 先说当前状态：**P3 首切片已经支持 `bash` 的 foreground `exec` 路由到 live `SandboxSession`**。这不是完整云端 Runner，也不是文件系统级隔离平台；它只是把一次性 shell 命令从本地 `LocalShellCommandExecutor` 切换到 `SandboxSession.execute(...)`。
@@ -147,7 +146,7 @@ mvn -pl ai4j-coding -am -DskipTests=false test
 
 ## 8. 继续阅读
 
-1. [Agent Sandbox SPI](/docs/agent/governance/sandbox-spi)
+1. [Agent 沙箱 SPI](/docs/agent/governance/sandbox-spi)
 2. [Tools 与审批机制](/docs/products/coding-agent/tools-and-approvals)
 3. [会话、流式与进程](/docs/products/coding-agent/session-runtime)
-4. [AI4J Agent SDK Roadmap](/docs/reference/about/sdk-roadmap)
+4. [AI4J Agent SDK 路线图](/docs/reference/about/sdk-roadmap)

--- a/docs-site/docs/products/coding-agent/skills.md
+++ b/docs-site/docs/products/coding-agent/skills.md
@@ -374,5 +374,5 @@ skill 本身不会执行任何动作。真正执行仍然要靠：
 
 1. [Tools 与审批机制](/docs/products/coding-agent/tools-and-approvals)
 2. [MCP 对接](/docs/products/coding-agent/mcp-integration)
-3. [Why Coding Agent](/docs/products/coding-agent/why-coding-agent)
-4. [Coding Agent Architecture](/docs/products/coding-agent/architecture)
+3. [为什么需要 Coding Agent](/docs/products/coding-agent/why-coding-agent)
+4. [Coding Agent 架构](/docs/products/coding-agent/architecture)

--- a/docs-site/docs/products/coding-agent/tools-and-approvals.md
+++ b/docs-site/docs/products/coding-agent/tools-and-approvals.md
@@ -428,7 +428,7 @@ ACP 下，则是：
 
 返回结果会带上 `executionEnvironment`、`sandboxSessionId`、`sandboxProviderId`，方便 CLI/TUI、日志或上层宿主展示“这次命令到底在哪执行”。
 
-注意：这不等于所有工具都已经远端化。`read_file`、`write_file`、`apply_patch`、后台进程、browser、git/project run 等仍需要后续切片逐步接入。完整边界见 [Sandbox Routing](/docs/products/coding-agent/sandbox-routing)。
+注意：这不等于所有工具都已经远端化。`read_file`、`write_file`、`apply_patch`、后台进程、browser、git/project run 等仍需要后续切片逐步接入。完整边界见 [沙箱路由](/docs/products/coding-agent/sandbox-routing)。
 
 ## 15. 当前最稳的扩展位置在哪里
 
@@ -488,7 +488,7 @@ AI4J 当前的 Coding Agent tools 机制，不是“8 个函数 + 一个确认�
 
 1. [会话、流式与进程](/docs/products/coding-agent/session-runtime)
 2. [Compact 与 Checkpoint 机制](/docs/products/coding-agent/compact-and-checkpoint)
-3. [Sandbox Routing](/docs/products/coding-agent/sandbox-routing)
+3. [沙箱路由](/docs/products/coding-agent/sandbox-routing)
 4. [生命周期钩子与工作区信任](/docs/products/coding-agent/lifecycle-hooks)
 5. [Runtime 架构](/docs/products/coding-agent/runtime-architecture)
 

--- a/docs-site/docs/products/coding-agent/why-coding-agent.md
+++ b/docs-site/docs/products/coding-agent/why-coding-agent.md
@@ -1,11 +1,10 @@
 ---
-title: Why Coding Agent
+title: 为什么需要 Coding Agent
 description: 解释 Coding Agent 在通用 Agent 之上叠加的 5 层本地交付语义（workspace、coding tools、多回合 loop、session/compact/restore、CLI/TUI/ACP 宿主），界定它和普通 Agent 的真实边界。
 tags: [concept]
 ---
 
-# Why Coding Agent
-
+# 为什么需要 Coding Agent
 `Coding Agent` 这页最容易写成一句空话：  
 “它是面向代码任务的 Agent。”
 
@@ -381,6 +380,6 @@ AI4J 当前的 `Coding Agent` 之所以不是通用 Agent 的别名，是因为�
 3. [Tools and Approvals](/docs/products/coding-agent/tools-and-approvals)
 4. [Compact and Checkpoint](/docs/products/coding-agent/compact-and-checkpoint)
 5. [CLI and TUI](/docs/products/coding-agent/cli-and-tui)
-6. [MCP and ACP](/docs/products/coding-agent/mcp-and-acp)
+6. [MCP 与 ACP](/docs/products/coding-agent/mcp-and-acp)
 
 下一页如果要继续沿着这条主线往下读，建议直接看 [Runtime Architecture](/docs/products/coding-agent/runtime-architecture)。

--- a/docs-site/docs/products/flowgram/architecture.md
+++ b/docs-site/docs/products/flowgram/architecture.md
@@ -1,11 +1,10 @@
 ---
-title: Flowgram Architecture
+title: Flowgram 架构
 description: 拆解 Flowgram 前端画布加 AI4J 后端执行层的四层架构：画布、适配、Spring Boot 平台接入与执行引擎，讲清编辑态与执行态 schema 的差异和默认安全姿态。
 tags: [concept]
 ---
 
-# Flowgram Architecture
-
+# Flowgram 架构
 `Flowgram` 的架构重点，不是单讲 `Flowgram.ai` 前端库本身，而是讲“前端画布 + AI4J 后端执行层”如何组成一个真正可运行的工作流平台。
 
 如果你只看 demo，会觉得这是一组 REST API；如果你沿着源码看，会发现它其实拆成了 4 个很明确的层次。
@@ -438,8 +437,8 @@ private final ConcurrentMap<String, TaskRecord> tasks = new ConcurrentHashMap<St
 
 1. [Runtime](/docs/products/flowgram/runtime)
 2. [Frontend / Backend Integration](/docs/products/flowgram/frontend-backend-integration)
-3. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
-4. [Custom Nodes](/docs/products/flowgram/custom-nodes)
+3. [内置节点](/docs/products/flowgram/built-in-nodes)
+4. [自定义节点](/docs/products/flowgram/custom-nodes)
 
 如果你只记住一个架构结论：
 

--- a/docs-site/docs/products/flowgram/built-in-nodes.md
+++ b/docs-site/docs/products/flowgram/built-in-nodes.md
@@ -1,11 +1,10 @@
 ---
-title: Built-in Nodes
+title: 内置节点
 description: 区分 Flowgram runtime 内核节点（START/END/LLM/CONDITION/LOOP）与 starter 注册的 executor 节点（HTTP/VARIABLE/CODE/TOOL/KNOWLEDGE），讲清共享值解析模型与各节点输入输出。
 tags: [concept]
 ---
 
-# Built-in Nodes
-
+# 内置节点
 `Built-in Nodes` 这一页最重要的不是罗列节点名，而是把“哪些能力属于 runtime 内核，哪些能力属于 starter 注册 executor”讲清楚。
 
 如果这个边界没看懂，后面做自定义节点时很容易把扩展点放错地方。

--- a/docs-site/docs/products/flowgram/custom-node-extension.md
+++ b/docs-site/docs/products/flowgram/custom-node-extension.md
@@ -275,7 +275,7 @@ executor 抛出的异常不会只是打印日志，它会直接影响节点和�
 
 ## 12. 这一页和其它页面的边界
 
-- [Custom Nodes](/docs/products/flowgram/custom-nodes)
+- [自定义节点](/docs/products/flowgram/custom-nodes)
   讲前后端整体契约
 - [前端自定义节点开发](/docs/products/flowgram/frontend-custom-node-development)
   讲前端 registry、表单和 type map

--- a/docs-site/docs/products/flowgram/custom-nodes.md
+++ b/docs-site/docs/products/flowgram/custom-nodes.md
@@ -1,11 +1,10 @@
 ---
-title: Custom Nodes
+title: 自定义节点
 description: 自定义节点是把能力正式接入 Flowgram 前后端执行契约：后端 FlowGramNodeExecutor 扩展点、getType 协议名、输入输出 contract 稳定性原则与前后端协同三件事。
 tags: [how-to]
 ---
 
-# Custom Nodes
-
+# 自定义节点
 `Custom Nodes` 的核心不是“再加一个节点卡片”，而是把一个能力正式接入 Flowgram 的前后端执行契约。
 
 如果只做前端节点而没有后端 executor，它只是一个画布元素；如果只有后端 executor 而前端没有稳定 schema，它也很难成为真正可用的平台节点。

--- a/docs-site/docs/products/flowgram/frontend-backend-integration.md
+++ b/docs-site/docs/products/flowgram/frontend-backend-integration.md
@@ -324,7 +324,7 @@ Runtime 负责：
 
 也就是说，权限控制不在前端 runtime plugin，而在后端 facade 这一层。
 
-另外，前端画布与后端任务 API 通常部署在不同 origin，浏览器跨域调用 `/flowgram/**` 需要后端放行 CORS：把编辑器来源加进 `ai4j.flowgram.cors.allowed-origins`（默认空列表，绑定 `CorsProperties`）。完整字段见 [Spring Boot Configuration Reference](/docs/integrations/spring-boot/configuration-reference) §5（`ai4j.flowgram.*` / CORS）。
+另外，前端画布与后端任务 API 通常部署在不同 origin，浏览器跨域调用 `/flowgram/**` 需要后端放行 CORS：把编辑器来源加进 `ai4j.flowgram.cors.allowed-origins`（默认空列表，绑定 `CorsProperties`）。完整字段见 [Spring Boot 配置参考](/docs/integrations/spring-boot/configuration-reference) §5（`ai4j.flowgram.*` / CORS）。
 
 ## 11. 最重要的对接原则
 

--- a/docs-site/docs/products/flowgram/overview.md
+++ b/docs-site/docs/products/flowgram/overview.md
@@ -84,7 +84,7 @@ LLM 节点可以复用 Agent runtime，但 FlowGram 不会把整个工作流重�
 - cancel、失败重试、异常展示和日志脱敏是否覆盖。
 :::
 
-更多检查项见 [Production Checklist](/docs/production/production-checklist)。
+更多检查项见 [生产检查清单](/docs/production/production-checklist)。
 
 ## 推荐阅读顺序
 
@@ -95,7 +95,7 @@ LLM 节点可以复用 Agent runtime，但 FlowGram 不会把整个工作流重�
 5. [Runtime](/docs/products/flowgram/runtime)
 6. [Frontend / Backend Integration](/docs/products/flowgram/frontend-backend-integration)
 7. [API and Runtime](/docs/products/flowgram/api-and-runtime)
-8. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
-9. [Custom Nodes](/docs/products/flowgram/custom-nodes)
+8. [内置节点](/docs/products/flowgram/built-in-nodes)
+9. [自定义节点](/docs/products/flowgram/custom-nodes)
 
 如果你要做的是本地代码仓任务，应该从 [Coding Agent](/docs/products/coding-agent/overview) 开始；如果你要做的是通用业务智能体，应该从 [Agent](/docs/agent/overview) 开始。

--- a/docs-site/docs/products/flowgram/quickstart.md
+++ b/docs-site/docs/products/flowgram/quickstart.md
@@ -367,4 +367,4 @@ $report = Invoke-RestMethod -Method Get -Uri ("http://127.0.0.1:18080/flowgram/t
 2. [Runtime](/docs/products/flowgram/runtime)
 3. [Flowgram API 与运行时](/docs/products/flowgram/api-and-runtime)
 4. [前端工作流如何在后端执行](/docs/products/flowgram/workflow-execution-pipeline)
-5. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
+5. [内置节点](/docs/products/flowgram/built-in-nodes)

--- a/docs-site/docs/products/flowgram/runtime.md
+++ b/docs-site/docs/products/flowgram/runtime.md
@@ -1,11 +1,10 @@
 ---
-title: Flowgram Runtime
+title: Flowgram 运行时
 description: Flowgram 后端执行真相：FlowGramRuntimeService 把 workflow schema 变成异步任务，节点图变成有状态执行链，节点输出变成 report/result/trace 读侧结构。
 tags: [concept]
 ---
 
-# Flowgram Runtime
-
+# Flowgram 运行时
 `Runtime` 这一层是 Flowgram 的后端执行真相，不是“controller 后面接个 service”那么简单。
 
 如果要用一句话概括：

--- a/docs-site/docs/products/flowgram/use-cases-and-paths.md
+++ b/docs-site/docs/products/flowgram/use-cases-and-paths.md
@@ -66,8 +66,8 @@ tags: [concept]
 
 先看：
 
-1. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
-2. [Custom Nodes](/docs/products/flowgram/custom-nodes)
+1. [内置节点](/docs/products/flowgram/built-in-nodes)
+2. [自定义节点](/docs/products/flowgram/custom-nodes)
 3. [Frontend / Backend Integration](/docs/products/flowgram/frontend-backend-integration)
 4. [Runtime](/docs/products/flowgram/runtime)
 
@@ -83,7 +83,7 @@ tags: [concept]
 
 先看：
 
-1. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
+1. [内置节点](/docs/products/flowgram/built-in-nodes)
 2. [Agent / Tool / Knowledge Integration](/docs/products/flowgram/agent-tool-knowledge-integration)
 3. [Runtime](/docs/products/flowgram/runtime)
 
@@ -226,8 +226,8 @@ tags: [concept]
 
 先看：
 
-1. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
-2. [Custom Nodes](/docs/products/flowgram/custom-nodes)
+1. [内置节点](/docs/products/flowgram/built-in-nodes)
+2. [自定义节点](/docs/products/flowgram/custom-nodes)
 
 然后再读：
 

--- a/docs-site/docs/products/flowgram/why-flowgram.md
+++ b/docs-site/docs/products/flowgram/why-flowgram.md
@@ -1,11 +1,10 @@
 ---
-title: Why Flowgram
+title: Flowgram 的价值
 description: Flowgram 存在的价值：补上 Agent 给不了的平台化后端结构——工作流契约、任务生命周期、节点执行边界与面向平台的读侧输出，同时讲清当前边界与适用场景。
 tags: [concept]
 ---
 
-# Why Flowgram
-
+# Flowgram 的价值
 `Flowgram` 值得单独存在，不是因为“可视化工作流”这个词听起来更完整，而是因为前端画布产品对后端的要求，和普通 `Agent` 运行时不是同一个问题。
 
 如果只靠 Agent，你可以做出能跑的智能体；如果要做一套能交给前端画布、平台控制面和任务中心消费的后端，你还缺很多结构化能力。
@@ -214,8 +213,8 @@ tags: [concept]
 1. [Architecture](/docs/products/flowgram/architecture)
 2. [Runtime](/docs/products/flowgram/runtime)
 3. [Frontend / Backend Integration](/docs/products/flowgram/frontend-backend-integration)
-4. [Built-in Nodes](/docs/products/flowgram/built-in-nodes)
-5. [Custom Nodes](/docs/products/flowgram/custom-nodes)
+4. [内置节点](/docs/products/flowgram/built-in-nodes)
+5. [自定义节点](/docs/products/flowgram/custom-nodes)
 
 如果你只记一个结论：
 

--- a/docs-site/docs/reference/about/comparison.md
+++ b/docs-site/docs/reference/about/comparison.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Comparison and Positioning
+title: 对比与定位
 description: AI4J 与 Spring AI、LangChain4j、AgentScope Java、Pi Agent 等方案的定位对比。不做拉踩，而是讲清 AI4J 专注 Java 8+ 多模块 SDK、渐进接入能力和更轻的按需取用路径，帮你判断何时选 AI4J。
 tags: [concept]
 ---
 
-# Comparison and Positioning
-
+# 对比与定位
 这页回答 AI4J 与 Spring AI、LangChain4j、AgentScope Java、Pi Agent 这类方案的区别。它不做拉踩，也不试图证明个人项目在生态规模上超过大团队项目。更实际的判断是：AI4J 应该把 Java 接入 AI 的成本做低，把模块边界讲清楚，并提供一些更轻、更直、更容易按需取用的路径。
 
 ## 先说结论
@@ -40,7 +39,7 @@ AI4J 的路线不是“替代所有框架”，而是先把 Java 项目接 AI �
 
 这些不是生态规模优势，而是产品取舍优势。个人项目更应该把“容易开始、边界清楚、按需取用”做到极致。
 
-后五行是能在选型文档里直接复述的硬技术差异点：每一项都有对应模块代码和文档页支撑（见 [Strengths and Differentiators](/docs/reference/about/strengths-and-differentiators)），不是路线图承诺。
+后五行是能在选型文档里直接复述的硬技术差异点：每一项都有对应模块代码和文档页支撑（见 [优势与差异点](/docs/reference/about/strengths-and-differentiators)），不是路线图承诺。
 
 ## 与 Spring AI 的区别
 

--- a/docs-site/docs/reference/about/contributing.md
+++ b/docs-site/docs/reference/about/contributing.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 14
-title: Contribute to AI4J
+title: AI4J 贡献指南
 description: How to contribute to AI4J — reporting issues, proposing changes, running docs-site local checks and Java module tests, and following the security disclosure policy.
 tags: [how-to]
 ---
 
-# Contribute to AI4J
-
+# AI4J 贡献指南
 This page is the documentation entry point for contributors. The repository's [full contribution guide](https://github.com/LnYo-Cly/ai4j/blob/main/CONTRIBUTING.md) is authoritative for source changes and pull requests.
 
 ## Choose a path

--- a/docs-site/docs/reference/about/sdk-roadmap.md
+++ b/docs-site/docs/reference/about/sdk-roadmap.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 4
-title: AI4J Agent SDK Roadmap
+title: AI4J Agent SDK 路线图
 description: ai4j-agent 技术路线图：从 P0 运行内核（Session/Memory/Compact/Plugin/Permission）到 P1 Blueprint YAML、P2 Sandbox SPI、P3 Coding 沙箱路由、P4 CLI 与 P5 远端 Runner 的分阶段演进。
 tags: [reference]
 ---
 
-# AI4J Agent SDK Roadmap
-
+# AI4J Agent SDK 路线图
 这一页说明 `ai4j-agent` 接下来要怎样从“可用的 Agent runtime”升级为更完整的 Java Agent SDK。
 
 先明确一个边界：这里是技术路线图，不代表所有能力都已经发布。当前已经存在的能力包括 `Agent`、`AgentBuilder`、`AgentRuntime`、`AgentSession`、memory、runtime、workflow、team、trace 等；下面的路线是后续要逐步补强的方向。
@@ -81,11 +80,11 @@ AgentSession =
 - `AgentBuilder.sessionStore(...)` 与 `Agent.resumeSession(...)`
 - 与现有 `Agent.run(...)` 兼容
 
-使用细节见 [Agent Session Runtime](/docs/agent/session-runtime)。
+使用细节见 [Agent 会话运行时](/docs/agent/session-runtime)。
 
 ### P0-B：Memory、Compact、Context Projector 分层
 
-P0-B 基础已经落地：`ContextBudget`、`ContextProjector`、`ContextReport`、`CompactPolicy`、`CompactResult`、`AgentSession.compact(...)` 和 session snapshot compact state。使用细节见 [Memory Compact Context Projector](/docs/agent/memory/memory-compact-context)。
+P0-B 基础已经落地：`ContextBudget`、`ContextProjector`、`ContextReport`、`CompactPolicy`、`CompactResult`、`AgentSession.compact(...)` 和 session snapshot compact state。使用细节见 [记忆压缩与上下文投影器](/docs/agent/memory/memory-compact-context)。
 
 这一层必须拆清楚三层：
 
@@ -121,7 +120,7 @@ Compact 结果应尽量结构化，不只是自然语言摘要。至少要保留
 
 插件不应该只贡献工具，还应该能参与 Agent 运行生命周期。
 
-P0-C 基础已经落地：`ai4j-extension-api` 增加 `io.github.lnyocly.ai4j.extension.lifecycle` 公共合同，`ai4j-agent` 在 ReAct/Base runtime、CodeAct runtime 和 `AgentSession.compact(...)` 中触发观察型 Hook。使用细节见 [Plugin Lifecycle Hooks](/docs/agent/governance/plugin-lifecycle-hooks)。
+P0-C 基础已经落地：`ai4j-extension-api` 增加 `io.github.lnyocly.ai4j.extension.lifecycle` 公共合同，`ai4j-agent` 在 ReAct/Base runtime、CodeAct runtime 和 `AgentSession.compact(...)` 中触发观察型 Hook。使用细节见 [插件生命周期钩子](/docs/agent/governance/plugin-lifecycle-hooks)。
 
 当前支持：
 
@@ -151,7 +150,7 @@ P0-D 基础已经落地：`ai4j-agent` 增加 `io.github.lnyocly.ai4j.agent.perm
   -> delegate ToolExecutor 或 TOOL_ERROR
 ```
 
-使用细节见 [Agent Approval / Permission Policy](/docs/agent/governance/approval-permission-policy)。
+使用细节见 [Agent 审批与权限策略](/docs/agent/governance/approval-permission-policy)。
 
 边界必须说清楚：
 
@@ -239,7 +238,7 @@ P1 的目标不是做一个完整低代码平台，而是先提供：
 - fixture tests
 - `AgentFactory`：由宿主显式提供 `AgentModelClient` 等依赖后，把 Blueprint 转成 `AgentBuilder` / `Agent`
 
-P1-A/P1-B/P1-C 基础已经落地：`io.github.lnyocly.ai4j.agent.blueprint` 包提供 `AgentBlueprint`、`AgentBlueprintLoader`、`AgentBlueprintValidator`、`AgentBlueprintValidationReport`、`AgentFactory`、`AgentFactoryContext` 和 YAML / Factory deterministic tests；`ai4j-cli` 提供 `ai4j-cli run <agent.yaml> --input <task>`，让用户可以从终端直接运行单 Agent Blueprint。使用细节见 [Agent Blueprint YAML](/docs/agent/agent-blueprint)。
+P1-A/P1-B/P1-C 基础已经落地：`io.github.lnyocly.ai4j.agent.blueprint` 包提供 `AgentBlueprint`、`AgentBlueprintLoader`、`AgentBlueprintValidator`、`AgentBlueprintValidationReport`、`AgentFactory`、`AgentFactoryContext` 和 YAML / Factory deterministic tests；`ai4j-cli` 提供 `ai4j-cli run <agent.yaml> --input <task>`，让用户可以从终端直接运行单 Agent Blueprint。使用细节见 [Agent 蓝图 YAML](/docs/agent/agent-blueprint)。
 
 Team Blueprint、Workflow Blueprint、FlowGram 导出可以后置。
 
@@ -267,7 +266,7 @@ P2-A 已落地最小合同，P2-B 已补上 `AgentSessionSandboxBinding`，让 s
 - `SandboxEvent` / `SandboxEventType`
 - `SandboxStatus`
 
-使用细节见 [Agent Sandbox SPI](/docs/agent/governance/sandbox-spi)。
+使用细节见 [Agent 沙箱 SPI](/docs/agent/governance/sandbox-spi)。
 
 原则：
 

--- a/docs-site/docs/reference/about/strengths-and-differentiators.md
+++ b/docs-site/docs/reference/about/strengths-and-differentiators.md
@@ -1,11 +1,10 @@
 ---
-title: Strengths and Differentiators
+title: 优势与差异点
 description: 从能力统一、边界清晰、provider 非对称、向上演进路径等维度说明 AI4J 作为 Java AI 基座的差异点与适用场景。
 tags: [concept]
 ---
 
-# Strengths and Differentiators
-
+# 优势与差异点
 这一页不列功能，而是回答一个更重要的问题：
 
 > 如果你要向别人解释“AI4J 强在哪”，最值得强调的到底是什么？
@@ -128,7 +127,7 @@ AI4J 的亮点并不只是“功能多”，而是很多长期工程问题已经
 - `DaytonaSandboxProvider`（Daytona）
 - `CubeSandboxProvider`（CubeSandbox）
 
-Agent 需要执行 shell / 文件 / 项目命令时，可以按 spec 选择沙箱后端，而不是绑定到单一平台或自建容器。优势：执行隔离能力可替换、可移植。详见 [Agent Sandbox SPI](/docs/agent/governance/sandbox-spi)。
+Agent 需要执行 shell / 文件 / 项目命令时，可以按 spec 选择沙箱后端，而不是绑定到单一平台或自建容器。优势：执行隔离能力可替换、可移植。详见 [Agent 沙箱 SPI](/docs/agent/governance/sandbox-spi)。
 
 ### 7.3 纯 Java 8、无 Kotlin、单一 JSON 栈
 

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -1,12 +1,11 @@
 ---
-title: API Reference
+title: API 参考
 sidebar_position: 1
 description: Versioned Javadoc entry points for each AI4J Maven module, indexed by capability for Core SDK, Agent, Coding Agent, and extension SPI Java types and signatures.
 tags: [reference]
 ---
 
-# API Reference
-
+# API 参考
 Use the conceptual documentation to choose an integration path, then open the rendered Javadoc for exact Java types and method signatures. The links below point to the published `2.4.2` Javadoc, not the repository's next snapshot.
 
 ## Rendered Javadoc by module
@@ -34,4 +33,4 @@ The guides explain behavior and design boundaries. Javadoc is the source for Jav
 
 The explicit `2.4.2` URLs make the reference reproducible for a released dependency. To browse a module's published versions, remove the version segment from the corresponding `javadoc.io` URL, for example [ai4j versions](https://javadoc.io/doc/io.github.lnyo-cly/ai4j).
 
-The repository currently develops the next `2.4.3-SNAPSHOT`; snapshots are not release API documentation. Use [Version Compatibility](/docs/reference/version-compatibility) before upgrading, and use the [release and artifacts guide](/docs/reference/release-and-artifacts) to align a multi-module build with the BOM.
+The repository currently develops the next `2.4.3-SNAPSHOT`; snapshots are not release API documentation. Use [版本兼容性](/docs/reference/version-compatibility) before upgrading, and use the [release and artifacts guide](/docs/reference/release-and-artifacts) to align a multi-module build with the BOM.

--- a/docs-site/docs/reference/faq.md
+++ b/docs-site/docs/reference/faq.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 998
-title: FAQ
+title: 常见问题
 description: AI4J 文档站常见问题收敛：第一次该看哪里、SDK 与 AI 基座的关系，以及 Chat/Responses、Function Call/Tool、MCP/Agent、Skill/Tool、ACP/MCP 等概念辨析与路径判断。
 tags: [reference]
 ---
 
-# FAQ
-
+# 常见问题
 本页收敛 AI4J 文档站里最常见的“我到底该看哪一页”和“这几个概念到底有什么区别”。
 
 如果你遇到的是某个接口调用失败、参数异常或具体报错，优先看对应专题页里的排障部分；本页更偏“路径判断”和“概念澄清”。
@@ -17,10 +16,10 @@ tags: [reference]
 
 优先顺序：
 
-1. [Why AI4J](/docs/getting-started/why-ai4j)
-2. [Architecture at a Glance](/docs/reference/maps/architecture-at-a-glance)
-3. [Quickstart for Java](/docs/getting-started/quickstart-java)
-4. [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot)
+1. [为什么选 AI4J](/docs/getting-started/why-ai4j)
+2. [架构一览](/docs/reference/maps/architecture-at-a-glance)
+3. [Java 快速开始](/docs/getting-started/quickstart-java)
+4. [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot)
 
 ---
 
@@ -45,8 +44,8 @@ tags: [reference]
 
 如果你要先理解这套基座是怎么分层的，优先看：
 
-- [Why AI4J](/docs/getting-started/why-ai4j)
-- [Architecture at a Glance](/docs/reference/maps/architecture-at-a-glance)
+- [为什么选 AI4J](/docs/getting-started/why-ai4j)
+- [架构一览](/docs/reference/maps/architecture-at-a-glance)
 
 ---
 
@@ -77,7 +76,7 @@ tags: [reference]
 
 对应文档：
 
-- [Chat vs Responses](/docs/capabilities/models/chat-vs-responses)
+- [Chat 与 Responses 对比](/docs/capabilities/models/chat-vs-responses)
 
 ---
 
@@ -92,7 +91,7 @@ tags: [reference]
 
 如果你现在只是想先理解第一条工具链路，优先看：
 
-- [First Tool Call](/docs/getting-started/first-tool-call)
+- [第一次工具调用](/docs/getting-started/first-tool-call)
 - [Core SDK / Tools](/docs/capabilities/tools/overview)
 
 ---

--- a/docs-site/docs/reference/glossary.md
+++ b/docs-site/docs/reference/glossary.md
@@ -27,8 +27,8 @@ tags: [reference]
 
 如果你要先看这套分层从哪里开始，优先看：
 
-- [Why AI4J](/docs/getting-started/why-ai4j)
-- [Architecture at a Glance](/docs/reference/maps/architecture-at-a-glance)
+- [为什么选 AI4J](/docs/getting-started/why-ai4j)
+- [架构一览](/docs/reference/maps/architecture-at-a-glance)
 
 ### ACP
 
@@ -54,7 +54,7 @@ AI4J 的统一服务工厂，用于按 `PlatformType` 获取 `Chat`、`Responses
 
 对应文档：
 
-- [Service Entry and Registry](/docs/capabilities/service-entry)
+- [服务入口与注册表](/docs/capabilities/service-entry)
 
 ---
 
@@ -111,7 +111,7 @@ AI4J 面向本地代码仓交付的一套工程化入口，包含：
 
 对应文档：
 
-- [First Tool Call](/docs/getting-started/first-tool-call)
+- [第一次工具调用](/docs/getting-started/first-tool-call)
 - [Core SDK / Tools / Function Calling](/docs/capabilities/tools/function-calling)
 
 ### FlowGram
@@ -225,7 +225,7 @@ AI4J 中的平台枚举，用于声明你要调用哪家模型平台。
 
 对应文档：
 
-- [Coding Agent Architecture](/docs/products/coding-agent/architecture)
+- [Coding Agent 架构](/docs/products/coding-agent/architecture)
 
 ---
 

--- a/docs-site/docs/reference/maintainers/release-checklist.md
+++ b/docs-site/docs/reference/maintainers/release-checklist.md
@@ -1,12 +1,11 @@
 ---
-title: Release Checklist
+title: 发布检查清单
 sidebar_position: 3
 description: 维护者把 AI4J 发布到 Maven Central 与 GitHub Release 的前后检查清单，覆盖版本策略、本地验证与发布后核对。
 tags: [reference]
 ---
 
-# Release Checklist
-
+# 发布检查清单
 这页是维护者发布 AI4J 到 Maven Central 和 GitHub Release 前后的最小检查清单。
 
 ## 版本策略

--- a/docs-site/docs/reference/maps/architecture-and-module-map.md
+++ b/docs-site/docs/reference/maps/architecture-and-module-map.md
@@ -1,11 +1,10 @@
 ---
-title: Architecture and Module Map
+title: 架构与模块地图
 description: 把 AI4J 仓库的 Maven 模块主线、依赖方向和代码定位入口落到真实工程上，帮助你在读源码或评估模块边界时找到正确落点。
 tags: [concept]
 ---
 
-# Architecture and Module Map
-
+# 架构与模块地图
 这一页把文档里的“分层”直接落到仓库真实模块上。
 
 如果你后面要读源码、做架构说明，或者评估模块边界，这一页应该能帮你回答三个问题：
@@ -196,7 +195,7 @@ ai4j-flowgram-demo          -> ai4j-flowgram-spring-boot-starter
 10. [Coding Agent / Overview](/docs/products/coding-agent/overview)
 11. [Flowgram / Overview](/docs/products/flowgram/overview)
 
-如果你下一步想继续从代码结构往包结构下钻，建议继续看 [Package Map](/docs/reference/maps/package-map)。
+如果你下一步想继续从代码结构往包结构下钻，建议继续看 [包地图](/docs/reference/maps/package-map)。
 
 ## 6. 还要特别注意两类相邻目录
 

--- a/docs-site/docs/reference/maps/architecture-at-a-glance.md
+++ b/docs-site/docs/reference/maps/architecture-at-a-glance.md
@@ -1,11 +1,10 @@
 ---
-title: Architecture at a Glance
+title: 架构一览
 description: 用一张四层图建立 AI4J 的整体心智模型：入门、Core SDK 基座、上层模块（Spring Boot/Agent/Coding Agent/FlowGram）与实战方案，并厘清 Function Call、Skill、MCP 三个最易混淆的概念边界。
 tags: [concept]
 ---
 
-# Architecture at a Glance
-
+# 架构一览
 这一页的目标不是讲细节，而是先帮你建立一个不会乱的总图。
 
 如果你能先把这张图记住，后面读 `Core SDK`、`Agent`、`Coding Agent`、`FlowGram` 时，就不会觉得这些模块只是“堆功能”。
@@ -33,7 +32,7 @@ Solutions
 最重要的一点是：`Core SDK` 才是整套体系的主干，其余模块都是在这层基础上往上长出来的。
 
 :::note 这张图讲的是模块，不是文档目录
-文档侧边栏按**读者意图**组织成八个分区（入门 / 核心能力 / Agent 开发 / 扩展 / 产品 / 集成 / 生产 / 参考），与本页的模块栈不是一一对应——例如 MCP 在代码里横跨多个模块，在文档里是核心能力下的一个子域。模块栈帮你看懂代码结构，八分区帮你找到要读的页。两套地图的关系见 [Documentation Map](/docs/reference/maps/documentation-map)。
+文档侧边栏按**读者意图**组织成八个分区（入门 / 核心能力 / Agent 开发 / 扩展 / 产品 / 集成 / 生产 / 参考），与本页的模块栈不是一一对应——例如 MCP 在代码里横跨多个模块，在文档里是核心能力下的一个子域。模块栈帮你看懂代码结构，八分区帮你找到要读的页。两套地图的关系见 [文档地图](/docs/reference/maps/documentation-map)。
 :::
 
 ## 2. 每一层各自负责什么
@@ -151,6 +150,6 @@ docs-site                   文档站源码
 
 ## 6. 下一步
 
-如果你已经知道自己想做哪类事情，继续看 [Choose Your Path](/docs/getting-started/choose-your-path)。
+如果你已经知道自己想做哪类事情，继续看 [入门路径选择](/docs/getting-started/choose-your-path)。
 
 如果你想先把基座主线吃透，下一页建议直接看 [Core SDK / Overview](/docs/capabilities/overview)。

--- a/docs-site/docs/reference/maps/documentation-map.md
+++ b/docs-site/docs/reference/maps/documentation-map.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 5
-title: Documentation Map
+title: 文档地图
 description: AI4J 文档站的正式阅读地图：八个顶层分区各回答什么问题、每个能力的唯一入口在哪，以及旧链接如何自动跳转。
 tags: [reference]
 ---
 
-# Documentation Map
-
+# 文档地图
 这页定义 AI4J 文档站的正式阅读地图。它的作用不是替代功能页，而是回答两个问题：
 
 - 八个顶层分区各自回答读者的什么问题，我该进哪个。
@@ -56,4 +55,4 @@ tags: [reference]
 
 新增文档必须落在八个分区的既有主题内；不要为单一页面新开顶层目录。
 
-如果你还不知道应该读哪条线，回到 [Choose Your Path](/docs/getting-started/choose-your-path)。
+如果你还不知道应该读哪条线，回到 [入门路径选择](/docs/getting-started/choose-your-path)。

--- a/docs-site/docs/reference/maps/package-map.md
+++ b/docs-site/docs/reference/maps/package-map.md
@@ -1,11 +1,10 @@
 ---
-title: Package Map
+title: 包地图
 description: 用包簇心智模型梳理 ai4j 模块源码分层，指明主能力面与支撑层包的职责，并给出读源码的推荐顺序。
 tags: [concept]
 ---
 
-# Package Map
-
+# 包地图
 这一页讲的是 `ai4j/` 模块的包级心智模型。
 
 它的目标不是列出每一个类，而是先回答三个问题：

--- a/docs-site/docs/reference/migration.md
+++ b/docs-site/docs/reference/migration.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 1
-title: Migration Guide
+title: 迁移指南
 description: AI4J 文档站从旧 getting-started/ai-basics/guides 结构收敛到按模块组织的 canonical 结构。说明迁移规则：不直接删除强内容、先迁稳定结论、加 legacy notice、以 sidebar 为正式阅读路径。
 tags: [reference]
 ---
 
-# Migration Guide
-
+# 迁移指南
 AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结构收敛到按模块和接入路径组织的 canonical 结构。本页说明迁移规则，避免用户把历史页当成新的 source of truth。
 
 ## 迁移原则
@@ -21,11 +20,11 @@ AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结�
 
 | 旧路径 | 新路径 | 状态 |
 | --- | --- | --- |
-| `getting-started/installation` | [Quickstart for Java](/docs/getting-started/quickstart-java) | 迁移中 |
-| `getting-started/quickstart-openai-jdk8` | [Quickstart for Java](/docs/getting-started/quickstart-java) | 迁移中 |
-| `getting-started/quickstart-springboot` | [Quickstart for Spring Boot](/docs/getting-started/quickstart-spring-boot) | 迁移中 |
-| `getting-started/version-compatibility` | [Version Compatibility](/docs/reference/version-compatibility) | 已建立新入口 |
-| `getting-started/modules-and-maven-central` | [Release and Artifacts](/docs/reference/release-and-artifacts) | 已建立新入口 |
+| `getting-started/installation` | [Java 快速开始](/docs/getting-started/quickstart-java) | 迁移中 |
+| `getting-started/quickstart-openai-jdk8` | [Java 快速开始](/docs/getting-started/quickstart-java) | 迁移中 |
+| `getting-started/quickstart-springboot` | [Spring Boot 快速开始](/docs/getting-started/quickstart-spring-boot) | 迁移中 |
+| `getting-started/version-compatibility` | [版本兼容性](/docs/reference/version-compatibility) | 已建立新入口 |
+| `getting-started/modules-and-maven-central` | [发布与制品](/docs/reference/release-and-artifacts) | 已建立新入口 |
 | `ai-basics/chat/*` | [Model Access](/docs/capabilities/models/overview) | 迁移中 |
 | `ai-basics/responses/*` | [Model Access](/docs/capabilities/models/overview) | 迁移中 |
 | `ai-basics/rag/*` | [Search & RAG](/docs/capabilities/rag/overview) | 迁移中 |
@@ -34,7 +33,7 @@ AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结�
 | `core-sdk/mcp/*` | [MCP Overview](/docs/capabilities/mcp/overview) | 顶层 MCP 已为正式主线 |
 | `guides/*` | [Solutions](/docs/integrations/solutions/overview) | 迁移中 |
 | `agent/coding-agent-*` | [Coding Agent](/docs/products/coding-agent/overview) | 已拆分新主线 |
-| `flowgram/builtin-nodes` | [Built-in Nodes](/docs/products/flowgram/built-in-nodes) | 命名收口中 |
+| `flowgram/builtin-nodes` | [内置节点](/docs/products/flowgram/built-in-nodes) | 命名收口中 |
 
 ## API 和使用方式迁移
 
@@ -48,7 +47,7 @@ AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结�
 
 正式入口：
 
-- [Service Entry and Registry](/docs/capabilities/service-entry)
+- [服务入口与注册表](/docs/capabilities/service-entry)
 - [Spring Boot Overview](/docs/integrations/spring-boot/overview)
 
 ### 从旧 Chat / Responses 分散页迁移
@@ -56,7 +55,7 @@ AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结�
 旧页按接口形态拆得比较细，适合查实现细节。新用户应先从：
 
 - [Model Access Overview](/docs/capabilities/models/overview)
-- [Chat vs Responses](/docs/capabilities/models/chat-vs-responses)
+- [Chat 与 Responses 对比](/docs/capabilities/models/chat-vs-responses)
 
 再进入具体 chat、responses、streaming、多模态页面。
 
@@ -77,11 +76,11 @@ AI4J 文档站正在从旧的 `getting-started/`、`ai-basics/`、`guides/` 结�
 
 生产检查、排障、安全、版本和发布说明应进入：
 
-- [Production Checklist](/docs/production/production-checklist)
-- [Troubleshooting](/docs/production/troubleshooting)
-- [Security Overview](/docs/production/security)
-- [Version Compatibility](/docs/reference/version-compatibility)
-- [Release and Artifacts](/docs/reference/release-and-artifacts)
+- [生产检查清单](/docs/production/production-checklist)
+- [排障指南](/docs/production/troubleshooting)
+- [安全总览](/docs/production/security)
+- [版本兼容性](/docs/reference/version-compatibility)
+- [发布与制品](/docs/reference/release-and-artifacts)
 
 ## 新文档写入规则
 

--- a/docs-site/docs/reference/reference-core-classes.md
+++ b/docs-site/docs/reference/reference-core-classes.md
@@ -560,9 +560,9 @@ Agent runtime 的统一事件总线。
 
 ## 15. 继续阅读
 
-1. [Agent Architecture](/docs/agent/architecture)
-2. [Tools and Registry](/docs/agent/tools-and-registry)
-3. [Runtime Implementations](/docs/agent/runtimes/runtime-implementations)
+1. [Agent 架构](/docs/agent/architecture)
+2. [工具与注册表](/docs/agent/tools-and-registry)
+3. [运行时实现](/docs/agent/runtimes/runtime-implementations)
 4. [CodeAct Runtime](/docs/agent/runtimes/codeact-runtime)
 5. [SubAgent 与 Handoff Policy](/docs/agent/orchestration/subagent-handoff-policy)
-6. [Agent Teams](/docs/agent/orchestration/agent-teams)
+6. [Agent 团队](/docs/agent/orchestration/agent-teams)

--- a/docs-site/docs/reference/release-and-artifacts.md
+++ b/docs-site/docs/reference/release-and-artifacts.md
@@ -1,12 +1,11 @@
 ---
-title: Release and Artifacts
+title: 发布与制品
 sidebar_position: 2
 description: AI4J 的发布 artifact、Maven 坐标与 BOM 版本对齐策略，说明各模块角色、依赖引入方式与版本升级顺序。
 tags: [reference]
 ---
 
-# Release and Artifacts
-
+# 发布与制品
 这页说明 AI4J 的发布 artifact、版本对齐和项目引入顺序。它面向使用者和维护者，不替代每个模块的 API 文档。
 
 ## Maven 坐标
@@ -78,7 +77,7 @@ AI4J 当前发布坐标使用：
 
 父 POM 是多模块发布入口，但根 artifact 默认不应被业务项目当成 SDK 使用。项目接入时只引入需要的模块。
 
-发布 profile 会处理 source、javadoc、GPG 签名和 Sonatype Central 发布配置。完整发布步骤见 [Release Checklist](/docs/reference/maintainers/release-checklist)。维护者发布前应确认：
+发布 profile 会处理 source、javadoc、GPG 签名和 Sonatype Central 发布配置。完整发布步骤见 [发布检查清单](/docs/reference/maintainers/release-checklist)。维护者发布前应确认：
 
 - 版本号已在根 POM 和模块 POM 中一致更新。
 - `ai4j-bom` 已包含需要对齐的发布模块。
@@ -128,4 +127,4 @@ Coding Agent 使用者通常还会需要 `ai4j-coding` 或 `ai4j-cli`，具体�
 4. 如果项目使用 Spring Boot starter，检查配置项是否仍能绑定。
 5. 如果项目使用 Coding Agent 或 FlowGram，检查宿主入口和任务 API。
 
-升级完成后，把项目内部的接入说明链接回 [Version Compatibility](/docs/reference/version-compatibility) 和 [Production Checklist](/docs/production/production-checklist)。
+升级完成后，把项目内部的接入说明链接回 [版本兼容性](/docs/reference/version-compatibility) 和 [生产检查清单](/docs/production/production-checklist)。

--- a/docs-site/docs/reference/version-compatibility.md
+++ b/docs-site/docs/reference/version-compatibility.md
@@ -1,12 +1,11 @@
 ---
-title: Version Compatibility
+title: 版本兼容性
 sidebar_position: 1
 description: AI4J 的版本评估与升级前检查：基线、模块兼容矩阵、Java 8 兼容说明、provider 能力差异与升级顺序建议。
 tags: [reference]
 ---
 
-# Version Compatibility
-
+# 版本兼容性
 这页用于版本评估和升级前检查。它不承诺所有 provider 的所有能力完全对称，而是把当前文档站推荐的兼容性边界讲清楚。
 
 ## 基线


### PR DESCRIPTION
## 背景

中文简体站此前 109 页 title 是英文(如 "Agent Overview"、"Documentation Map"),IA 重构把一级分区中文化后,侧边栏"分区中文、叶子英文"的混杂成了最显眼的问题。

## 做了什么

109 页逐页由 agent 按正文实际内容提译名(不机械替换),规则与分区 label 同一套词表:

- **专名/协议/产品/通用缩写保留**:AI4J、MCP、A2A、RAG、SPI、Agent、API、Spring Boot、Coding Agent、FlowGram、Streamable HTTP……
- **中心词中文**:Overview→总览、Architecture→架构、Quickstart→快速开始、Cookbook→实战指南、Reference→参考……
- **title 与 H1 成对**替换
- **418 条**引用旧英文标题的站内链接文本同步(`[Agent Overview](/docs/agent/overview)` → `[Agent 总览](...)`)

结果:108 页落地;1 页有意保留("CubeSandbox Provider"——正文通篇以 provider 指代代码角色,站内既有中文标题同此约定)。

## 验证

- 双 locale build SUCCESS,零坏链零坏锚
- zh 侧边栏现存英文 title 仅剩 1 个(上述有意保留)
- EN locale 不受影响(title 在独立文件中)

## 关联

分区 label 策略(专名保留原文)由用户确认;"API 与版本""Agent 开发"等含通用缩写的中文标签为标准形态,保持不变。
