### PR TITLE
feat(audio): 零样本语音克隆支持（prompt_audio_url + url 响应解析）

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioService.java
@@ -1,6 +1,7 @@
 package io.github.lnyocly.ai4j.platform.openai.audio;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import io.github.lnyocly.ai4j.config.OpenAiConfig;
 import io.github.lnyocly.ai4j.constant.Constants;
 import io.github.lnyocly.ai4j.exception.Ai4jException;
@@ -85,6 +86,47 @@ public class OpenAiAudioService implements IAudioService {
     @Override
     public InputStream textToSpeech(TextToSpeech textToSpeech) {
         return this.textToSpeech(null, null, textToSpeech);
+    }
+
+    /**
+     * response_format=url 形态：网关不回音频流而是回 JSON（含音频下载 URL），
+     * 零样本克隆（prompt_audio_url + IndexTTS 系模型）多走此形态。
+     * 宽容提取 url / audio_url / data.url / data.audio_url，提取失败抛出携带响应片段的异常。
+     */
+    @Override
+    public String textToSpeechUrl(String baseUrl, String apiKey, TextToSpeech textToSpeech) {
+        Request request = buildAuthorizedRequest(
+                baseUrl,
+                apiKey,
+                openAiConfig.getSpeechUrl(),
+                RequestBody.create(JSON.toJSONString(textToSpeech), JSON_MEDIA_TYPE)
+        );
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw HttpErrorDecoder.decode(response);
+            }
+            ResponseBody responseBody = response.body();
+            String payload = responseBody == null ? "" : responseBody.string();
+            JSONObject root = JSON.parseObject(payload);
+            String url = firstNonBlank(
+                    root == null ? null : root.getString("url"),
+                    root == null ? null : root.getString("audio_url"),
+                    root == null || root.getJSONObject("data") == null ? null : root.getJSONObject("data").getString("url"),
+                    root == null || root.getJSONObject("data") == null ? null : root.getJSONObject("data").getString("audio_url")
+            );
+            if (url == null || url.isEmpty()) {
+                throw new AiClientException(response.code(),
+                        "speech url response missing audio url: " + truncate(payload));
+            }
+            return url;
+        } catch (IOException e) {
+            throw new Ai4jException("OpenAI speech request failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String textToSpeechUrl(TextToSpeech textToSpeech) {
+        return this.textToSpeechUrl(null, null, textToSpeech);
     }
 
     @Override
@@ -179,6 +221,22 @@ public class OpenAiAudioService implements IAudioService {
         if (response != null) {
             response.close();
         }
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isEmpty()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String truncate(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.length() <= 300 ? value : value.substring(0, 300);
     }
 
     /**

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/entity/TextToSpeech.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/audio/entity/TextToSpeech.java
@@ -53,4 +53,12 @@ public class TextToSpeech {
      */
     @Builder.Default
     private Double speed = 1.0d;
+
+    /**
+     * 零样本语音克隆：参考音频的公网 URL（网关扩展字段，OpenAI 官方无此参数）。
+     * 提供后按参考音色合成；chatfire 网关配合 IndexTTS-1.5 / F5-TTS /
+     * Step-Audio-TTS-3B / CosyVoice2 等克隆模型使用。
+     */
+    @JsonProperty("prompt_audio_url")
+    private String promptAudioUrl;
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IAudioService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/IAudioService.java
@@ -14,6 +14,13 @@ public interface IAudioService {
     InputStream textToSpeech(String baseUrl, String apiKey, TextToSpeech textToSpeech);
     InputStream textToSpeech(TextToSpeech textToSpeech);
 
+    /**
+     * response_format=url 形态：返回 JSON 中的音频下载 URL 而非音频流。
+     * 零样本克隆（prompt_audio_url）走此形态。
+     */
+    String textToSpeechUrl(String baseUrl, String apiKey, TextToSpeech textToSpeech);
+    String textToSpeechUrl(TextToSpeech textToSpeech);
+
     TranscriptionResponse transcription(String baseUrl, String apiKey, Transcription transcription);
     TranscriptionResponse transcription(Transcription transcription);
 

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/openai/audio/OpenAiAudioServiceTest.java
@@ -59,6 +59,83 @@ public class OpenAiAudioServiceTest {
         Assert.assertEquals("https://unit.test/v1/audio/speech", recordedRequest.get().url().toString());
     }
 
+    @Test
+    public void test_text_to_speech_serializes_prompt_audio_url_for_voice_clone() throws Exception {
+        final AtomicReference<Request> recordedRequest = new AtomicReference<Request>();
+
+        OpenAiAudioService service = serviceWithInterceptor(chain -> {
+            recordedRequest.set(chain.request());
+            return jsonResponse("{\"url\":\"https://cdn.unit.test/a.mp3\"}");
+        });
+
+        service.textToSpeechUrl(TextToSpeech.builder()
+                .model("IndexTTS-1.5")
+                .input("克隆测试")
+                .promptAudioUrl("https://unit.test/prompt.wav")
+                .responseFormat("url")
+                .build());
+
+        okio.Buffer buffer = new okio.Buffer();
+        recordedRequest.get().body().writeTo(buffer);
+        String payload = buffer.readUtf8();
+        Assert.assertTrue("prompt_audio_url must be serialized: " + payload,
+                payload.contains("\"prompt_audio_url\":\"https://unit.test/prompt.wav\""));
+        Assert.assertTrue("response_format must stay snake_case: " + payload,
+                payload.contains("\"response_format\":\"url\""));
+        Assert.assertTrue("model must serialize: " + payload,
+                payload.contains("\"model\":\"IndexTTS-1.5\""));
+    }
+
+    @Test
+    public void test_text_to_speech_url_extracts_flat_and_nested_forms() throws Exception {
+        OpenAiAudioService service = serviceWithInterceptor(chain ->
+                jsonResponse("{\"audio_url\":\"https://cdn.unit.test/flat.mp3\"}"));
+        Assert.assertEquals("https://cdn.unit.test/flat.mp3",
+                service.textToSpeechUrl(TextToSpeech.builder().input("a").responseFormat("url").build()));
+
+        OpenAiAudioService nestedService = serviceWithInterceptor(chain ->
+                jsonResponse("{\"data\":{\"url\":\"https://cdn.unit.test/nested.mp3\"}}"));
+        Assert.assertEquals("https://cdn.unit.test/nested.mp3",
+                nestedService.textToSpeechUrl(TextToSpeech.builder().input("a").responseFormat("url").build()));
+    }
+
+    @Test
+    public void test_text_to_speech_url_fails_with_response_snippet_when_url_missing() {
+        OpenAiAudioService service = serviceWithInterceptor(chain ->
+                jsonResponse("{\"foo\":\"bar\"}"));
+        try {
+            service.textToSpeechUrl(TextToSpeech.builder().input("a").responseFormat("url").build());
+            Assert.fail("expected AiClientException");
+        } catch (io.github.lnyocly.ai4j.exception.AiClientException expected) {
+            Assert.assertTrue(expected.getMessage().contains("foo"));
+        }
+    }
+
+    private OpenAiAudioService serviceWithInterceptor(
+            okhttp3.Interceptor interceptor) {
+        OpenAiConfig openAiConfig = new OpenAiConfig();
+        openAiConfig.setApiHost("https://unit.test/");
+        openAiConfig.setApiKey("config-api-key");
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+
+        Configuration configuration = new Configuration();
+        configuration.setOpenAiConfig(openAiConfig);
+        configuration.setOkHttpClient(okHttpClient);
+
+        return new OpenAiAudioService(configuration);
+    }
+
+    private static Response jsonResponse(String body) {
+        return new Response.Builder()
+                .request(new Request.Builder().url("https://unit.test/v1/audio/speech").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create(body, MediaType.get("application/json")))
+                .build();
+    }
+
     private static byte[] readAll(InputStream inputStream) throws Exception {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         byte[] buffer = new byte[256];


### PR DESCRIPTION
## 背景
chatfire 网关语音克隆（IndexTTS-1.5 / F5-TTS / Step-Audio-TTS-3B / CosyVoice2）走 `/v1/audio/speech` + `prompt_audio_url`（参考音频公网 URL）+ `response_format:"url"`（返回 JSON 而非音频流）。

## 改动
- `TextToSpeech` 增加 `promptAudioUrl`（序列化为 `prompt_audio_url` 网关扩展字段，NON_NULL 向后兼容）
- `IAudioService`/`OpenAiAudioService` 新增 `textToSpeechUrl`：宽容提取 url / audio_url / data.url / data.audio_url，缺 URL 抛携带响应片段的 AiClientException
- 单测 4/4 绿（克隆字段序列化、扁平/嵌套提取、缺 URL 报错），模块 325 全绿

注：chatfire speech 上游（rix）当前故障（tts-1 也 500 Python 报错），API 形态按官方文档实现，渠道恢复后实测校准。