### PR TITLE
feat(video): Seedance/Ark 方言（多模态 content[] + 可配 task 路径）

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
@@ -1,0 +1,133 @@
+package io.github.lnyocly.ai4j.platform.doubao.video;
+
+import io.github.lnyocly.ai4j.platform.openai.video.AbstractVideoService;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoReference;
+import io.github.lnyocly.ai4j.service.Configuration;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Seedance (Volcengine Ark) video service.
+ *
+ * <p>Dialect shape, per the Ark content-generation contract:
+ * <pre>
+ *   POST {base}api/v3/contents/generations/tasks
+ *   {
+ *     "model": "doubao-seedance-...",
+ *     "content": [
+ *       {"type":"text","text":"..."},
+ *       {"type":"image_url","image_url":{"url":"..."},"role":"first_frame"},
+ *       {"type":"video_url","video_url":{"url":"..."},"role":"reference_video"},
+ *       {"type":"audio_url","audio_url":{"url":"..."},"role":"reference_audio"}
+ *     ],
+ *     "duration": 4, "ratio": "16:9", "resolution": "480p",
+ *     "generate_audio": true, "watermark": false
+ *   }
+ *   GET  {base}api/v3/contents/generations/tasks/{id}
+ *       -> { "status": "...", "content": { "video_url": "..." }, "usage": {...} }
+ * </pre>
+ *
+ * <p>{@code apiHost} carries the base URL, so the same dialect serves the official Ark
+ * endpoint and any faithful relay (which may prefix the path, e.g.
+ * {@code /volcengine/api/v3/...}) — set {@code videoTaskUrl} for that.
+ *
+ * <p>Which reference roles a model accepts differs by generation (2.x supports omni-modal
+ * references, 1.x only frames). That is a catalog concern: this service forwards whatever
+ * roles the caller supplies rather than filtering them.
+ */
+public class SeedanceVideoService extends AbstractVideoService {
+
+    public static final String DEFAULT_TASK_PATH = "api/v3/contents/generations/tasks";
+
+    private final String taskPath;
+
+    public SeedanceVideoService(Configuration configuration) {
+        this(configuration, DEFAULT_TASK_PATH);
+    }
+
+    /**
+     * @param taskPath path of the task collection, e.g. {@code api/v3/contents/generations/tasks}
+     *                 or a relay prefix such as {@code volcengine/api/v3/contents/generations/tasks}
+     */
+    public SeedanceVideoService(Configuration configuration, String taskPath) {
+        super(configuration);
+        this.taskPath = taskPath == null || taskPath.isEmpty() ? DEFAULT_TASK_PATH : taskPath;
+    }
+
+    @Override
+    protected String defaultCreatePath() {
+        return taskPath;
+    }
+
+    /** Ark polls and fetches content under the same task collection as create. */
+    @Override
+    protected String taskResourcePath() {
+        return taskPath;
+    }
+
+    @Override
+    protected Map<String, Object> toJsonBody(VideoCreateRequest request) {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        body.put("model", request.getModel());
+        body.put("content", contentParts(request));
+        Object duration = request.getDurationSeconds() != null ? request.getDurationSeconds() : request.getSeconds();
+        putIfPresent(body, "duration", duration);
+        putIfPresent(body, "ratio", request.getAspectRatio());
+        putIfPresent(body, "resolution", request.getResolution());
+        putIfPresent(body, "generate_audio", request.getGenerateAudio());
+        putIfPresent(body, "watermark", request.getWatermark());
+        return body;
+    }
+
+    /**
+     * Build the {@code content[]} array: the prompt first, then typed references. The simple
+     * {@code inputImage} / {@code referenceImages} fields map onto {@code first_frame} and
+     * {@code reference_image} so callers that do not know this dialect still work.
+     */
+    private List<Map<String, Object>> contentParts(VideoCreateRequest request) {
+        List<Map<String, Object>> parts = new ArrayList<Map<String, Object>>();
+        String prompt = request.getPrompt();
+        if (prompt != null && !prompt.isEmpty()) {
+            Map<String, Object> text = new LinkedHashMap<String, Object>();
+            text.put("type", "text");
+            text.put("text", prompt);
+            parts.add(text);
+        }
+        if (request.getInputImage() != null && !request.getInputImage().isEmpty()) {
+            parts.add(referencePart(VideoReference.firstFrame(request.getInputImage())));
+        }
+        if (request.getReferenceImages() != null) {
+            for (String url : request.getReferenceImages()) {
+                if (url != null && !url.isEmpty()) {
+                    parts.add(referencePart(VideoReference.image(url)));
+                }
+            }
+        }
+        if (request.getReferences() != null) {
+            for (VideoReference reference : request.getReferences()) {
+                if (reference == null || reference.getUrl() == null || reference.getUrl().isEmpty()) {
+                    continue;
+                }
+                parts.add(referencePart(reference));
+            }
+        }
+        return parts;
+    }
+
+    private Map<String, Object> referencePart(VideoReference reference) {
+        VideoReference.Kind kind = reference.getKind() == null ? VideoReference.Kind.IMAGE : reference.getKind();
+        Map<String, Object> url = new LinkedHashMap<String, Object>();
+        url.put("url", reference.getUrl());
+        Map<String, Object> part = new LinkedHashMap<String, Object>();
+        part.put("type", kind.contentType());
+        part.put(kind.contentType(), url);
+        if (reference.getRole() != null && !reference.getRole().isEmpty()) {
+            part.put("role", reference.getRole());
+        }
+        return part;
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/AbstractVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/AbstractVideoService.java
@@ -54,6 +54,15 @@ public abstract class AbstractVideoService implements IVideoService {
     /** Maps the neutral request onto this dialect's JSON body. */
     protected abstract Map<String, Object> toJsonBody(VideoCreateRequest request);
 
+    /**
+     * Collection that owns the created task, used by retrieve / content / remix. Defaults to
+     * the OpenAI {@code videoUrl}; dialects whose task lives elsewhere (Ark keeps create and
+     * retrieve on the same {@code .../tasks} collection) override this.
+     */
+    protected String taskResourcePath() {
+        return openAiConfig.getVideoUrl();
+    }
+
     @Override
     public VideoResponse create(String baseUrl, String apiKey, VideoCreateRequest request) throws Exception {
         String path = request.getCreatePath() != null && !request.getCreatePath().isEmpty()
@@ -71,7 +80,7 @@ public abstract class AbstractVideoService implements IVideoService {
 
     @Override
     public VideoResponse retrieve(String baseUrl, String apiKey, String id) throws Exception {
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id))
+        Request request = authorizedRequest(baseUrl, apiKey, taskResourcePath(), encodePathSegment(id))
                 .get()
                 .build();
         return executeJson(request);
@@ -84,7 +93,7 @@ public abstract class AbstractVideoService implements IVideoService {
 
     @Override
     public InputStream content(String baseUrl, String apiKey, String id) throws Exception {
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "content")
+        Request request = authorizedRequest(baseUrl, apiKey, taskResourcePath(), encodePathSegment(id), "content")
                 .get()
                 .build();
         Response response = okHttpClient.newCall(request).execute();
@@ -107,7 +116,7 @@ public abstract class AbstractVideoService implements IVideoService {
     public VideoResponse remix(String baseUrl, String apiKey, String id, String prompt) throws Exception {
         Map<String, String> body = new LinkedHashMap<String, String>();
         body.put("prompt", prompt);
-        Request request = authorizedRequest(baseUrl, apiKey, openAiConfig.getVideoUrl(), encodePathSegment(id), "remix")
+        Request request = authorizedRequest(baseUrl, apiKey, taskResourcePath(), encodePathSegment(id), "remix")
                 .post(RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE))
                 .build();
         return executeJson(request);

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoCreateRequest.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoCreateRequest.java
@@ -50,6 +50,19 @@ public class VideoCreateRequest {
     /** Optional additional reference images (URL or data URL). */
     private List<String> referenceImages;
 
+    /**
+     * Typed references (image / video / audio with a role). Dialects that accept multimodal
+     * references use this; {@link #inputImage} and {@link #referenceImages} remain the simple
+     * path for dialects that only take frames.
+     */
+    private List<VideoReference> references;
+
+    /** Whether the model should generate a synchronized audio track, when it supports one. */
+    private Boolean generateAudio;
+
+    /** Whether the provider should burn in a watermark, when it supports the option. */
+    private Boolean watermark;
+
     /** Legacy OpenAI duration field. Used only when {@link #durationSeconds} is null. */
     private Object seconds;
 

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoReference.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoReference.java
@@ -1,0 +1,69 @@
+package io.github.lnyocly.ai4j.platform.openai.video.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One reference asset for video generation.
+ *
+ * <p>Dialects that accept references as typed content parts (Seedance/Ark) build them from
+ * this flat shape; dialects that only take a first frame use the {@code first_frame} entry
+ * and ignore the rest. The role stays a plain string because each model generation supports
+ * a different set, and which roles are offered is a catalog decision, not an SDK one.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoReference {
+
+    /** Asset kind; dialects map it onto their own content-part type. */
+    public enum Kind {
+        IMAGE("image_url"),
+        VIDEO("video_url"),
+        AUDIO("audio_url");
+
+        private final String contentType;
+
+        Kind(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public String contentType() {
+            return contentType;
+        }
+    }
+
+    public static final String ROLE_FIRST_FRAME = "first_frame";
+    public static final String ROLE_LAST_FRAME = "last_frame";
+    public static final String ROLE_REFERENCE_IMAGE = "reference_image";
+    public static final String ROLE_REFERENCE_VIDEO = "reference_video";
+    public static final String ROLE_REFERENCE_AUDIO = "reference_audio";
+
+    private Kind kind;
+
+    /** Publicly reachable asset URL. */
+    private String url;
+
+    private String role;
+
+    public static VideoReference firstFrame(String url) {
+        return new VideoReference(Kind.IMAGE, url, ROLE_FIRST_FRAME);
+    }
+
+    public static VideoReference lastFrame(String url) {
+        return new VideoReference(Kind.IMAGE, url, ROLE_LAST_FRAME);
+    }
+
+    public static VideoReference image(String url) {
+        return new VideoReference(Kind.IMAGE, url, ROLE_REFERENCE_IMAGE);
+    }
+
+    public static VideoReference video(String url) {
+        return new VideoReference(Kind.VIDEO, url, ROLE_REFERENCE_VIDEO);
+    }
+
+    public static VideoReference audio(String url) {
+        return new VideoReference(Kind.AUDIO, url, ROLE_REFERENCE_AUDIO);
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
@@ -38,6 +38,12 @@ public class VideoResponse {
     @JsonProperty("video_url")
     private String videoUrl;
 
+    /** Ark returns the finished asset under {@code content.video_url}. */
+    private VideoContent content;
+
+    /** Token accounting, when the provider reports it. */
+    private Map<String, Object> usage;
+
     @JsonProperty("created_at")
     private Long createdAt;
 
@@ -45,6 +51,12 @@ public class VideoResponse {
     private VideoError error;
 
     private Map<String, Object> raw;
+
+    /** Result URL regardless of whether the dialect nests it under {@code content}. */
+    public String resolveVideoUrl() {
+        if (videoUrl != null && !videoUrl.isEmpty()) return videoUrl;
+        return content == null ? null : content.getVideoUrl();
+    }
 
     /** Task id regardless of vendor field naming. */
     public String getTaskId() {
@@ -54,6 +66,16 @@ public class VideoResponse {
     /** Provider error message, or {@code null} when the task carries no error. */
     public String getErrorMessage() {
         return error == null ? null : error.getMessage();
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VideoContent {
+        @JsonProperty("video_url")
+        private String videoUrl;
     }
 
     @Data

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
@@ -25,6 +25,7 @@ import io.github.lnyocly.ai4j.platform.openai.image.OpenAiImageService;
 import io.github.lnyocly.ai4j.platform.openai.realtime.OpenAiRealtimeService;
 import io.github.lnyocly.ai4j.platform.openai.video.OpenAiVideoService;
 import io.github.lnyocly.ai4j.platform.grok.video.GrokVideoService;
+import io.github.lnyocly.ai4j.platform.doubao.video.SeedanceVideoService;
 import io.github.lnyocly.ai4j.platform.suno.music.SunoMusicService;
 import io.github.lnyocly.ai4j.platform.zhipu.chat.ZhipuChatService;
 import io.github.lnyocly.ai4j.rag.DefaultRagContextAssembler;
@@ -230,6 +231,8 @@ public class AiService {
                 return new OpenAiVideoService(configuration);
             case GROK:
                 return new GrokVideoService(configuration);
+            case DOUBAO:
+                return new SeedanceVideoService(configuration);
             default:
                 throw new IllegalArgumentException("No video service for platform: " + platform);
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
@@ -1,0 +1,133 @@
+package io.github.lnyocly.ai4j.platform.doubao.video;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.platform.openai.video.OpenAiVideoServiceTest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoReference;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shapes below mirror a live Ark-contract run (2026-08-19): create returns only
+ * {@code {"id": "cgt-..."}} and the finished task nests the asset under
+ * {@code content.video_url} while reporting {@code status: succeeded}.
+ */
+public class SeedanceVideoServiceTest {
+
+    @Test
+    public void test_create_posts_content_array_to_ark_task_path() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"id\":\"cgt-20260819155207-n9qmw\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(OpenAiVideoServiceTest.configuration(server));
+            List<VideoReference> references = new ArrayList<VideoReference>();
+            references.add(VideoReference.lastFrame("https://cdn.example/last.png"));
+            references.add(VideoReference.video("https://cdn.example/ref.mp4"));
+            references.add(VideoReference.audio("https://cdn.example/bgm.mp3"));
+
+            VideoResponse response = service.create(VideoCreateRequest.builder()
+                    .model("doubao-seedance-2-0-fast-real_480p")
+                    .prompt("柠檬在木桌上滚动")
+                    .durationSeconds(4)
+                    .aspectRatio("16:9")
+                    .resolution("480p")
+                    .generateAudio(Boolean.TRUE)
+                    .watermark(Boolean.FALSE)
+                    .inputImage("https://cdn.example/first.png")
+                    .references(references)
+                    .build());
+
+            Assert.assertEquals("cgt-20260819155207-n9qmw", response.getTaskId());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(request);
+            Assert.assertEquals("/api/v3/contents/generations/tasks", request.getPath());
+            Assert.assertTrue(request.getHeader("Content-Type").startsWith("application/json"));
+
+            JSONObject body = JSON.parseObject(request.getBody().readUtf8());
+            Assert.assertEquals("doubao-seedance-2-0-fast-real_480p", body.getString("model"));
+            Assert.assertEquals(Integer.valueOf(4), body.getInteger("duration"));
+            Assert.assertEquals("16:9", body.getString("ratio"));
+            Assert.assertEquals("480p", body.getString("resolution"));
+            Assert.assertEquals(Boolean.TRUE, body.getBoolean("generate_audio"));
+            Assert.assertEquals(Boolean.FALSE, body.getBoolean("watermark"));
+            // Ark carries prompt and references as typed content parts, not top-level fields.
+            Assert.assertNull(body.getString("prompt"));
+
+            JSONArray content = body.getJSONArray("content");
+            Assert.assertEquals(5, content.size());
+            Assert.assertEquals("text", content.getJSONObject(0).getString("type"));
+            Assert.assertEquals("柠檬在木桌上滚动", content.getJSONObject(0).getString("text"));
+
+            JSONObject first = content.getJSONObject(1);
+            Assert.assertEquals("image_url", first.getString("type"));
+            Assert.assertEquals("first_frame", first.getString("role"));
+            Assert.assertEquals("https://cdn.example/first.png", first.getJSONObject("image_url").getString("url"));
+
+            Assert.assertEquals("last_frame", content.getJSONObject(2).getString("role"));
+            Assert.assertEquals("video_url", content.getJSONObject(3).getString("type"));
+            Assert.assertEquals("reference_video", content.getJSONObject(3).getString("role"));
+            Assert.assertEquals("audio_url", content.getJSONObject(4).getString("type"));
+            Assert.assertEquals("reference_audio", content.getJSONObject(4).getString("role"));
+            Assert.assertEquals("https://cdn.example/bgm.mp3",
+                    content.getJSONObject(4).getJSONObject("audio_url").getString("url"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_reads_nested_content_video_url_on_same_task_path() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse(
+                "{\"id\":\"cgt-1\",\"model\":\"doubao-seedance-1-5-pro-251215\",\"status\":\"succeeded\","
+                        + "\"content\":{\"video_url\":\"https://tos.example/out.mp4\"},"
+                        + "\"usage\":{\"completion_tokens\":40594,\"total_tokens\":40594}}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(OpenAiVideoServiceTest.configuration(server));
+            VideoResponse response = service.retrieve("cgt-1");
+
+            Assert.assertEquals("succeeded", response.getStatus());
+            Assert.assertNull(response.getVideoUrl());
+            Assert.assertEquals("https://tos.example/out.mp4", response.resolveVideoUrl());
+            Assert.assertEquals(40594, ((Number) response.getUsage().get("total_tokens")).intValue());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/api/v3/contents/generations/tasks/cgt-1", request.getPath());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_relay_path_prefix_is_configurable() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"id\":\"cgt-2\"}"));
+        server.enqueue(OpenAiVideoServiceTest.jsonResponse("{\"id\":\"cgt-2\",\"status\":\"running\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(
+                    OpenAiVideoServiceTest.configuration(server), "volcengine/api/v3/contents/generations/tasks");
+            service.create(VideoCreateRequest.builder().model("m").prompt("p").durationSeconds(4).build());
+            service.retrieve("cgt-2");
+
+            Assert.assertEquals("/volcengine/api/v3/contents/generations/tasks",
+                    server.takeRequest(1, TimeUnit.SECONDS).getPath());
+            Assert.assertEquals("/volcengine/api/v3/contents/generations/tasks/cgt-2",
+                    server.takeRequest(1, TimeUnit.SECONDS).getPath());
+        } finally {
+            server.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## 背景

统一视频接口（`IVideoService` + 各家方言）再加一家官方方言：**Seedance / Volcengine Ark**。

与已有方言的差异都在「怎么跟模型说话」这一层，业务侧无需感知：

| | 创建路径 | 参数承载 | 任务 id | 结果字段 |
|---|---|---|---|---|
| OpenAI | `v1/videos` | 顶层 `seconds`/`size` | `id` | `video_url` |
| Grok | `v1/videos/generations` | 顶层 `duration`/`aspect_ratio` | `request_id` | `video_url` |
| **Seedance** | `api/v3/contents/generations/tasks` | **`content[]`** 多模态 + 顶层 `duration`/`ratio`/`resolution` | `id` | **`content.video_url`** |

## 改动

- **`SeedanceVideoService`**：按 Ark 契约组装 `content[]`（`text` / `image_url` / `video_url` / `audio_url` + `role`）；创建与查询共用同一任务集合
- **`AbstractVideoService.taskResourcePath()`** 钩子：`retrieve`/`content`/`remix` 不再写死 `videoUrl`
- **`VideoReference`**（中性）：`image`/`video`/`audio` + `role`（`first_frame`/`last_frame`/`reference_image`/`reference_video`/`reference_audio`）；`inputImage`/`referenceImages` 自动映射，旧调用方无需改动
- `VideoCreateRequest` 增 `references` / `generateAudio` / `watermark`
- `VideoResponse` 支持嵌套 `content.video_url` 与 `usage`，新增 `resolveVideoUrl()`
- `PlatformType.DOUBAO` → `SeedanceVideoService`；**task 路径可配**，适配代理前缀（如 `/volcengine/api/v3/...`）

模型能力差异（2.x 全模态参考 vs 1.x 仅首尾帧）不写死在 SDK：服务转发调用方给出的 role，由上层目录决定露出哪些。

## 真机依据（2026-08-19）

同一契约实测通过：

```
POST {base}/api/v3/contents/generations/tasks
  {"model":...,"content":[{"type":"text","text":...}],"duration":4,"ratio":"16:9","resolution":"480p"}
→ 200 {"id":"cgt-20260819155207-n9qmw"}

GET  {base}/api/v3/contents/generations/tasks/cgt-...
→ status: running → succeeded
   content.video_url: https://ark-content-generation-...tos-cn-beijing.volces.com/...mp4
   usage: {"completion_tokens":40594,"total_tokens":40594}
```

下载确认为真实 mp4（2.4 MB）。测试断言用的就是这些真机形状（创建**只回 `id`**、结果**嵌在 `content`**）。

## 测试

`mvn -pl ai4j test` → **325 passed / 0 failed**（新增 3 例：content[] 组装、嵌套结果读取、代理路径前缀可配）