### PR TITLE
feat(video): 视频创建统一 JSON + create/retrieve 路径分离 + Grok 方言

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OpenAiConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OpenAiConfig.java
@@ -24,6 +24,11 @@ public class OpenAiConfig {
     private String imageGenerationUrl = "v1/images/generations";
     private String responsesUrl = "v1/responses";
     private String videoUrl = "v1/videos";
+    /**
+     * Path used to create a video task. Kept separate from {@link #videoUrl} because some
+     * gateways create at {@code v1/videos/generations} while still polling {@code v1/videos/{id}}.
+     */
+    private String videoCreateUrl = "v1/videos";
 
 }
 

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoService.java
@@ -1,0 +1,47 @@
+package io.github.lnyocly.ai4j.platform.grok.video;
+
+import io.github.lnyocly.ai4j.platform.openai.video.AbstractVideoService;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.service.Configuration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Video service for the Grok / xAI gateway.
+ *
+ * <p>Dialect differences from {@link io.github.lnyocly.ai4j.platform.openai.video.OpenAiVideoService}:
+ * tasks are created at {@code v1/videos/generations} (while polling stays on
+ * {@code v1/videos/{request_id}}) and the duration / ratio / reference parameters use
+ * {@code duration}, {@code aspect_ratio}, {@code resolution}, {@code image} and
+ * {@code reference_images}.
+ */
+public class GrokVideoService extends AbstractVideoService {
+
+    public static final String DEFAULT_CREATE_PATH = "v1/videos/generations";
+
+    public GrokVideoService(Configuration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    protected String defaultCreatePath() {
+        return DEFAULT_CREATE_PATH;
+    }
+
+    @Override
+    protected Map<String, Object> toJsonBody(VideoCreateRequest request) {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        body.put("model", request.getModel());
+        putIfPresent(body, "prompt", request.getPrompt());
+        Object duration = request.getDurationSeconds() != null ? request.getDurationSeconds() : request.getSeconds();
+        putIfPresent(body, "duration", duration);
+        putIfPresent(body, "aspect_ratio", request.getAspectRatio());
+        putIfPresent(body, "resolution", request.getResolution());
+        putIfPresent(body, "image", request.getInputImage());
+        if (request.getReferenceImages() != null && !request.getReferenceImages().isEmpty()) {
+            body.put("reference_images", request.getReferenceImages());
+        }
+        return body;
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/AbstractVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/AbstractVideoService.java
@@ -1,0 +1,245 @@
+package io.github.lnyocly.ai4j.platform.openai.video;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.constant.Constants;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
+import io.github.lnyocly.ai4j.network.UrlUtils;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoBodyMode;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IVideoService;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Shared HTTP plumbing for video services.
+ *
+ * <p>Every first-party video API we target creates tasks with {@code application/json} and
+ * polls a task id, but they disagree on paths and parameter names. Subclasses therefore
+ * only declare their dialect: which create path to use and how to name the neutral fields
+ * of {@link VideoCreateRequest}.
+ */
+public abstract class AbstractVideoService implements IVideoService {
+
+    protected static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
+    private static final MediaType OCTET_STREAM_MEDIA_TYPE = MediaType.get("application/octet-stream");
+
+    protected final OpenAiConfig openAiConfig;
+    protected final OkHttpClient okHttpClient;
+    protected final ObjectMapper mapper = new ObjectMapper();
+
+    protected AbstractVideoService(Configuration configuration) {
+        this.openAiConfig = configuration.getOpenAiConfig();
+        this.okHttpClient = configuration.getOkHttpClient();
+    }
+
+    /** Default create path for this dialect, e.g. {@code v1/videos}. */
+    protected abstract String defaultCreatePath();
+
+    /** Maps the neutral request onto this dialect's JSON body. */
+    protected abstract Map<String, Object> toJsonBody(VideoCreateRequest request);
+
+    @Override
+    public VideoResponse create(String baseUrl, String apiKey, VideoCreateRequest request) throws Exception {
+        String path = request.getCreatePath() != null && !request.getCreatePath().isEmpty()
+                ? request.getCreatePath()
+                : defaultCreatePath();
+        Request.Builder requestBuilder = authorizedRequest(baseUrl, apiKey, path).post(buildBody(request));
+        applyHeaders(requestBuilder, request);
+        return executeJson(requestBuilder.build());
+    }
+
+    @Override
+    public VideoResponse create(VideoCreateRequest request) throws Exception {
+        return create(null, null, request);
+    }
+
+    @Override
+    public VideoResponse retrieve(String baseUrl, String apiKey, String id) throws Exception {
+        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id))
+                .get()
+                .build();
+        return executeJson(request);
+    }
+
+    @Override
+    public VideoResponse retrieve(String id) throws Exception {
+        return retrieve(null, null, id);
+    }
+
+    @Override
+    public InputStream content(String baseUrl, String apiKey, String id) throws Exception {
+        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "content")
+                .get()
+                .build();
+        Response response = okHttpClient.newCall(request).execute();
+        if (!response.isSuccessful() || response.body() == null) {
+            try {
+                throw HttpErrorDecoder.decode(response);
+            } finally {
+                response.close();
+            }
+        }
+        return new ResponseInputStream(response, response.body().byteStream());
+    }
+
+    @Override
+    public InputStream content(String id) throws Exception {
+        return content(null, null, id);
+    }
+
+    @Override
+    public VideoResponse remix(String baseUrl, String apiKey, String id, String prompt) throws Exception {
+        Map<String, String> body = new LinkedHashMap<String, String>();
+        body.put("prompt", prompt);
+        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "remix")
+                .post(RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE))
+                .build();
+        return executeJson(request);
+    }
+
+    @Override
+    public VideoResponse remix(String id, String prompt) throws Exception {
+        return remix(null, null, id, prompt);
+    }
+
+    private RequestBody buildBody(VideoCreateRequest request) throws Exception {
+        boolean multipart = request.getBodyMode() == VideoBodyMode.MULTIPART
+                || (request.getFileFields() != null && !request.getFileFields().isEmpty());
+        return multipart ? multipartBody(request) : jsonBody(request);
+    }
+
+    private RequestBody jsonBody(VideoCreateRequest request) throws Exception {
+        Map<String, Object> body = toJsonBody(request);
+        if (request.getExtraFields() != null) {
+            for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
+                if (entry.getValue() != null) {
+                    body.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE);
+    }
+
+    /**
+     * Legacy relay gateways that only accept {@code multipart/form-data}.
+     *
+     * @deprecated first-party video APIs use JSON; this path exists only until the
+     * remaining relay integrations are retired.
+     */
+    @Deprecated
+    private RequestBody multipartBody(VideoCreateRequest request) {
+        MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        for (Map.Entry<String, Object> entry : toJsonBody(request).entrySet()) {
+            addFormDataPart(builder, entry.getKey(), entry.getValue());
+        }
+        if (request.getExtraFields() != null) {
+            for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
+                addFormDataPart(builder, entry.getKey(), entry.getValue());
+            }
+        }
+        if (request.getFileFields() != null) {
+            for (Map.Entry<String, File> entry : request.getFileFields().entrySet()) {
+                File file = entry.getValue();
+                if (file != null) {
+                    builder.addFormDataPart(entry.getKey(), file.getName(),
+                            RequestBody.create(file, OCTET_STREAM_MEDIA_TYPE));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    protected static void putIfPresent(Map<String, Object> body, String name, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String && ((String) value).isEmpty()) {
+            return;
+        }
+        body.put(name, value);
+    }
+
+    private void applyHeaders(Request.Builder requestBuilder, VideoCreateRequest request) {
+        if (request.getHeaders() == null) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
+            if (entry.getValue() != null) {
+                requestBuilder.header(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    private Request.Builder authorizedRequest(String baseUrl, String apiKey, String... pathParts) {
+        String[] parts = new String[pathParts.length + 1];
+        parts[0] = resolveBaseUrl(baseUrl);
+        System.arraycopy(pathParts, 0, parts, 1, pathParts.length);
+        return new Request.Builder()
+                .header("Authorization", "Bearer " + resolveApiKey(apiKey))
+                .url(UrlUtils.concatUrl(parts));
+    }
+
+    private VideoResponse executeJson(Request request) throws Exception {
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                String body = response.body().string();
+                VideoResponse videoResponse = mapper.readValue(body, VideoResponse.class);
+                videoResponse.setRaw(mapper.readValue(body, new TypeReference<Map<String, Object>>() { }));
+                return videoResponse;
+            }
+            throw HttpErrorDecoder.decode(response);
+        }
+    }
+
+    private void addFormDataPart(MultipartBody.Builder builder, String name, Object value) {
+        if (name != null && value != null) {
+            builder.addFormDataPart(name, String.valueOf(value));
+        }
+    }
+
+    private String resolveBaseUrl(String baseUrl) {
+        return (baseUrl == null || "".equals(baseUrl)) ? openAiConfig.getApiHost() : baseUrl;
+    }
+
+    private String resolveApiKey(String apiKey) {
+        return (apiKey == null || "".equals(apiKey)) ? openAiConfig.getApiKey() : apiKey;
+    }
+
+    private String encodePathSegment(String value) throws IOException {
+        return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+    }
+
+    private static final class ResponseInputStream extends FilterInputStream {
+        private final Response response;
+
+        private ResponseInputStream(Response response, InputStream delegate) {
+            super(delegate);
+            this.response = response;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                response.close();
+            }
+        }
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoService.java
@@ -1,189 +1,38 @@
 package io.github.lnyocly.ai4j.platform.openai.video;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.lnyocly.ai4j.config.OpenAiConfig;
-import io.github.lnyocly.ai4j.constant.Constants;
-import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
-import io.github.lnyocly.ai4j.network.UrlUtils;
 import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
-import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
 import io.github.lnyocly.ai4j.service.Configuration;
-import io.github.lnyocly.ai4j.service.IVideoService;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
-import java.io.File;
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * OpenAI-compatible video service, including ChatFire's /v1/videos gateway.
+ * OpenAI-compatible video service ({@code POST v1/videos}, {@code GET v1/videos/{id}}).
+ *
+ * <p>The create call sends {@code application/json}. Gateways that still require
+ * {@code multipart/form-data} must opt in explicitly via
+ * {@link io.github.lnyocly.ai4j.platform.openai.video.entity.VideoBodyMode#MULTIPART}.
  */
-public class OpenAiVideoService implements IVideoService {
-    private static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
-    private static final MediaType OCTET_STREAM_MEDIA_TYPE = MediaType.get("application/octet-stream");
-
-    private final OpenAiConfig openAiConfig;
-    private final OkHttpClient okHttpClient;
-    private final ObjectMapper mapper = new ObjectMapper();
+public class OpenAiVideoService extends AbstractVideoService {
 
     public OpenAiVideoService(Configuration configuration) {
-        this.openAiConfig = configuration.getOpenAiConfig();
-        this.okHttpClient = configuration.getOkHttpClient();
+        super(configuration);
     }
 
     @Override
-    public VideoResponse create(String baseUrl, String apiKey, VideoCreateRequest request) throws Exception {
-        MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
-        addFormDataPart(builder, "model", request.getModel());
-        addFormDataPart(builder, "prompt", request.getPrompt());
-        addFormDataPart(builder, "seconds", request.getSeconds());
-        addFormDataPart(builder, "size", request.getSize());
-
-        if (request.getExtraFields() != null) {
-            for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
-                addFormDataPart(builder, entry.getKey(), entry.getValue());
-            }
-        }
-        if (request.getFileFields() != null) {
-            for (Map.Entry<String, File> entry : request.getFileFields().entrySet()) {
-                File file = entry.getValue();
-                if (file != null) {
-                    builder.addFormDataPart(entry.getKey(), file.getName(), RequestBody.create(file, OCTET_STREAM_MEDIA_TYPE));
-                }
-            }
-        }
-
-        Request.Builder requestBuilder = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl())
-                .post(builder.build());
-        if (request.getHeaders() != null) {
-            for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
-                if (entry.getValue() != null) {
-                    requestBuilder.header(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-        return executeJson(requestBuilder.build());
+    protected String defaultCreatePath() {
+        return openAiConfig.getVideoCreateUrl();
     }
 
     @Override
-    public VideoResponse create(VideoCreateRequest request) throws Exception {
-        return create(null, null, request);
-    }
-
-    @Override
-    public VideoResponse retrieve(String baseUrl, String apiKey, String id) throws Exception {
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id))
-                .get()
-                .build();
-        return executeJson(request);
-    }
-
-    @Override
-    public VideoResponse retrieve(String id) throws Exception {
-        return retrieve(null, null, id);
-    }
-
-    @Override
-    public InputStream content(String baseUrl, String apiKey, String id) throws Exception {
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "content")
-                .get()
-                .build();
-        Response response = okHttpClient.newCall(request).execute();
-        if (!response.isSuccessful() || response.body() == null) {
-            try {
-                throw HttpErrorDecoder.decode(response);
-            } finally {
-                response.close();
-            }
-        }
-        return new ResponseInputStream(response, response.body().byteStream());
-    }
-
-    @Override
-    public InputStream content(String id) throws Exception {
-        return content(null, null, id);
-    }
-
-    @Override
-    public VideoResponse remix(String baseUrl, String apiKey, String id, String prompt) throws Exception {
-        Map<String, String> body = new LinkedHashMap<String, String>();
-        body.put("prompt", prompt);
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "remix")
-                .post(RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE))
-                .build();
-        return executeJson(request);
-    }
-
-    @Override
-    public VideoResponse remix(String id, String prompt) throws Exception {
-        return remix(null, null, id, prompt);
-    }
-
-    private Request.Builder authorizedRequest(String baseUrl, String apiKey, String... pathParts) {
-        String[] parts = new String[pathParts.length + 1];
-        parts[0] = resolveBaseUrl(baseUrl);
-        System.arraycopy(pathParts, 0, parts, 1, pathParts.length);
-        return new Request.Builder()
-                .header("Authorization", "Bearer " + resolveApiKey(apiKey))
-                .url(UrlUtils.concatUrl(parts));
-    }
-
-    private VideoResponse executeJson(Request request) throws Exception {
-        try (Response response = okHttpClient.newCall(request).execute()) {
-            if (response.isSuccessful() && response.body() != null) {
-                String body = response.body().string();
-                VideoResponse videoResponse = mapper.readValue(body, VideoResponse.class);
-                videoResponse.setRaw(mapper.readValue(body, new TypeReference<Map<String, Object>>() { }));
-                return videoResponse;
-            }
-            throw HttpErrorDecoder.decode(response);
-        }
-    }
-
-    private void addFormDataPart(MultipartBody.Builder builder, String name, Object value) {
-        if (name != null && value != null) {
-            builder.addFormDataPart(name, String.valueOf(value));
-        }
-    }
-
-    private String resolveBaseUrl(String baseUrl) {
-        return (baseUrl == null || "".equals(baseUrl)) ? openAiConfig.getApiHost() : baseUrl;
-    }
-
-    private String resolveApiKey(String apiKey) {
-        return (apiKey == null || "".equals(apiKey)) ? openAiConfig.getApiKey() : apiKey;
-    }
-
-    private String encodePathSegment(String value) throws IOException {
-        return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
-    }
-
-    private static final class ResponseInputStream extends FilterInputStream {
-        private final Response response;
-
-        private ResponseInputStream(Response response, InputStream delegate) {
-            super(delegate);
-            this.response = response;
-        }
-
-        @Override
-        public void close() throws IOException {
-            try {
-                super.close();
-            } finally {
-                response.close();
-            }
-        }
+    protected Map<String, Object> toJsonBody(VideoCreateRequest request) {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        body.put("model", request.getModel());
+        putIfPresent(body, "prompt", request.getPrompt());
+        Object seconds = request.getDurationSeconds() != null ? request.getDurationSeconds() : request.getSeconds();
+        putIfPresent(body, "seconds", seconds);
+        putIfPresent(body, "size", request.getSize());
+        putIfPresent(body, "input_reference", request.getInputImage());
+        return body;
     }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoBodyMode.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoBodyMode.java
@@ -1,0 +1,14 @@
+package io.github.lnyocly.ai4j.platform.openai.video.entity;
+
+/**
+ * Wire format used when creating a video task.
+ *
+ * <p>{@link #JSON} is the default and matches every first-party video API we target
+ * (OpenAI, Grok/xAI, and the other official subscriptions). {@link #MULTIPART} exists
+ * only for legacy relay gateways that still require {@code multipart/form-data}; it is
+ * deprecated and will be removed once those relays are retired.
+ */
+public enum VideoBodyMode {
+    JSON,
+    MULTIPART
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoCreateRequest.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoCreateRequest.java
@@ -11,10 +11,17 @@ import lombok.NonNull;
 
 import java.io.File;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Request for OpenAI-compatible video creation.
+ * Vendor-neutral request for creating a video task.
+ *
+ * <p>The fields below are the minimal intersection shared by the first-party video APIs
+ * we target. Each {@code IVideoService} implementation maps them onto its own dialect
+ * (for example {@code durationSeconds} becomes {@code seconds} on OpenAI and
+ * {@code duration} on the Grok gateway). Vendor-only parameters go through
+ * {@link #extraFields} and are merged verbatim into the request body.
  */
 @Data
 @AllArgsConstructor
@@ -26,16 +33,46 @@ public class VideoCreateRequest {
     @NonNull
     private String model;
 
-    @NonNull
     private String prompt;
 
+    /** Neutral duration in seconds. Preferred over the legacy {@link #seconds} field. */
+    private Integer durationSeconds;
+
+    /** Neutral aspect ratio such as {@code 16:9}. */
+    private String aspectRatio;
+
+    /** Neutral resolution such as {@code 720p} or {@code 1080p}. */
+    private String resolution;
+
+    /** Optional first-frame / driving image reference (URL or data URL). */
+    private String inputImage;
+
+    /** Optional additional reference images (URL or data URL). */
+    private List<String> referenceImages;
+
+    /** Legacy OpenAI duration field. Used only when {@link #durationSeconds} is null. */
     private Object seconds;
+
+    /** Legacy OpenAI pixel size such as {@code 1280x720}. */
     private String size;
+
+    /** Overrides the implementation's default create path, e.g. {@code v1/videos/generations}. */
+    @JsonIgnore
+    private String createPath;
+
+    /**
+     * Wire format for the create call. Defaults to JSON; multipart is only kept for legacy
+     * relay gateways and is deprecated.
+     */
+    @JsonIgnore
+    @Builder.Default
+    private VideoBodyMode bodyMode = VideoBodyMode.JSON;
 
     @JsonIgnore
     @Builder.Default
     private Map<String, Object> extraFields = new LinkedHashMap<String, Object>();
 
+    /** Only usable with {@link VideoBodyMode#MULTIPART}. */
     @JsonIgnore
     @Builder.Default
     private Map<String, File> fileFields = new LinkedHashMap<String, File>();

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
@@ -10,7 +10,11 @@ import lombok.NoArgsConstructor;
 import java.util.Map;
 
 /**
- * OpenAI-compatible video task response.
+ * Vendor-neutral video task response.
+ *
+ * <p>Task ids arrive under different names: OpenAI returns {@code id} while the Grok
+ * gateway returns {@code request_id}. Both are captured and {@link #getTaskId()} returns
+ * whichever is present so callers never have to branch per vendor.
  */
 @Data
 @AllArgsConstructor
@@ -19,6 +23,11 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VideoResponse {
     private String id;
+
+    /** Grok gateway task id ({@code POST v1/videos/generations} returns only this field). */
+    @JsonProperty("request_id")
+    private String requestId;
+
     private String object;
     private String status;
     private String model;
@@ -32,5 +41,30 @@ public class VideoResponse {
     @JsonProperty("created_at")
     private Long createdAt;
 
+    /** Present when the provider reports a task-level failure (HTTP may still be 200). */
+    private VideoError error;
+
     private Map<String, Object> raw;
+
+    /** Task id regardless of vendor field naming. */
+    public String getTaskId() {
+        return id != null && !id.isEmpty() ? id : requestId;
+    }
+
+    /** Provider error message, or {@code null} when the task carries no error. */
+    public String getErrorMessage() {
+        return error == null ? null : error.getMessage();
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VideoError {
+        private String code;
+        private String message;
+        private String type;
+        private String param;
+    }
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/PlatformType.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/PlatformType.java
@@ -25,6 +25,7 @@ public enum PlatformType {
     DOUBAO("doubao"),
     JINA("jina"),
     SUNO("suno"),
+    GROK("grok"),
     ;
     private final String platform;
 

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
@@ -24,6 +24,7 @@ import io.github.lnyocly.ai4j.platform.openai.embedding.OpenAiEmbeddingService;
 import io.github.lnyocly.ai4j.platform.openai.image.OpenAiImageService;
 import io.github.lnyocly.ai4j.platform.openai.realtime.OpenAiRealtimeService;
 import io.github.lnyocly.ai4j.platform.openai.video.OpenAiVideoService;
+import io.github.lnyocly.ai4j.platform.grok.video.GrokVideoService;
 import io.github.lnyocly.ai4j.platform.suno.music.SunoMusicService;
 import io.github.lnyocly.ai4j.platform.zhipu.chat.ZhipuChatService;
 import io.github.lnyocly.ai4j.rag.DefaultRagContextAssembler;
@@ -227,6 +228,8 @@ public class AiService {
         switch (platform) {
             case OPENAI:
                 return new OpenAiVideoService(configuration);
+            case GROK:
+                return new GrokVideoService(configuration);
             default:
                 throw new IllegalArgumentException("No video service for platform: " + platform);
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoServiceTest.java
@@ -20,7 +20,8 @@ public class GrokVideoServiceTest {
     @Test
     public void test_create_posts_json_to_videos_generations() throws Exception {
         MockWebServer server = new MockWebServer();
-        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"request_id\":\"req-1\",\"id\":\"req-1\",\"status\":\"queued\"}"));
+        // Live gateway shape (verified 2026-08-19): create returns ONLY request_id.
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"request_id\":\"video_zoobap6\"}"));
         server.start();
         try {
             GrokVideoService service = new GrokVideoService(OpenAiVideoServiceTest.configuration(server));
@@ -37,7 +38,9 @@ public class GrokVideoServiceTest {
                     .referenceImages(references)
                     .build());
 
-            Assert.assertEquals("req-1", response.getId());
+            Assert.assertNull(response.getId());
+            Assert.assertEquals("video_zoobap6", response.getRequestId());
+            Assert.assertEquals("video_zoobap6", response.getTaskId());
 
             RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
             Assert.assertNotNull(request);
@@ -55,6 +58,27 @@ public class GrokVideoServiceTest {
             Assert.assertEquals(1, refs.size());
             Assert.assertEquals("https://cdn.example/ref-1.png", refs.getString(0));
             Assert.assertNull(body.getString("seconds"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_surfaces_task_failure_returned_with_http_200() throws Exception {
+        MockWebServer server = new MockWebServer();
+        // Live gateway shape (verified 2026-08-19): failures come back as HTTP 200 + error body.
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse(
+                "{\"error\":{\"code\":\"internal_error\",\"message\":\"Console 媒体上游返回 429: Free usage quota exceeded\"},\"status\":\"failed\"}"));
+        server.start();
+        try {
+            GrokVideoService service = new GrokVideoService(OpenAiVideoServiceTest.configuration(server));
+            VideoResponse response = service.retrieve("video_zoobap6");
+
+            Assert.assertEquals("failed", response.getStatus());
+            Assert.assertNull(response.getVideoUrl());
+            Assert.assertNotNull(response.getError());
+            Assert.assertEquals("internal_error", response.getError().getCode());
+            Assert.assertTrue(response.getErrorMessage().contains("429"));
         } finally {
             server.shutdown();
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/grok/video/GrokVideoServiceTest.java
@@ -1,0 +1,81 @@
+package io.github.lnyocly.ai4j.platform.grok.video;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.platform.openai.video.OpenAiVideoServiceTest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class GrokVideoServiceTest {
+
+    @Test
+    public void test_create_posts_json_to_videos_generations() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"request_id\":\"req-1\",\"id\":\"req-1\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            GrokVideoService service = new GrokVideoService(OpenAiVideoServiceTest.configuration(server));
+            List<String> references = new ArrayList<String>();
+            references.add("https://cdn.example/ref-1.png");
+
+            VideoResponse response = service.create(VideoCreateRequest.builder()
+                    .model("grok-imagine-video")
+                    .prompt("城市屋顶的星空")
+                    .durationSeconds(6)
+                    .aspectRatio("16:9")
+                    .resolution("720p")
+                    .inputImage("https://cdn.example/first.png")
+                    .referenceImages(references)
+                    .build());
+
+            Assert.assertEquals("req-1", response.getId());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(request);
+            Assert.assertEquals("/v1/videos/generations", request.getPath());
+            Assert.assertTrue(request.getHeader("Content-Type").startsWith("application/json"));
+
+            JSONObject body = JSON.parseObject(request.getBody().readUtf8());
+            Assert.assertEquals("grok-imagine-video", body.getString("model"));
+            Assert.assertEquals("城市屋顶的星空", body.getString("prompt"));
+            Assert.assertEquals(Integer.valueOf(6), body.getInteger("duration"));
+            Assert.assertEquals("16:9", body.getString("aspect_ratio"));
+            Assert.assertEquals("720p", body.getString("resolution"));
+            Assert.assertEquals("https://cdn.example/first.png", body.getString("image"));
+            JSONArray refs = body.getJSONArray("reference_images");
+            Assert.assertEquals(1, refs.size());
+            Assert.assertEquals("https://cdn.example/ref-1.png", refs.getString(0));
+            Assert.assertNull(body.getString("seconds"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_polls_videos_request_id_without_generations_suffix() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"id\":\"req-1\",\"status\":\"completed\",\"video_url\":\"https://cdn.example/out.mp4\"}"));
+        server.start();
+        try {
+            GrokVideoService service = new GrokVideoService(OpenAiVideoServiceTest.configuration(server));
+            VideoResponse response = service.retrieve("req-1");
+
+            Assert.assertEquals("completed", response.getStatus());
+            Assert.assertEquals("https://cdn.example/out.mp4", response.getVideoUrl());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/v1/videos/req-1", request.getPath());
+        } finally {
+            server.shutdown();
+        }
+    }
+}

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/video/OpenAiVideoServiceTest.java
@@ -3,6 +3,7 @@ package io.github.lnyocly.ai4j.platform.openai.video;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoBodyMode;
 import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
 import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
 import io.github.lnyocly.ai4j.service.Configuration;
@@ -23,18 +24,18 @@ import java.util.concurrent.TimeUnit;
 public class OpenAiVideoServiceTest {
 
     @Test
-    public void test_create_video_uses_multipart_videos_endpoint() throws Exception {
+    public void test_create_video_posts_json_to_videos_endpoint() throws Exception {
         MockWebServer server = new MockWebServer();
         server.enqueue(jsonResponse("{\"id\":\"video-1\",\"object\":\"video\",\"status\":\"queued\",\"created_at\":1764240518}"));
         server.start();
         try {
             OpenAiVideoService service = new OpenAiVideoService(configuration(server));
             Map<String, Object> extraFields = new LinkedHashMap<String, Object>();
-            extraFields.put("enable_upsample", "true");
+            extraFields.put("enable_upsample", true);
             VideoResponse response = service.create(VideoCreateRequest.builder()
                     .model("veo3.1")
                     .prompt("飞上天")
-                    .seconds(8)
+                    .durationSeconds(8)
                     .size("1280x720")
                     .extraFields(extraFields)
                     .build());
@@ -47,13 +48,59 @@ public class OpenAiVideoServiceTest {
             Assert.assertNotNull(request);
             Assert.assertEquals("/v1/videos", request.getPath());
             Assert.assertEquals("Bearer test-key", request.getHeader("Authorization"));
+            Assert.assertTrue(request.getHeader("Content-Type").startsWith("application/json"));
+            JSONObject body = JSON.parseObject(request.getBody().readUtf8());
+            Assert.assertEquals("veo3.1", body.getString("model"));
+            Assert.assertEquals("飞上天", body.getString("prompt"));
+            Assert.assertEquals(Integer.valueOf(8), body.getInteger("seconds"));
+            Assert.assertEquals("1280x720", body.getString("size"));
+            Assert.assertEquals(Boolean.TRUE, body.getBoolean("enable_upsample"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_video_multipart_is_opt_in_for_legacy_relays() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"video-1\",\"object\":\"video\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            OpenAiVideoService service = new OpenAiVideoService(configuration(server));
+            service.create(VideoCreateRequest.builder()
+                    .model("veo3.1")
+                    .prompt("飞上天")
+                    .seconds(8)
+                    .bodyMode(VideoBodyMode.MULTIPART)
+                    .build());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(request);
+            Assert.assertEquals("/v1/videos", request.getPath());
             Assert.assertTrue(request.getHeader("Content-Type").startsWith("multipart/form-data"));
             String body = request.getBody().readUtf8();
             Assert.assertTrue(body.contains("name=\"model\""));
             Assert.assertTrue(body.contains("veo3.1"));
-            Assert.assertTrue(body.contains("name=\"prompt\""));
-            Assert.assertTrue(body.contains("飞上天"));
-            Assert.assertTrue(body.contains("name=\"enable_upsample\""));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_video_honours_create_path_override() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"video-1\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            OpenAiVideoService service = new OpenAiVideoService(configuration(server));
+            service.create(VideoCreateRequest.builder()
+                    .model("veo3.1")
+                    .prompt("飞上天")
+                    .createPath("v1/videos/generations")
+                    .build());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/v1/videos/generations", request.getPath());
         } finally {
             server.shutdown();
         }
@@ -120,11 +167,12 @@ public class OpenAiVideoServiceTest {
         }
     }
 
-    private static Configuration configuration(MockWebServer server) {
+    public static Configuration configuration(MockWebServer server) {
         OpenAiConfig openAiConfig = new OpenAiConfig();
         openAiConfig.setApiHost(server.url("/").toString());
         openAiConfig.setApiKey("test-key");
         openAiConfig.setVideoUrl("v1/videos");
+        openAiConfig.setVideoCreateUrl("v1/videos");
 
         Configuration configuration = new Configuration();
         configuration.setOpenAiConfig(openAiConfig);
@@ -132,7 +180,7 @@ public class OpenAiVideoServiceTest {
         return configuration;
     }
 
-    private static MockResponse jsonResponse(String body) {
+    public static MockResponse jsonResponse(String body) {
         return new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")


### PR DESCRIPTION
## 背景

各家**官方**视频 API 创建任务统一使用 `application/json`；此前 `OpenAiVideoService.create()` 写死 `multipart/form-data`（对齐的是第三方中转网关时代的形状），因此：

- 无法对接 `POST /v1/videos/generations`（JSON）这类官方网关
- `create` 与 `retrieve` 共用同一个 `videoUrl`，把创建路径改成 `.../generations` 会让轮询错打到 `.../generations/{id}`

## 改动

- 新增 `AbstractVideoService`：抽出 HTTP 管道，**create 默认 JSON**
- `VideoBodyMode.MULTIPART`：遗留中转网关显式选择，已 `@Deprecated`
- `VideoCreateRequest` 增加厂商中性字段（最小交集）：`durationSeconds` / `aspectRatio` / `resolution` / `inputImage` / `referenceImages`；厂商专有参数仍走 `extraFields`
- `OpenAiConfig.videoCreateUrl` 与 `videoUrl` 解耦；`VideoCreateRequest.createPath` 可按次覆盖
- 新增 `GrokVideoService`：create `v1/videos/generations`，轮询 `GET v1/videos/{request_id}`，字段 `duration/aspect_ratio/resolution/image/reference_images`
- `PlatformType.GROK` + `AiService.getVideoService(GROK)`

统一放在**语义层**（一个 `IVideoService` + 各家方言实现），不假装各家 HTTP 长一样。

## 兼容性

- 仍需 multipart 的中转网关：调用方显式设 `bodyMode(VideoBodyMode.MULTIPART)`
- `retrieve` / `content` / `remix` 行为不变

## 测试

`mvn -pl ai4j test`：**321 passed / 0 failed**

- OpenAI：JSON 创建、multipart 显式选择、`createPath` 覆盖、retrieve/content/remix
- Grok：JSON body 字段映射 + 轮询路径不带 `generations`