### PR TITLE
feat(minimax): Hailuo 视频生成服务

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/MinimaxConfig.java
@@ -23,4 +23,19 @@ public class MinimaxConfig {
     private String apiHost = "https://api.minimaxi.com/";
     private String apiKey = "";
     private String chatCompletionUrl = "v1/chat/completions";
+
+    /**
+     * Hailuo 视频网关。视频 API 与 chat 网关不同域（私有协议 {@code api.minimax.chat}，
+     * 非 OpenAI 兼容），故独立配置 host；为空时回退 {@link #apiHost}。
+     */
+    private String videoApiHost = "https://api.minimax.chat";
+
+    /** 视频网关 key（api.minimax.chat 平台 key）。为空时回退 {@link #apiKey}。 */
+    private String videoApiKey = "";
+
+    private String videoCreateUrl = "v1/video_generation";
+
+    private String videoQueryUrl = "v1/query/video_generation";
+
+    private String fileRetrieveUrl = "v1/files/retrieve";
 }

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/MinimaxVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/MinimaxVideoService.java
@@ -1,0 +1,246 @@
+package io.github.lnyocly.ai4j.platform.minimax.video;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.config.MinimaxConfig;
+import io.github.lnyocly.ai4j.constant.Constants;
+import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
+import io.github.lnyocly.ai4j.network.UrlUtils;
+import io.github.lnyocly.ai4j.platform.minimax.video.entity.MinimaxFileResponse;
+import io.github.lnyocly.ai4j.platform.minimax.video.entity.MinimaxVideoRequest;
+import io.github.lnyocly.ai4j.platform.minimax.video.entity.MinimaxVideoResponse;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IVideoService;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * MiniMax Hailuo 视频生成服务（私有协议，非 OpenAI 兼容，故不继承
+ * {@code AbstractVideoService}）。
+ *
+ * <p>流程：POST video_generation 拿 task_id → 轮询 query/video_generation →
+ * Success 后经 files/retrieve 换取 download_url。MiniMax 失败也返回 HTTP 200，
+ * 错误藏在 base_resp.status_code != 0，需映射进 {@code VideoResponse.error}。
+ */
+public class MinimaxVideoService implements IVideoService {
+
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
+    private static final String STATUS_SUCCESS = "Success";
+    private static final String STATUS_FAIL = "Fail";
+
+    private final MinimaxConfig minimaxConfig;
+    private final OkHttpClient okHttpClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public MinimaxVideoService(Configuration configuration) {
+        this.minimaxConfig = configuration.getMinimaxConfig();
+        this.okHttpClient = configuration.getOkHttpClient();
+    }
+
+    @Override
+    public VideoResponse create(String baseUrl, String apiKey, VideoCreateRequest request) throws Exception {
+        Map<String, Object> body = mapper.convertValue(toMinimaxRequest(request),
+                new TypeReference<Map<String, Object>>() { });
+        if (request.getExtraFields() != null) {
+            for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
+                if (entry.getValue() != null) {
+                    body.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        Request httpRequest = authorizedRequest(baseUrl, apiKey, minimaxConfig.getVideoCreateUrl())
+                .post(RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE))
+                .build();
+        try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+            MinimaxVideoResponse minimaxResponse = parse(response, MinimaxVideoResponse.class);
+            return toVideoResponse(minimaxResponse, null);
+        }
+    }
+
+    @Override
+    public VideoResponse create(VideoCreateRequest request) throws Exception {
+        return create(null, null, request);
+    }
+
+    @Override
+    public VideoResponse retrieve(String baseUrl, String apiKey, String id) throws Exception {
+        String url = UrlUtils.concatUrl(resolveBaseUrl(baseUrl), minimaxConfig.getVideoQueryUrl())
+                + "?task_id=" + encode(id);
+        Request httpRequest = authorizedUrlRequest(baseUrl, apiKey, url).get().build();
+        MinimaxVideoResponse minimaxResponse;
+        try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+            minimaxResponse = parse(response, MinimaxVideoResponse.class);
+        }
+
+        String downloadUrl = null;
+        if (STATUS_SUCCESS.equals(minimaxResponse.getStatus()) && minimaxResponse.getFileId() != null) {
+            downloadUrl = retrieveDownloadUrl(baseUrl, apiKey, minimaxResponse.getFileId());
+        }
+        return toVideoResponse(minimaxResponse, downloadUrl);
+    }
+
+    @Override
+    public VideoResponse retrieve(String id) throws Exception {
+        return retrieve(null, null, id);
+    }
+
+    @Override
+    public InputStream content(String baseUrl, String apiKey, String id) throws Exception {
+        VideoResponse response = retrieve(baseUrl, apiKey, id);
+        if (response.getVideoUrl() == null) {
+            throw new CommonException("Minimax 视频 " + id + " 尚无下载地址，当前状态: " + response.getStatus());
+        }
+        Request request = new Request.Builder().url(response.getVideoUrl()).get().build();
+        Response download = okHttpClient.newCall(request).execute();
+        if (!download.isSuccessful() || download.body() == null) {
+            try {
+                throw HttpErrorDecoder.decode(download);
+            } finally {
+                download.close();
+            }
+        }
+        return new ResponseInputStream(download, download.body().byteStream());
+    }
+
+    @Override
+    public InputStream content(String id) throws Exception {
+        return content(null, null, id);
+    }
+
+    @Override
+    public VideoResponse remix(String baseUrl, String apiKey, String id, String prompt) {
+        throw new UnsupportedOperationException("MiniMax Hailuo 视频不支持 remix");
+    }
+
+    @Override
+    public VideoResponse remix(String id, String prompt) {
+        throw new UnsupportedOperationException("MiniMax Hailuo 视频不支持 remix");
+    }
+
+    private MinimaxVideoRequest toMinimaxRequest(VideoCreateRequest request) {
+        return MinimaxVideoRequest.builder()
+                .model(request.getModel())
+                .prompt(request.getPrompt())
+                .firstFrameImage(request.getInputImage())
+                // 实测协议默认关掉提示词增强，避免平台改写用户提示词
+                .promptEnhance(Boolean.FALSE)
+                .build();
+    }
+
+    private String retrieveDownloadUrl(String baseUrl, String apiKey, String fileId) throws Exception {
+        String url = UrlUtils.concatUrl(resolveBaseUrl(baseUrl), minimaxConfig.getFileRetrieveUrl())
+                + "?file_id=" + encode(fileId);
+        Request httpRequest = authorizedUrlRequest(baseUrl, apiKey, url).get().build();
+        try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+            MinimaxFileResponse fileResponse = parse(response, MinimaxFileResponse.class);
+            if (fileResponse.getFile() == null || fileResponse.getFile().getDownloadUrl() == null) {
+                throw new CommonException("Minimax files/retrieve 未返回 download_url，file_id=" + fileId);
+            }
+            return fileResponse.getFile().getDownloadUrl();
+        }
+    }
+
+    private VideoResponse toVideoResponse(MinimaxVideoResponse minimaxResponse, String downloadUrl) {
+        VideoResponse response = new VideoResponse();
+        response.setId(minimaxResponse.getTaskId());
+        response.setStatus(mapStatus(minimaxResponse.getStatus()));
+        if (minimaxResponse.getVideoWidth() != null && minimaxResponse.getVideoHeight() != null) {
+            response.setSize(minimaxResponse.getVideoWidth() + "x" + minimaxResponse.getVideoHeight());
+        }
+        response.setVideoUrl(downloadUrl);
+        response.setRaw(mapper.convertValue(minimaxResponse, new TypeReference<Map<String, Object>>() { }));
+
+        MinimaxVideoResponse.BaseResp baseResp = minimaxResponse.getBaseResp();
+        if (baseResp != null && baseResp.getStatusCode() != null && baseResp.getStatusCode() != 0) {
+            VideoResponse.VideoError error = new VideoResponse.VideoError();
+            error.setCode(String.valueOf(baseResp.getStatusCode()));
+            error.setMessage(baseResp.getStatusMsg());
+            response.setError(error);
+            response.setStatus("failed");
+        }
+        return response;
+    }
+
+    /** Preparing/Processing → processing，Success → succeeded，Fail → failed，其余原样小写。 */
+    private String mapStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        if (STATUS_SUCCESS.equals(status)) {
+            return "succeeded";
+        }
+        if (STATUS_FAIL.equals(status)) {
+            return "failed";
+        }
+        return status.toLowerCase(Locale.ROOT);
+    }
+
+    private <T> T parse(Response response, Class<T> type) throws IOException {
+        if (response.isSuccessful() && response.body() != null) {
+            return mapper.readValue(response.body().string(), type);
+        }
+        throw HttpErrorDecoder.decode(response);
+    }
+
+    private Request.Builder authorizedRequest(String baseUrl, String apiKey, String path) {
+        return authorizedUrlRequest(baseUrl, apiKey,
+                UrlUtils.concatUrl(resolveBaseUrl(baseUrl), path));
+    }
+
+    private Request.Builder authorizedUrlRequest(String baseUrl, String apiKey, String url) {
+        return new Request.Builder()
+                .header("Authorization", "Bearer " + resolveApiKey(apiKey))
+                .url(url);
+    }
+
+    private String resolveBaseUrl(String baseUrl) {
+        if (baseUrl != null && !baseUrl.isEmpty()) {
+            return baseUrl;
+        }
+        String host = minimaxConfig.getVideoApiHost();
+        return (host == null || host.isEmpty()) ? minimaxConfig.getApiHost() : host;
+    }
+
+    private String resolveApiKey(String apiKey) {
+        if (apiKey != null && !apiKey.isEmpty()) {
+            return apiKey;
+        }
+        String key = minimaxConfig.getVideoApiKey();
+        return (key == null || key.isEmpty()) ? minimaxConfig.getApiKey() : key;
+    }
+
+    private static String encode(String value) throws IOException {
+        return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+    }
+
+    private static final class ResponseInputStream extends FilterInputStream {
+        private final Response response;
+
+        private ResponseInputStream(Response response, InputStream delegate) {
+            super(delegate);
+            this.response = response;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                response.close();
+            }
+        }
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxFileResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxFileResponse.java
@@ -1,0 +1,38 @@
+package io.github.lnyocly.ai4j.platform.minimax.video.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * GET v1/files/retrieve?file_id=xxx 响应，成功任务经此换取 download_url。
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MinimaxFileResponse {
+    private MinimaxFile file;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MinimaxFile {
+        /** 轮询响应里是字符串，本接口返回数字，Jackson 均可反序列化为 String。 */
+        @JsonProperty("file_id")
+        private String fileId;
+
+        @JsonProperty("download_url")
+        private String downloadUrl;
+
+        private String filename;
+        private Long bytes;
+        private String purpose;
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxVideoRequest.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxVideoRequest.java
@@ -1,0 +1,34 @@
+package io.github.lnyocly.ai4j.platform.minimax.video.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Hailuo 视频生成请求体（POST v1/video_generation）。
+ *
+ * <p>Vendor-only 参数（duration、resolution 等）不在此枚举，经
+ * {@code VideoCreateRequest.extraFields} 原样合并进请求体。
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MinimaxVideoRequest {
+    private String model;
+
+    private String prompt;
+
+    /** 图生视频首帧（URL 或 data URL）。 */
+    @JsonProperty("first_frame_image")
+    private String firstFrameImage;
+
+    @JsonProperty("promptenhance")
+    private Boolean promptEnhance;
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxVideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/minimax/video/entity/MinimaxVideoResponse.java
@@ -1,0 +1,51 @@
+package io.github.lnyocly.ai4j.platform.minimax.video.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Hailuo 视频任务响应（创建与轮询共用）。
+ *
+ * <p>MiniMax 失败时仍返回 HTTP 200，错误藏在 {@code base_resp.status_code != 0}。
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MinimaxVideoResponse {
+    @JsonProperty("task_id")
+    private String taskId;
+
+    /** {@code Preparing | Processing | Success | Fail} */
+    private String status;
+
+    @JsonProperty("file_id")
+    private String fileId;
+
+    @JsonProperty("video_width")
+    private Integer videoWidth;
+
+    @JsonProperty("video_height")
+    private Integer videoHeight;
+
+    @JsonProperty("base_resp")
+    private BaseResp baseResp;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BaseResp {
+        @JsonProperty("status_code")
+        private Integer statusCode;
+
+        @JsonProperty("status_msg")
+        private String statusMsg;
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
@@ -230,6 +230,8 @@ public class AiService {
                 return new OpenAiVideoService(configuration);
             case GROK:
                 return new GrokVideoService(configuration);
+            case MINIMAX:
+                return new io.github.lnyocly.ai4j.platform.minimax.video.MinimaxVideoService(configuration);
             default:
                 throw new IllegalArgumentException("No video service for platform: " + platform);
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/minimax/video/MinimaxVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/minimax/video/MinimaxVideoServiceTest.java
@@ -1,0 +1,230 @@
+package io.github.lnyocly.ai4j.platform.minimax.video;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.config.MinimaxConfig;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+public class MinimaxVideoServiceTest {
+
+    @Test
+    public void test_create_posts_minimax_dialect_body() throws Exception {
+        MockWebServer server = new MockWebServer();
+        // Live shape (verified 2026-08-25): HTTP 200 + task_id + base_resp.
+        server.enqueue(jsonResponse("{\"task_id\":\"435016732930334\",\"base_resp\":{\"status_code\":0,\"status_msg\":\"success\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            VideoResponse response = service.create(VideoCreateRequest.builder()
+                    .model("MiniMax-Hailuo-2.3")
+                    .prompt("一只猫在月光下奔跑")
+                    .inputImage("https://cdn.example/first.png")
+                    .build());
+
+            Assert.assertEquals("435016732930334", response.getTaskId());
+            Assert.assertNull(response.getError());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(request);
+            Assert.assertEquals("/v1/video_generation", request.getPath());
+            Assert.assertEquals("Bearer test-key", request.getHeader("Authorization"));
+            Assert.assertTrue(request.getHeader("Content-Type").startsWith("application/json"));
+            JSONObject body = JSON.parseObject(request.getBody().readUtf8());
+            Assert.assertEquals("MiniMax-Hailuo-2.3", body.getString("model"));
+            Assert.assertEquals("一只猫在月光下奔跑", body.getString("prompt"));
+            Assert.assertEquals("https://cdn.example/first.png", body.getString("first_frame_image"));
+            Assert.assertEquals(Boolean.FALSE, body.getBoolean("promptenhance"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_merges_extra_fields_for_vendor_params() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"task_id\":\"t-1\",\"base_resp\":{\"status_code\":0,\"status_msg\":\"success\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            java.util.Map<String, Object> extra = new java.util.LinkedHashMap<String, Object>();
+            extra.put("promptenhance", Boolean.TRUE);
+            extra.put("duration", 6);
+            service.create(VideoCreateRequest.builder()
+                    .model("MiniMax-Hailuo-2.3")
+                    .prompt("p")
+                    .extraFields(extra)
+                    .build());
+
+            JSONObject body = JSON.parseObject(server.takeRequest(1, TimeUnit.SECONDS).getBody().readUtf8());
+            Assert.assertEquals(Boolean.TRUE, body.getBoolean("promptenhance"));
+            Assert.assertEquals(Integer.valueOf(6), body.getInteger("duration"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_surfaces_base_resp_error_returned_with_http_200() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"base_resp\":{\"status_code\":1004,\"status_msg\":\"invalid api key\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            VideoResponse response = service.create(VideoCreateRequest.builder()
+                    .model("MiniMax-Hailuo-2.3")
+                    .prompt("p")
+                    .build());
+
+            Assert.assertEquals("failed", response.getStatus());
+            Assert.assertEquals("1004", response.getError().getCode());
+            Assert.assertEquals("invalid api key", response.getErrorMessage());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_processing_maps_status_and_skips_file_lookup() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"task_id\":\"t-1\",\"status\":\"Processing\",\"base_resp\":{\"status_code\":0,\"status_msg\":\"\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            VideoResponse response = service.retrieve("t-1");
+
+            Assert.assertEquals("processing", response.getStatus());
+            Assert.assertNull(response.getVideoUrl());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/v1/query/video_generation?task_id=t-1", request.getPath());
+            // 未成功时不应触发 files/retrieve
+            Assert.assertNull(server.takeRequest(1, TimeUnit.SECONDS));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_success_resolves_download_url_via_files_retrieve() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"task_id\":\"t-1\",\"status\":\"Success\",\"file_id\":\"123\",\"video_width\":1366,\"video_height\":768,\"base_resp\":{\"status_code\":0,\"status_msg\":\"success\"}}"));
+        server.enqueue(jsonResponse(
+                "{\"file\":{\"file_id\":123,\"download_url\":\"https://public-cdn.example.com/output_aigc.mp4\",\"filename\":\"output_aigc.mp4\",\"bytes\":0,\"purpose\":\"video_generation\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            VideoResponse response = service.retrieve("t-1");
+
+            Assert.assertEquals("succeeded", response.getStatus());
+            Assert.assertEquals("https://public-cdn.example.com/output_aigc.mp4", response.getVideoUrl());
+            Assert.assertEquals("1366x768", response.getSize());
+            Assert.assertEquals("t-1", response.getRaw().get("task_id"));
+
+            server.takeRequest(1, TimeUnit.SECONDS);
+            RecordedRequest fileRequest = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/v1/files/retrieve?file_id=123", fileRequest.getPath());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_fail_maps_status_and_error_message() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"task_id\":\"t-1\",\"status\":\"Fail\",\"base_resp\":{\"status_code\":3001,\"status_msg\":\"content policy violation\"}}"));
+        server.start();
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            VideoResponse response = service.retrieve("t-1");
+
+            Assert.assertEquals("failed", response.getStatus());
+            Assert.assertNull(response.getVideoUrl());
+            Assert.assertEquals("3001", response.getError().getCode());
+            Assert.assertEquals("content policy violation", response.getErrorMessage());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_content_downloads_video_stream() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        server.enqueue(jsonResponse(
+                "{\"task_id\":\"t-1\",\"status\":\"Success\",\"file_id\":\"123\",\"base_resp\":{\"status_code\":0,\"status_msg\":\"success\"}}"));
+        server.enqueue(jsonResponse(
+                "{\"file\":{\"file_id\":123,\"download_url\":\"" + server.url("/download.mp4") + "\"}}"));
+        byte[] expected = "fake-hailuo-video".getBytes(StandardCharsets.UTF_8);
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "video/mp4")
+                .setBody(new okio.Buffer().write(expected)));
+        try {
+            MinimaxVideoService service = new MinimaxVideoService(configuration(server));
+            byte[] actual;
+            try (InputStream stream = service.content("t-1")) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[256];
+                int read;
+                while ((read = stream.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                actual = out.toByteArray();
+            }
+            Assert.assertArrayEquals(expected, actual);
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_remix_is_unsupported() {
+        MinimaxConfig minimaxConfig = new MinimaxConfig();
+        minimaxConfig.setVideoApiHost("https://api.minimax.chat");
+        Configuration configuration = new Configuration();
+        configuration.setMinimaxConfig(minimaxConfig);
+        configuration.setOkHttpClient(new OkHttpClient());
+        MinimaxVideoService service = new MinimaxVideoService(configuration);
+        try {
+            service.remix("t-1", "p");
+            Assert.fail("expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            // MiniMax 无 remix 端点
+        }
+    }
+
+    private static Configuration configuration(MockWebServer server) {
+        MinimaxConfig minimaxConfig = new MinimaxConfig();
+        minimaxConfig.setApiHost("https://api.minimaxi.com/");
+        minimaxConfig.setApiKey("chat-key");
+        minimaxConfig.setVideoApiHost(server.url("/").toString());
+        minimaxConfig.setVideoApiKey("test-key");
+
+        Configuration configuration = new Configuration();
+        configuration.setMinimaxConfig(minimaxConfig);
+        configuration.setOkHttpClient(new OkHttpClient());
+        return configuration;
+    }
+
+    private static MockResponse jsonResponse(String body) {
+        return new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(body);
+    }
+}


### PR DESCRIPTION
## 摘要

为 MiniMax Hailuo（MiniMax-Hailuo-2.3）新增视频生成渠道，走私有协议（`task_id` + `base_resp`，非 OpenAI 兼容），故独立实现 `IVideoService` 而非继承 `AbstractVideoService`。

## 协议链路（2026-08-25 实测）

1. `POST v1/video_generation` → `task_id`
2. `GET v1/query/video_generation?task_id=` → status `Preparing|Processing|Success|Fail`
3. 成功后 `GET v1/files/retrieve?file_id=` → `download_url`

## IVideoService 方法映射

| 方法 | 行为 |
|---|---|
| `create` | POST video_generation；`inputImage`→`first_frame_image`，`promptenhance` 默认 false；`extraFields` 原样合并（duration/resolution 等）；`task_id`→`id` |
| `retrieve` | 轮询 query；Preparing/Processing→`processing`、Success→`succeeded`、Fail→`failed`；成功时自动调 files/retrieve 填 `videoUrl`，宽高拼成 `1366x768` 形式 `size` |
| `content` | retrieve 拿到 download_url 后下载为 InputStream |
| `remix` | 抛 `UnsupportedOperationException`（MiniMax 无此端点） |

## 错误处理

MiniMax 失败也返回 HTTP 200，错误在 `base_resp.status_code != 0`——已映射进 `VideoResponse.error`（code/status_msg），同时 status 置 `failed`。

## 配置

`MinimaxConfig` 新增：`videoApiHost`（默认 `https://api.minimax.chat`，视频域与 chat 网关不同域）、`videoApiKey`（空则回退 `apiKey`）、`videoCreateUrl`/`videoQueryUrl`/`fileRetrieveUrl` 三个路径。注册于 `AiService.createVideoService` 的 `MINIMAX` 分支。

## 测试

`MinimaxVideoServiceTest` 8 例（MockWebServer）：创建方言体、extraFields 合并、base_resp 错误映射、processing 不触发 files/retrieve、成功换 download_url、Fail 映射、content 字节流下载、remix 不支持。全绿；既有 OpenAI/Grok video 与 MiniMax chat 测试无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)