### PR TITLE
fix(#264): AgentTrace 中途失败标 ERROR

### DIFF
--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/runtime/BaseAgentRuntime.java
@@ -225,6 +225,8 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
                         .name(call.getName())
                         .callId(call.getCallId())
                         .output(output)
+                        .ok(Boolean.FALSE)
+                        .error(validationError)
                         .build();
                 toolResults.add(toolResult);
                 memory.addToolOutput(call.getCallId(), output);
@@ -720,12 +722,16 @@ public abstract class BaseAgentRuntime implements io.github.lnyocly.ai4j.agent.A
                                                    String turnId) throws Exception {
         String output = executeTool(context, call, step, listener, runId, sessionId, turnId);
         Object trace = toolTrace(context);
-        return AgentToolResult.builder()
+        AgentToolResult.AgentToolResultBuilder builder = AgentToolResult.builder()
                 .name(call.getName())
                 .callId(call.getCallId())
                 .output(output)
-                .trace(trace)
-                .build();
+                .trace(trace);
+        // #264: 运行时 TOOL_ERROR 输出带上 ok=false，供 AgentTraceListener 标 ERROR
+        if (output != null && output.startsWith("TOOL_ERROR")) {
+            builder.ok(Boolean.FALSE).error(output);
+        }
+        return builder.build();
     }
 
     /** Returns the executor's last sub-trace (if it is a TraceableToolExecutor), else null. */

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/tool/AgentToolResult.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/tool/AgentToolResult.java
@@ -23,4 +23,27 @@ public class AgentToolResult {
      * trace 里可见。默认 null（普通 tool 不带）。LLM 只看 {@link #output}，不受影响。
      */
     private Object trace;
+
+    /**
+     * 显式成功/失败（#264）。{@code null} = 兼容旧调用方，按 {@link #output} 启发式判断；
+     * {@code Boolean.FALSE} = 失败；{@code Boolean.TRUE} = 成功。
+     */
+    private Boolean ok;
+
+    /** 失败原因（给人/trace 看）；LLM 仍主要读 {@link #output}。 */
+    private String error;
+
+    /**
+     * 是否应记为 TOOL span ERROR。
+     * <p>规则：{@code ok == false}，或 {@code error} 非空，或 {@code output} 以 {@code TOOL_ERROR} 开头。
+     */
+    public boolean isFailed() {
+        if (Boolean.FALSE.equals(ok)) {
+            return true;
+        }
+        if (error != null && !error.trim().isEmpty()) {
+            return true;
+        }
+        return output != null && output.startsWith("TOOL_ERROR");
+    }
 }

--- a/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/trace/AgentTraceListener.java
+++ b/ai4j-agent/src/main/java/io/github/lnyocly/ai4j/agent/trace/AgentTraceListener.java
@@ -273,11 +273,23 @@ public class AgentTraceListener implements AgentListener {
             }
         } else if (payload instanceof AgentToolResult) {
             AgentToolResult result = (AgentToolResult) payload;
+            if (result.isFailed()) {
+                status = TraceSpanStatus.ERROR;
+                error = firstNonBlank(result.getError(), result.getOutput(), event.getMessage());
+            }
             if (config.isRecordToolOutput()) {
                 putAttribute(span, "output", safeValue(result.getOutput()));
+                if (result.getError() != null) {
+                    putAttribute(span, "error", safeValue(result.getError()));
+                }
             }
         } else if (config.isRecordToolOutput()) {
             putAttribute(span, "output", safeValue(event.getMessage()));
+            // 启发式：事件 message 以 TOOL_ERROR 开头时也标失败
+            if (event.getMessage() != null && event.getMessage().startsWith("TOOL_ERROR")) {
+                status = TraceSpanStatus.ERROR;
+                error = event.getMessage();
+            }
         }
         finishSpan(span, status, error);
     }
@@ -287,6 +299,7 @@ public class AgentTraceListener implements AgentListener {
             putAttribute(rootSpan, "finalOutput", safeValue(event.getMessage()));
         }
         mergeAttributes(rootSpan, attributesFromEvent(event));
+        // #264: root 已 ERROR 时不降级为 OK（例如 ERROR 后再收到收尾事件）
         finishSpan(rootSpan, TraceSpanStatus.OK, null);
     }
 
@@ -868,9 +881,22 @@ public class AgentTraceListener implements AgentListener {
         if (span == null) {
             return;
         }
+        // #264: 已结束的 span 不重复导出；ERROR 不被后续 OK 覆盖，OK 可被 ERROR 升级（极少见）
+        if (span.getEndTime() > 0) {
+            if (span.getStatus() == TraceSpanStatus.ERROR) {
+                return;
+            }
+            if (status != TraceSpanStatus.ERROR) {
+                return;
+            }
+        }
         span.setStatus(status == null ? TraceSpanStatus.OK : status);
         span.setEndTime(System.currentTimeMillis());
-        span.setError(error);
+        if (error != null) {
+            span.setError(error);
+        } else if (status != TraceSpanStatus.ERROR) {
+            span.setError(null);
+        }
         if (config.isRecordMetrics()) {
             TraceMetrics metrics = span.getMetrics();
             if (metrics == null) {

--- a/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentTraceListenerTest.java
+++ b/ai4j-agent/src/test/java/io/github/lnyocly/agent/AgentTraceListenerTest.java
@@ -244,6 +244,76 @@ public class AgentTraceListenerTest {
         Assert.assertNull(runSpan.getMetrics().getCurrency());
     }
 
+    @Test
+    public void test_tool_result_ok_false_marks_error_span() {
+        // #264
+        InMemoryTraceExporter exporter = new InMemoryTraceExporter();
+        AgentTraceListener listener = new AgentTraceListener(exporter);
+
+        listener.onEvent(event(AgentEventType.STEP_START, 0, null, null));
+        AgentToolCall call = AgentToolCall.builder().name("broken").callId("tool_err").arguments("{}").build();
+        listener.onEvent(event(AgentEventType.TOOL_CALL, 0, call.getName(), call));
+        listener.onEvent(event(AgentEventType.TOOL_RESULT, 0, "TOOL_ERROR: boom", AgentToolResult.builder()
+                .name("broken")
+                .callId("tool_err")
+                .output("TOOL_ERROR: boom")
+                .ok(Boolean.FALSE)
+                .error("boom")
+                .build()));
+        listener.onEvent(event(AgentEventType.FINAL_OUTPUT, 0, "done", null));
+        listener.onEvent(event(AgentEventType.STEP_END, 0, null, null));
+
+        TraceSpan tool = findSpan(exporter.getSpans(), TraceSpanType.TOOL);
+        Assert.assertNotNull(tool);
+        Assert.assertEquals(TraceSpanStatus.ERROR, tool.getStatus());
+        Assert.assertEquals("boom", tool.getError());
+    }
+
+    @Test
+    public void test_tool_error_output_prefix_marks_error_without_ok_flag() {
+        // #264 兼容：只填 output=TOOL_ERROR... 也算失败
+        InMemoryTraceExporter exporter = new InMemoryTraceExporter();
+        AgentTraceListener listener = new AgentTraceListener(exporter);
+
+        listener.onEvent(event(AgentEventType.STEP_START, 0, null, null));
+        AgentToolCall call = AgentToolCall.builder().name("broken").callId("tool_err2").arguments("{}").build();
+        listener.onEvent(event(AgentEventType.TOOL_CALL, 0, call.getName(), call));
+        listener.onEvent(event(AgentEventType.TOOL_RESULT, 0, "TOOL_ERROR: {\"error\":\"x\"}", AgentToolResult.builder()
+                .name("broken")
+                .callId("tool_err2")
+                .output("TOOL_ERROR: {\"error\":\"x\"}")
+                .build()));
+
+        TraceSpan tool = findSpan(exporter.getSpans(), TraceSpanType.TOOL);
+        Assert.assertNotNull(tool);
+        Assert.assertEquals(TraceSpanStatus.ERROR, tool.getStatus());
+        Assert.assertTrue(tool.getError().startsWith("TOOL_ERROR"));
+    }
+
+    @Test
+    public void test_error_event_root_not_downgraded_by_final_output() {
+        // #264
+        InMemoryTraceExporter exporter = new InMemoryTraceExporter();
+        AgentTraceListener listener = new AgentTraceListener(exporter);
+
+        listener.onEvent(event(AgentEventType.STEP_START, 0, null, null));
+        listener.onEvent(event(AgentEventType.ERROR, 0, "LLM exploded", null));
+        // 若实现错误地再 finish OK，exporter 会多一条或 status 被盖掉
+        listener.onEvent(event(AgentEventType.FINAL_OUTPUT, 0, "should not clear error", null));
+
+        TraceSpan run = findSpan(exporter.getSpans(), TraceSpanType.RUN);
+        Assert.assertNotNull(run);
+        Assert.assertEquals(TraceSpanStatus.ERROR, run.getStatus());
+        Assert.assertEquals("LLM exploded", run.getError());
+        int runExports = 0;
+        for (TraceSpan span : exporter.getSpans()) {
+            if (span.getType() == TraceSpanType.RUN) {
+                runExports++;
+            }
+        }
+        Assert.assertEquals(1, runExports);
+    }
+
     private TraceSpan findSpan(List<TraceSpan> spans, TraceSpanType type) {
         for (TraceSpan span : spans) {
             if (span != null && span.getType() == type) {


### PR DESCRIPTION
## Summary
- `AgentToolResult` 增加可选 `ok`/`error` + `isFailed()`（兼容旧只填 output）
- 运行时 `TOOL_ERROR` 输出自动 `ok=false`
- `AgentTraceListener`：工具失败 → TOOL span ERROR；已 ERROR 的 span 不被后续 OK/`FINAL_OUTPUT` 覆盖

Closes #264

## Test plan
- [x] `AgentTraceListenerTest` 新增 3 例（ok=false / TOOL_ERROR 前缀 / ERROR 不被 FINAL 降级）
- [x] 既有 `AgentTraceListenerTest` + `AgentControlFlowExceptionTest` 全绿
- [ ] CI green