### PR TITLE
feat(image): IImageService 补图片编辑 edit（JSON + multipart 双形态）

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OpenAiConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OpenAiConfig.java
@@ -22,6 +22,12 @@ public class OpenAiConfig {
     private String translationUrl = "v1/audio/translations";
     private String realtimeUrl = "v1/realtime";
     private String imageGenerationUrl = "v1/images/generations";
+
+    /**
+     * 图片编辑端点（图生图/编辑）。OpenAI 标准为 multipart；JSON 形态（image 传
+     * URL/base64 数组）为兼容网关通用扩展（chat2api/skyengine 等）。
+     */
+    private String imageEditUrl = "v1/images/edits";
     private String responsesUrl = "v1/responses";
     private String videoUrl = "v1/videos";
     /**

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
@@ -5,6 +5,7 @@ import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
 import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
 import io.github.lnyocly.ai4j.listener.ImageSseListener;
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageEdit;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGenerationResponse;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageStreamEvent;
@@ -92,6 +93,53 @@ public class OpenAiImageService implements IImageService {
                 .post(RequestBody.create(requestString, JSON_MEDIA_TYPE))
                 .build();
 
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return mapper.readValue(response.body().string(), ImageGenerationResponse.class);
+            }
+            throw HttpErrorDecoder.decode(response);
+        }
+    }
+
+    /**
+     * 图片编辑（图生图）：POST /v1/images/edits，multipart/form-data 形态
+     * （OpenAI 官方标准：文件字节直传，不依赖网关回源）。参考图同名 image 字段可重复。
+     */
+    @Override
+    public ImageGenerationResponse edit(String baseUrl, String apiKey, ImageEdit imageEdit) throws Exception {
+        if (baseUrl == null || "".equals(baseUrl)) {
+            baseUrl = openAiConfig.getApiHost();
+        }
+        if (apiKey == null || "".equals(apiKey)) {
+            apiKey = openAiConfig.getApiKey();
+        }
+
+        okhttp3.MultipartBody.Builder body = new okhttp3.MultipartBody.Builder()
+                .setType(okhttp3.MultipartBody.FORM)
+                .addFormDataPart("model", imageEdit.getModel())
+                .addFormDataPart("prompt", imageEdit.getPrompt());
+        if (imageEdit.getN() != null) body.addFormDataPart("n", String.valueOf(imageEdit.getN()));
+        if (imageEdit.getSize() != null) body.addFormDataPart("size", imageEdit.getSize());
+        if (imageEdit.getQuality() != null) body.addFormDataPart("quality", imageEdit.getQuality());
+        if (imageEdit.getOutputFormat() != null) body.addFormDataPart("output_format", imageEdit.getOutputFormat());
+        if (imageEdit.getResponseFormat() != null) body.addFormDataPart("response_format", imageEdit.getResponseFormat());
+        for (ImageEdit.ImagePart image : imageEdit.getImages()) {
+            MediaType mediaType = MediaType.get(image.getContentType() == null ? "application/octet-stream" : image.getContentType());
+            body.addFormDataPart("image", image.getFilename(), RequestBody.create(image.getData(), mediaType));
+        }
+        if (imageEdit.getMask() != null) {
+            ImageEdit.ImagePart mask = imageEdit.getMask();
+            MediaType maskType = MediaType.get(mask.getContentType() == null ? "image/png" : mask.getContentType());
+            body.addFormDataPart("mask", mask.getFilename(), RequestBody.create(mask.getData(), maskType));
+        }
+
+        Request request = new Request.Builder()
+                .header("Authorization", "Bearer " + apiKey)
+                .url(UrlUtils.concatUrl(baseUrl, openAiConfig.getImageEditUrl()))
+                .post(body.build())
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
         try (Response response = okHttpClient.newCall(request).execute()) {
             if (response.isSuccessful() && response.body() != null) {
                 return mapper.readValue(response.body().string(), ImageGenerationResponse.class);

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/OpenAiImageService.java
@@ -70,6 +70,36 @@ public class OpenAiImageService implements IImageService {
         }
     }
 
+    /**
+     * 图片编辑（图生图）：POST /v1/images/edits，JSON 形态（image 字段 =
+     * URL/base64 字符串数组，网关通用扩展）。与 generate 同构，仅端点不同。
+     */
+    @Override
+    public ImageGenerationResponse edit(String baseUrl, String apiKey, ImageGeneration imageGeneration) throws Exception {
+        if (baseUrl == null || "".equals(baseUrl)) {
+            baseUrl = openAiConfig.getApiHost();
+        }
+        if (apiKey == null || "".equals(apiKey)) {
+            apiKey = openAiConfig.getApiKey();
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        String requestString = mapper.writeValueAsString(imageGeneration);
+
+        Request request = new Request.Builder()
+                .header("Authorization", "Bearer " + apiKey)
+                .url(UrlUtils.concatUrl(baseUrl, openAiConfig.getImageEditUrl()))
+                .post(RequestBody.create(requestString, JSON_MEDIA_TYPE))
+                .build();
+
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                return mapper.readValue(response.body().string(), ImageGenerationResponse.class);
+            }
+            throw HttpErrorDecoder.decode(response);
+        }
+    }
+
     @Override
     public ImageGenerationResponse generate(ImageGeneration imageGeneration) throws Exception {
         return this.generate(null, null, imageGeneration);

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/entity/ImageEdit.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/image/entity/ImageEdit.java
@@ -1,0 +1,72 @@
+package io.github.lnyocly.ai4j.platform.openai.image.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Singular;
+
+import java.util.List;
+
+/**
+ * 图片编辑请求（multipart/form-data 形态，OpenAI 官方标准）。
+ *
+ * <p>与 JSON 形态（{@link ImageGeneration} + image 字段数组，走网关通用扩展）相对：
+ * multipart 直接以文件字节上传参考图，不依赖网关回源拉 URL，是 OpenAI
+ * 官方文档的示例形态（官方未声明 Content-Type 限制，社区实测 multipart 稳定可用）。两者共用 {@code POST /v1/images/edits} 端点，
+ * 由 {@code Content-Type} 区分。
+ *
+ * <p>multipart 下多张参考图 = 同名 {@code image} 字段重复。
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageEdit {
+
+    /** 模型 ID，例如 gpt-image-2。 */
+    @NonNull
+    private String model;
+
+    /** 提示词（必填）。 */
+    @NonNull
+    private String prompt;
+
+    /** 输出数量（1~10）。 */
+    private Integer n;
+
+    /** 输出尺寸，例如 1024x1024 / 1536x1024 / 1024x1536。 */
+    private String size;
+
+    /** 输出质量 low / medium / high。 */
+    private String quality;
+
+    /** 输出格式 png（默认）/ jpeg / webp（GPT image 系专属）。 */
+    private String outputFormat;
+
+    /** 返回格式 url / b64_json。 */
+    private String responseFormat;
+
+    /** 参考图（一张或多张；multipart 下同名 image 字段重复）。 */
+    @Singular("image")
+    private List<ImagePart> images;
+
+    /** 可选 PNG mask（alpha 透明区 = 编辑处），尺寸须与首张参考图一致。 */
+    private ImagePart mask;
+
+    /** multipart 文件部件。 */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImagePart {
+        private byte[] data;
+        private String filename;
+        private String contentType;
+
+        public static ImagePart of(byte[] data, String filename, String contentType) {
+            return new ImagePart(data, filename, contentType);
+        }
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
@@ -17,6 +17,8 @@ public interface IImageService {
     /**
      * 图片编辑（图生图）：POST /v1/images/edits。请求体复用 ImageGeneration，
      * 参考图通过 image 字段传入（URL 或 base64 字符串数组，平台扩展 JSON 形态）。
+     * 局部重绘：extraBody("mask", urlOrBase64) 同规则传入（仅 edits 端点支持，
+     * generations+image 的方式 C 不支持 mask；实测 chat2api JSON mask 可用）。
      */
     default ImageGenerationResponse edit(String baseUrl, String apiKey, ImageGeneration imageGeneration) throws Exception {
         throw new UnsupportedOperationException("image edit is not supported by this platform service");

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
@@ -1,5 +1,6 @@
 package io.github.lnyocly.ai4j.service;
 
+import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageEdit;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGeneration;
 import io.github.lnyocly.ai4j.platform.openai.image.entity.ImageGenerationResponse;
 import io.github.lnyocly.ai4j.listener.ImageSseListener;
@@ -19,6 +20,14 @@ public interface IImageService {
      */
     default ImageGenerationResponse edit(String baseUrl, String apiKey, ImageGeneration imageGeneration) throws Exception {
         throw new UnsupportedOperationException("image edit is not supported by this platform service");
+    }
+
+    /**
+     * 图片编辑（图生图）：POST /v1/images/edits，multipart/form-data 形态
+     * （OpenAI 官方标准，文件字节直传）。JSON 形态见 {@link #edit(String, String, ImageGeneration)}。
+     */
+    default ImageGenerationResponse edit(String baseUrl, String apiKey, ImageEdit imageEdit) throws Exception {
+        throw new UnsupportedOperationException("image edit (multipart) is not supported by this platform service");
     }
 
     ImageGenerationResponse generate(ImageGeneration imageGeneration) throws Exception;

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IImageService.java
@@ -13,6 +13,14 @@ public interface IImageService {
 
     ImageGenerationResponse generate(String baseUrl, String apiKey, ImageGeneration imageGeneration) throws Exception;
 
+    /**
+     * 图片编辑（图生图）：POST /v1/images/edits。请求体复用 ImageGeneration，
+     * 参考图通过 image 字段传入（URL 或 base64 字符串数组，平台扩展 JSON 形态）。
+     */
+    default ImageGenerationResponse edit(String baseUrl, String apiKey, ImageGeneration imageGeneration) throws Exception {
+        throw new UnsupportedOperationException("image edit is not supported by this platform service");
+    }
+
     ImageGenerationResponse generate(ImageGeneration imageGeneration) throws Exception;
 
     void generateStream(String baseUrl, String apiKey, ImageGeneration imageGeneration, ImageSseListener listener) throws Exception;


### PR DESCRIPTION
## 图片编辑能力补全（图生图 / 局部重绘）

### 背景
`IImageService` 此前只有 `generate`（文生图端点）。图片编辑一直由调用方借 `generate + extraBody("image")` 模拟——发往 `/v1/images/generations` 的非标准形态，依赖各网关私有兼容（实测 chat2api 会忽略 n 只回 1 张）。

### 改动
**① JSON 形态（主用，网关通用扩展）**
- `edit(baseUrl, apiKey, ImageGeneration)` → `POST /v1/images/edits`
- image = URL/base64 字符串数组（`extraBody("image", List.of(url))`）
- **mask 局部重绘**：`extraBody("mask", urlOrBase64)`（仅 edits 端点支持）
- n 1~10 单次

**② multipart 形态（OpenAI 官方文档示例形态，文件直传）**
- `edit(baseUrl, apiKey, ImageEdit)` 新 entity：images[] 文件部件 + 可选 mask + quality/output_format
- 不依赖网关回源拉 URL；备官方直连与回源受限场景

**③ 接口设计**
- 两个 edit 均为 `default` 方法（DoubaoImageService 等其他实现不破）
- `OpenAiConfig.imageEditUrl` 可配（默认 v1/images/edits）

### 实测（chat2api / gpt-image-2）
- JSON image 数组 + presigned URL 回源 + n=4 → 精确 4 张
- JSON mask（base64，1024 PNG alpha）→ 正常出图
- multipart（SDK smoke）→ 正常返回
- zhiying 生产链路已切换：https://github.com/LnYo-Cly/zhiying-ai-studio/pull/53（图生图+多张 E2E）