### PR TITLE
fix(okhttp): readTimeout 300s → 600s（本地 TTS 慢生成不被掐断）

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OkHttpConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/OkHttpConfig.java
@@ -18,7 +18,7 @@ public class OkHttpConfig {
     private HttpLoggingInterceptor.Level log = HttpLoggingInterceptor.Level.HEADERS;
     private int connectTimeout = 300;
     private int writeTimeout = 300;
-    private int readTimeout = 300;
+    private int readTimeout = 600;
     private int proxyPort = 10809;
     private String proxyHost = "";
 


### PR DESCRIPTION
实测本地 Chatterbox CPU 推理（RTF≈13）在 8s 台词上生成 110-300s+，300s 默认 readTimeout 触发 Socket closed → provider_outcome_unknown。600s 覆盖本地推理最长场景，慢图片生成同样受益。