### PR TITLE
fix(#262): 宿主控制流异常通道 + 宿主输入一等语义

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentControlFlowException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentControlFlowException.java
@@ -1,0 +1,21 @@
+package io.github.lnyocly.ai4j.agent.control;
+
+/**
+ * 控制流异常基类（#262）：宿主介入（审批 / 用户输入等）需要中断 agent 循环并
+ * 原样抛给调用方，禁止被 {@code BaseAgentRuntime#executeTool} 降级为 TOOL_ERROR
+ * 喂回模型（那会让模型"看到工具失败"后自行继续，破坏宿主暂停语义）。
+ *
+ * <p>受检异常：宿主调用方必须显式处理。已知子类：
+ * {@code AgentApprovalRequiredException}（宿主审批暂停；deny 反馈仍走 TOOL_ERROR 让模型自适应）与
+ * {@link AgentHostInputException}（宿主用户输入）。
+ */
+public class AgentControlFlowException extends Exception {
+
+    public AgentControlFlowException(String message) {
+        super(message);
+    }
+
+    public AgentControlFlowException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentHostInputChannel.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentHostInputChannel.java
@@ -1,0 +1,29 @@
+package io.github.lnyocly.ai4j.agent.control;
+
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+
+import java.util.Map;
+
+/**
+ * 阻塞式宿主输入通道（#262，Claude Code AskUserQuestion 语义）：工具执行阻塞等待
+ * 宿主收集用户答案，{@link #awaitUserInput} 的返回值即工具结果，模型在同一回合内
+ * 拿到真实答案继续。
+ *
+ * <p>实现方约定：
+ * <ul>
+ *   <li>阻塞直至答案就绪；返回值即工具输出（建议为可读文本）；</li>
+ *   <li>超时抛 {@link java.util.concurrent.TimeoutException} →
+ *       {@link HostInputToolExecutor} 转为可读工具结果（模型可自行处理）；</li>
+ *   <li>取消/中断抛 {@link InterruptedException} → 中断整个 run；</li>
+ *   <li>其余异常原样抛出；{@link AgentControlFlowException} 会按控制流穿透。</li>
+ * </ul>
+ */
+public interface AgentHostInputChannel {
+
+    /**
+     * @param call    触发输入的宿主工具调用（含 callId，宿主可用作问卷关联键）
+     * @param request 工具参数解析出的结构化问卷请求
+     * @return 用户答案（即工具结果）
+     */
+    String awaitUserInput(AgentToolCall call, Map<String, Object> request) throws Exception;
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentHostInputException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/AgentHostInputException.java
@@ -1,0 +1,32 @@
+package io.github.lnyocly.ai4j.agent.control;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * 宿主用户输入请求（#262）：工具抛出本异常中断 agent 循环，宿主捕获后渲染问卷、
+ * 收集答案，再以新输入恢复回合——适合"暂停-恢复新回合"型宿主。
+ *
+ * <p>需要"工具结果 = 用户答案"的阻塞式语义（Claude Code AskUserQuestion 同构），
+ * 用 {@link HostInputToolExecutor} + {@link AgentHostInputChannel}。
+ */
+public class AgentHostInputException extends AgentControlFlowException {
+
+    private final Map<String, Object> request;
+
+    public AgentHostInputException(String message, Map<String, Object> request) {
+        super(message);
+        this.request = request == null ? Collections.emptyMap() : request;
+    }
+
+    /** 宿主工具的原生异常作为 cause 携带，宿主边界可无损还原。 */
+    public AgentHostInputException(String message, Map<String, Object> request, Throwable cause) {
+        super(message, cause);
+        this.request = request == null ? Collections.emptyMap() : request;
+    }
+
+    /** 结构化问卷请求（questions/choices/multiple 等，由宿主工具定义）。 */
+    public Map<String, Object> getRequest() {
+        return request;
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/HostInputToolExecutor.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/control/HostInputToolExecutor.java
@@ -1,0 +1,56 @@
+package io.github.lnyocly.ai4j.agent.control;
+
+import com.alibaba.fastjson2.JSON;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * 宿主输入型工具执行器（#262）：名单内工具阻塞等待 {@link AgentHostInputChannel}
+ * 回填用户答案并作为工具结果返回；名单外工具委托原执行器。
+ *
+ * <p>组装示例：{@code builder.toolExecutor(new HostInputToolExecutor(baseExecutor,
+ * channel, Set.of("ask_user")))}。
+ */
+public class HostInputToolExecutor implements ToolExecutor {
+
+    private final ToolExecutor delegate;
+    private final AgentHostInputChannel channel;
+    private final Set<String> hostInputTools;
+
+    public HostInputToolExecutor(ToolExecutor delegate, AgentHostInputChannel channel, Set<String> hostInputTools) {
+        this.delegate = delegate;
+        this.channel = channel;
+        this.hostInputTools = hostInputTools == null ? Collections.emptySet() : hostInputTools;
+    }
+
+    @Override
+    public String execute(AgentToolCall call) throws Exception {
+        if (call == null || call.getName() == null || !hostInputTools.contains(call.getName())) {
+            return delegate.execute(call);
+        }
+        try {
+            return channel.awaitUserInput(call, parseRequest(call.getArguments()));
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            throw interruptedException;
+        } catch (TimeoutException timeoutException) {
+            // 可读工具结果（非 TOOL_ERROR）：模型能理解"用户未作答"并自行决定下一步。
+            return "HOST_INPUT_TIMEOUT: " + (timeoutException.getMessage() == null
+                    ? "user did not answer in time" : timeoutException.getMessage());
+        }
+    }
+
+    private static Map<String, Object> parseRequest(String arguments) {
+        if (arguments == null || arguments.trim().isEmpty()) return Collections.emptyMap();
+        try {
+            return JSON.parseObject(arguments);
+        } catch (Exception exception) {
+            return Collections.singletonMap("question", arguments);
+        }
+    }
+}

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/permission/AgentApprovalRequiredException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/permission/AgentApprovalRequiredException.java
@@ -1,11 +1,29 @@
 package io.github.lnyocly.ai4j.agent.permission;
 
+import io.github.lnyocly.ai4j.agent.control.AgentControlFlowException;
+
 /**
  * Raised when a policy requires human or host approval before a tool can run.
+ * Extends {@link AgentControlFlowException} (#262) so it interrupts the agent loop and
+ * propagates out of run/runStreamResult to the host — instead of degrading into a
+ * TOOL_ERROR the model shrugs off before continuing on its own.
  */
-public class AgentApprovalRequiredException extends AgentPermissionException {
+public class AgentApprovalRequiredException extends AgentControlFlowException {
+
+    private final AgentPermissionRequest request;
+    private final AgentPermissionDecision decision;
 
     public AgentApprovalRequiredException(String message, AgentPermissionRequest request, AgentPermissionDecision decision) {
-        super(message, request, decision);
+        super(message);
+        this.request = request;
+        this.decision = decision;
+    }
+
+    public AgentPermissionRequest getRequest() {
+        return request;
+    }
+
+    public AgentPermissionDecision getDecision() {
+        return decision;
     }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/permission/AgentPermissionException.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/permission/AgentPermissionException.java
@@ -1,7 +1,10 @@
 package io.github.lnyocly.ai4j.agent.permission;
 
 /**
- * Base exception raised when a tool execution is blocked by an agent permission policy.
+ * Base exception raised when a tool execution is blocked by an agent permission policy
+ * (deny path). Deliberately NOT a control-flow exception (#262): deny is per-tool veto
+ * feedback, the runtime degrades it to TOOL_ERROR so the model can adapt and retry.
+ * Host-approval pause is {@link AgentApprovalRequiredException}.
  */
 public class AgentPermissionException extends Exception {
 

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -30,6 +30,7 @@ import io.github.lnyocly.ai4j.agent.sandbox.SandboxSession;
 import io.github.lnyocly.ai4j.agent.sandbox.SandboxResult;
 import io.github.lnyocly.ai4j.agent.skill.AgentSkillRuntimeSupport;
 import io.github.lnyocly.ai4j.agent.compact.CompactPolicy;
+import io.github.lnyocly.ai4j.agent.control.AgentControlFlowException;
 import io.github.lnyocly.ai4j.agent.compact.CompactResult;
 import io.github.lnyocly.ai4j.agent.interceptor.ModelRequestHook;
 import io.github.lnyocly.ai4j.agent.memory.MemorySnapshot;
@@ -557,6 +558,9 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
             throw interruptedException;
         } catch (HandoffPolicyException handoffPolicyException) {
             throw handoffPolicyException;
+        } catch (AgentControlFlowException controlFlowException) {
+            // #262: 宿主介入（审批/用户输入）必须中断循环并抛给调用方，禁止降级为 TOOL_ERROR。
+            throw controlFlowException;
         } catch (Exception ex) {
             return buildToolErrorOutput(callToRun, ex);
         } finally {

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -232,9 +232,21 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
             }
 
             boolean parallelExecution = Boolean.TRUE.equals(context.getParallelToolCalls()) && validatedCalls.size() > 1;
-            List<AgentToolResult> executed = parallelExecution
-                    ? executeToolCallsInParallel(context, validatedCalls, step, listener, runId, sessionId, turnId)
-                    : executeToolCallsSequential(context, validatedCalls, step, listener, runId, sessionId, turnId);
+            List<AgentToolResult> executed;
+            try {
+                executed = parallelExecution
+                        ? executeToolCallsInParallel(context, validatedCalls, step, listener, runId, sessionId, turnId)
+                        : executeToolCallsSequential(context, validatedCalls, step, listener, runId, sessionId, turnId);
+            } catch (AgentControlFlowException controlFlow) {
+                // #262: 宿主介入中断——已进历史的 tool_use 必须有配对 tool_result，
+                // 否则 anthropic_messages 等协议在恢复回合时按 invalid params 400 拒绝。
+                for (AgentToolCall unmatchedCall : validatedCalls) {
+                    memory.addToolOutput(unmatchedCall.getCallId(),
+                            "HOST_INPUT_REQUIRED: tool execution interrupted for host mediation; "
+                                    + "the conversation continues with a follow-up host/user message.");
+                }
+                throw controlFlow;
+            }
             throwIfInterrupted();
 
             for (int i = 0; i < validatedCalls.size(); i++) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentApprovalPermissionPolicyTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentApprovalPermissionPolicyTest.java
@@ -145,14 +145,14 @@ public class AgentApprovalPermissionPolicyTest {
                 .options(AgentOptions.builder().maxSteps(4).build())
                 .build();
 
-        AgentResult result = agent.run(AgentRequest.builder().input("hi").build());
-
-        Assert.assertEquals("done", result.getOutputText());
+        // #262: approval-required 是控制流——中断 run 并抛给宿主，不再降级 TOOL_ERROR 让模型继续。
+        try {
+            agent.run(AgentRequest.builder().input("hi").build());
+            Assert.fail("expected AgentApprovalRequiredException");
+        } catch (AgentApprovalRequiredException expected) {
+            Assert.assertEquals("write_file", expected.getRequest().getToolName());
+        }
         Assert.assertEquals("write_file must be blocked by default SAFE policy", 0, delegate.count);
-        Assert.assertEquals(1, result.getToolResults().size());
-        Assert.assertTrue("must mention approval requirement",
-                result.getToolResults().get(0).getOutput().contains("approval")
-                        || result.getToolResults().get(0).getOutput().contains("Approval"));
     }
 
     @Test
@@ -169,9 +169,13 @@ public class AgentApprovalPermissionPolicyTest {
                 .options(AgentOptions.builder().maxSteps(4).build())
                 .build();
 
-        AgentResult result = agent.run(AgentRequest.builder().input("hi").build());
-
-        Assert.assertEquals("done", result.getOutputText());
+        // #262: 同上，SAFE 策略下的审批需求以控制流异常抛出。
+        try {
+            agent.run(AgentRequest.builder().input("hi").build());
+            Assert.fail("expected AgentApprovalRequiredException");
+        } catch (AgentApprovalRequiredException expected) {
+            Assert.assertEquals("bash", expected.getRequest().getToolName());
+        }
         Assert.assertEquals("bash must be blocked by default SAFE policy", 0, delegate.count);
     }
 

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
@@ -86,6 +86,34 @@ public class AgentControlFlowExceptionTest {
     }
 
     @Test
+    public void interruptedToolCallLeavesPairedToolResultInMemory() throws Exception {
+        // #262: 宿主中断后历史必须保留配对 tool_result，否则 anthropic_messages 恢复回合 400。
+        InMemoryAgentMemory memory = new InMemoryAgentMemory();
+        ToolExecutor askUser = call -> {
+            throw new AgentHostInputException("ask_user", Map.of("question", "画幅？"));
+        };
+        AgentContext context = AgentContext.builder()
+                .modelClient(new AskThenFallbackModelClient())
+                .toolExecutor(askUser)
+                .memory(memory)
+                .options(AgentOptions.builder().maxSteps(4).build())
+                .model("test-model")
+                .build();
+
+        try {
+            new ReActRuntime().run(context, AgentRequest.builder().input("hi").build());
+            Assert.fail("expected AgentHostInputException");
+        } catch (AgentHostInputException expected) {
+            // ignore
+        }
+        String items = String.valueOf(memory.getItems());
+        Assert.assertTrue("memory must contain the synthetic tool_result",
+                items.contains("HOST_INPUT_REQUIRED"));
+        Assert.assertTrue("memory must reference the interrupted callId",
+                items.contains("call_1"));
+    }
+
+    @Test
     public void approvalExceptionPropagatesAndStopsLoop() throws Exception {
         AskThenFallbackModelClient modelClient = new AskThenFallbackModelClient();
         ToolExecutor approval = call -> {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -72,7 +71,7 @@ public class AgentControlFlowExceptionTest {
     public void hostInputExceptionPropagatesAndStopsLoop() throws Exception {
         AskThenFallbackModelClient modelClient = new AskThenFallbackModelClient();
         ToolExecutor askUser = call -> {
-            throw new AgentHostInputException("ask_user", Map.of("question", "画幅？"));
+            throw new AgentHostInputException("ask_user", Collections.singletonMap("question", "画幅？"));
         };
 
         try {
@@ -90,7 +89,7 @@ public class AgentControlFlowExceptionTest {
         // #262: 宿主中断后历史必须保留配对 tool_result，否则 anthropic_messages 恢复回合 400。
         InMemoryAgentMemory memory = new InMemoryAgentMemory();
         ToolExecutor askUser = call -> {
-            throw new AgentHostInputException("ask_user", Map.of("question", "画幅？"));
+            throw new AgentHostInputException("ask_user", Collections.singletonMap("question", "画幅？"));
         };
         AgentContext context = AgentContext.builder()
                 .modelClient(new AskThenFallbackModelClient())
@@ -162,7 +161,7 @@ public class AgentControlFlowExceptionTest {
             return "9:16 竖屏";
         };
         HostInputToolExecutor executor = new HostInputToolExecutor(
-                call -> "delegated", channel, Set.of("ask_user"));
+                call -> "delegated", channel, Collections.singleton("ask_user"));
 
         AgentResult result = new ReActRuntime().run(
                 contextWith(client, executor), AgentRequest.builder().input("hi").build());
@@ -178,7 +177,7 @@ public class AgentControlFlowExceptionTest {
             throw new TimeoutException("10 分钟未作答");
         };
         HostInputToolExecutor executor = new HostInputToolExecutor(
-                call -> "delegated", timeoutChannel, Set.of("ask_user"));
+                call -> "delegated", timeoutChannel, Collections.singleton("ask_user"));
         AgentToolCall call = AgentToolCall.builder()
                 .callId("call_1").name("ask_user").arguments("{}").type("function").build();
 
@@ -189,7 +188,7 @@ public class AgentControlFlowExceptionTest {
     public void nonHostToolsDelegateUntouched() throws Exception {
         AgentHostInputChannel channel = (call, request) -> "should not be used";
         HostInputToolExecutor executor = new HostInputToolExecutor(
-                call -> "delegated", channel, Set.of("ask_user"));
+                call -> "delegated", channel, Collections.singleton("ask_user"));
         AgentToolCall other = AgentToolCall.builder()
                 .callId("call_2").name("read_file").arguments("{}").type("function").build();
 

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentControlFlowExceptionTest.java
@@ -1,0 +1,170 @@
+package io.github.lnyocly.agent;
+
+import io.github.lnyocly.ai4j.agent.AgentContext;
+import io.github.lnyocly.ai4j.agent.AgentOptions;
+import io.github.lnyocly.ai4j.agent.AgentRequest;
+import io.github.lnyocly.ai4j.agent.AgentResult;
+import io.github.lnyocly.ai4j.agent.control.AgentHostInputChannel;
+import io.github.lnyocly.ai4j.agent.control.AgentHostInputException;
+import io.github.lnyocly.ai4j.agent.control.HostInputToolExecutor;
+import io.github.lnyocly.ai4j.agent.memory.InMemoryAgentMemory;
+import io.github.lnyocly.ai4j.agent.model.AgentModelClient;
+import io.github.lnyocly.ai4j.agent.model.AgentModelResult;
+import io.github.lnyocly.ai4j.agent.model.AgentModelStreamListener;
+import io.github.lnyocly.ai4j.agent.model.AgentPrompt;
+import io.github.lnyocly.ai4j.agent.permission.AgentApprovalRequiredException;
+import io.github.lnyocly.ai4j.agent.permission.AgentExecutionEnvironment;
+import io.github.lnyocly.ai4j.agent.permission.AgentPermissionDecision;
+import io.github.lnyocly.ai4j.agent.permission.AgentPermissionRequest;
+import io.github.lnyocly.ai4j.agent.runtime.ReActRuntime;
+import io.github.lnyocly.ai4j.agent.tool.AgentToolCall;
+import io.github.lnyocly.ai4j.agent.tool.ToolExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * #262：宿主审批/输入类控制流异常必须中断循环并从 run 抛出（禁止降级 TOOL_ERROR）；
+ * HostInputToolExecutor 的阻塞通道语义（工具结果 = 用户答案）。
+ */
+public class AgentControlFlowExceptionTest {
+
+    /** 第 1 次返回 ask_user 工具调用，之后返回 fallback 文本（若被调到即证明异常被吞）。 */
+    private static final class AskThenFallbackModelClient implements AgentModelClient {
+        final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public AgentModelResult create(AgentPrompt prompt) {
+            if (invocations.incrementAndGet() == 1) {
+                return AgentModelResult.builder()
+                        .outputText("I will ask the user.")
+                        .toolCalls(Arrays.asList(AgentToolCall.builder()
+                                .callId("call_1").name("ask_user").arguments("{}").type("function").build()))
+                        .memoryItems(new ArrayList<>())
+                        .build();
+            }
+            return AgentModelResult.builder().outputText("fallback after tool").memoryItems(new ArrayList<>()).build();
+        }
+
+        @Override
+        public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+            return create(prompt);
+        }
+    }
+
+    private static AgentContext contextWith(AgentModelClient modelClient, ToolExecutor executor) {
+        return AgentContext.builder()
+                .modelClient(modelClient)
+                .toolExecutor(executor)
+                .memory(new InMemoryAgentMemory())
+                .options(AgentOptions.builder().maxSteps(4).build())
+                .model("test-model")
+                .build();
+    }
+
+    @Test
+    public void hostInputExceptionPropagatesAndStopsLoop() throws Exception {
+        AskThenFallbackModelClient modelClient = new AskThenFallbackModelClient();
+        ToolExecutor askUser = call -> {
+            throw new AgentHostInputException("ask_user", Map.of("question", "画幅？"));
+        };
+
+        try {
+            new ReActRuntime().run(contextWith(modelClient, askUser), AgentRequest.builder().input("hi").build());
+            Assert.fail("expected AgentHostInputException to propagate");
+        } catch (AgentHostInputException expected) {
+            Assert.assertEquals("画幅？", expected.getRequest().get("question"));
+        }
+        // 循环在工具处中断：模型没有被再次调用，也就没有 fallback 生成。
+        Assert.assertEquals(1, modelClient.invocations.get());
+    }
+
+    @Test
+    public void approvalExceptionPropagatesAndStopsLoop() throws Exception {
+        AskThenFallbackModelClient modelClient = new AskThenFallbackModelClient();
+        ToolExecutor approval = call -> {
+            AgentPermissionRequest request = AgentPermissionRequest.builder()
+                    .toolCall(call)
+                    .environment(AgentExecutionEnvironment.LOCAL)
+                    .build();
+            throw new AgentApprovalRequiredException("needs approval", request,
+                    AgentPermissionDecision.requireApproval("confirm canvas writes"));
+        };
+
+        try {
+            new ReActRuntime().run(contextWith(modelClient, approval), AgentRequest.builder().input("hi").build());
+            Assert.fail("expected AgentApprovalRequiredException to propagate");
+        } catch (AgentApprovalRequiredException expected) {
+            Assert.assertEquals("confirm canvas writes", expected.getDecision().getReason());
+        }
+        Assert.assertEquals(1, modelClient.invocations.get());
+    }
+
+    @Test
+    public void hostInputChannelAnswerBecomesToolResultAndLoopContinues() throws Exception {
+        final AtomicInteger calls = new AtomicInteger();
+        AgentModelClient client = new AgentModelClient() {
+            @Override
+            public AgentModelResult create(AgentPrompt prompt) {
+                if (calls.incrementAndGet() == 1) {
+                    return AgentModelResult.builder()
+                            .outputText("I will ask the user.")
+                            .toolCalls(Arrays.asList(AgentToolCall.builder()
+                                    .callId("call_1").name("ask_user")
+                                    .arguments("{\"question\":\"画幅？\"}").type("function").build()))
+                            .memoryItems(new ArrayList<>())
+                            .build();
+                }
+                return AgentModelResult.builder().outputText("done with the answer").memoryItems(new ArrayList<>()).build();
+            }
+
+            @Override
+            public AgentModelResult createStream(AgentPrompt prompt, AgentModelStreamListener listener) {
+                return create(prompt);
+            }
+        };
+        AgentHostInputChannel channel = (call, request) -> {
+            Assert.assertEquals("画幅？", request.get("question"));
+            return "9:16 竖屏";
+        };
+        HostInputToolExecutor executor = new HostInputToolExecutor(
+                call -> "delegated", channel, Set.of("ask_user"));
+
+        AgentResult result = new ReActRuntime().run(
+                contextWith(client, executor), AgentRequest.builder().input("hi").build());
+
+        Assert.assertEquals("done with the answer", result.getOutputText());
+        // 第二次模型调用发生 = 工具结果（用户答案）被接受、循环正常继续。
+        Assert.assertEquals(2, calls.get());
+    }
+
+    @Test
+    public void hostInputTimeoutBecomesReadableToolResult() throws Exception {
+        AgentHostInputChannel timeoutChannel = (call, request) -> {
+            throw new TimeoutException("10 分钟未作答");
+        };
+        HostInputToolExecutor executor = new HostInputToolExecutor(
+                call -> "delegated", timeoutChannel, Set.of("ask_user"));
+        AgentToolCall call = AgentToolCall.builder()
+                .callId("call_1").name("ask_user").arguments("{}").type("function").build();
+
+        Assert.assertEquals("HOST_INPUT_TIMEOUT: 10 分钟未作答", executor.execute(call));
+    }
+
+    @Test
+    public void nonHostToolsDelegateUntouched() throws Exception {
+        AgentHostInputChannel channel = (call, request) -> "should not be used";
+        HostInputToolExecutor executor = new HostInputToolExecutor(
+                call -> "delegated", channel, Set.of("ask_user"));
+        AgentToolCall other = AgentToolCall.builder()
+                .callId("call_2").name("read_file").arguments("{}").type("function").build();
+
+        Assert.assertEquals("delegated", executor.execute(other));
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `AgentControlFlowException` 受检通道；`executeTool` 白名单放行，避免宿主审批/输入被吞成 TOOL_ERROR
- `AgentHostInputException` + `HostInputToolExecutor`/`AgentHostInputChannel`：问卷暂停-恢复与阻塞式回填
- 宿主介入中断时为未配对 `tool_use` 补合成 `tool_result`，避免 Anthropic 侧 tool_use/tool_result 不成对

Closes #262

## Test plan
- [x] `AgentControlFlowExceptionTest`：HostInput / Approval 穿透、无 TOOL_ERROR
- [x] `HostInputToolExecutor` 回填答案 / 超时
- [ ] CI green on this PR