### PR TITLE
feat(doubao): Seedance 视频生成服务——Ark 任务协议 content 数组 + 轮询

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/config/DoubaoConfig.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/config/DoubaoConfig.java
@@ -21,5 +21,20 @@ public class DoubaoConfig {
     private String responsesUrl = "responses";
     private String rerankApiHost = "https://api-knowledgebase.mlp.cn-beijing.volces.com/";
     private String rerankUrl = "api/knowledge/service/rerank";
+
+    /**
+     * Seedance 视频网关根地址（含 /api/v3 前缀由路径承担）。默认空：调用方经
+     * {@code IVideoService.create(baseUrl, ...)} 传入网关 baseUrl；为空且未传参时回退 Ark 官方根
+     * （不回退 {@link #apiHost}，其默认值已含 /api/v3/ 段，直接拼接会重复）。
+     */
+    private String videoApiHost = "";
+
+    /** 视频网关 key。为空时回退 {@link #apiKey}。 */
+    private String videoApiKey = "";
+
+    private String videoCreatePath = "api/v3/contents/generations/tasks";
+
+    /** 轮询路径：GET 同路径 + /{task_id}。 */
+    private String videoQueryPath = "api/v3/contents/generations/tasks";
 }
 

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
@@ -1,0 +1,270 @@
+package io.github.lnyocly.ai4j.platform.doubao.video;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.lnyocly.ai4j.config.DoubaoConfig;
+import io.github.lnyocly.ai4j.constant.Constants;
+import io.github.lnyocly.ai4j.exception.CommonException;
+import io.github.lnyocly.ai4j.exception.HttpErrorDecoder;
+import io.github.lnyocly.ai4j.network.UrlUtils;
+import io.github.lnyocly.ai4j.platform.doubao.video.entity.SeedanceVideoResponse;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import io.github.lnyocly.ai4j.service.IVideoService;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 火山引擎 Seedance（doubao-seedance 系列）视频生成服务。私有任务协议
+ * （task_id 在 {@code id} 字段、视频地址嵌套在 {@code content.video_url}），与 OpenAI
+ * 响应格式不同，故不继承 {@code AbstractVideoService}。
+ *
+ * <p>流程：POST {@code api/v3/contents/generations/tasks} 建任务 → 轮询
+ * GET 同路径 {@code /{task_id}} 直到 succeeded，取 {@code content.video_url}。
+ *
+ * <p>模型版本差异（1.5 / 2.0 / 2.5）只是可选参数与 image role 的增减——last_frame、
+ * reference_image、generate_audio、seed 由调用方按模型能力放进请求，本服务不做版本分支。
+ */
+public class SeedanceVideoService implements IVideoService {
+
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
+    /** chat 网关 {@link DoubaoConfig#getApiHost()} 默认已含 /api/v3/ 段，直接回退会和路径拼重，故回退到 Ark 根。 */
+    private static final String ARK_ROOT = "https://ark.cn-beijing.volces.com/";
+
+    private final DoubaoConfig doubaoConfig;
+    private final OkHttpClient okHttpClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public SeedanceVideoService(Configuration configuration) {
+        this.doubaoConfig = configuration.getDoubaoConfig();
+        this.okHttpClient = configuration.getOkHttpClient();
+    }
+
+    @Override
+    public VideoResponse create(String baseUrl, String apiKey, VideoCreateRequest request) throws Exception {
+        Map<String, Object> body = toJsonBody(request);
+        Request httpRequest = new Request.Builder()
+                .header("Authorization", "Bearer " + resolveApiKey(apiKey))
+                .url(UrlUtils.concatUrl(resolveBaseUrl(baseUrl), doubaoConfig.getVideoCreatePath()))
+                .post(RequestBody.create(mapper.writeValueAsString(body), JSON_MEDIA_TYPE))
+                .build();
+        try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+            return toVideoResponse(parse(response));
+        }
+    }
+
+    @Override
+    public VideoResponse create(VideoCreateRequest request) throws Exception {
+        return create(null, null, request);
+    }
+
+    @Override
+    public VideoResponse retrieve(String baseUrl, String apiKey, String id) throws Exception {
+        String url = UrlUtils.concatUrl(resolveBaseUrl(baseUrl), doubaoConfig.getVideoQueryPath())
+                + "/" + encode(id);
+        Request httpRequest = new Request.Builder()
+                .header("Authorization", "Bearer " + resolveApiKey(apiKey))
+                .url(url)
+                .get()
+                .build();
+        try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+            return toVideoResponse(parse(response));
+        }
+    }
+
+    @Override
+    public VideoResponse retrieve(String id) throws Exception {
+        return retrieve(null, null, id);
+    }
+
+    @Override
+    public InputStream content(String baseUrl, String apiKey, String id) throws Exception {
+        VideoResponse response = retrieve(baseUrl, apiKey, id);
+        if (response.getVideoUrl() == null) {
+            throw new CommonException("Seedance 视频 " + id + " 尚无下载地址，当前状态: " + response.getStatus());
+        }
+        Request request = new Request.Builder().url(response.getVideoUrl()).get().build();
+        Response download = okHttpClient.newCall(request).execute();
+        if (!download.isSuccessful() || download.body() == null) {
+            try {
+                throw HttpErrorDecoder.decode(download);
+            } finally {
+                download.close();
+            }
+        }
+        return new ResponseInputStream(download, download.body().byteStream());
+    }
+
+    @Override
+    public InputStream content(String id) throws Exception {
+        return content(null, null, id);
+    }
+
+    @Override
+    public VideoResponse remix(String baseUrl, String apiKey, String id, String prompt) {
+        throw new UnsupportedOperationException("Seedance 视频不支持 remix");
+    }
+
+    @Override
+    public VideoResponse remix(String id, String prompt) {
+        throw new UnsupportedOperationException("Seedance 视频不支持 remix");
+    }
+
+    private Map<String, Object> toJsonBody(VideoCreateRequest request) {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        body.put("model", request.getModel());
+        body.put("content", toContent(request));
+        if (request.getDurationSeconds() != null) {
+            body.put("duration", request.getDurationSeconds());
+        } else if (request.getSeconds() instanceof Number) {
+            body.put("duration", ((Number) request.getSeconds()).intValue());
+        }
+        putIfPresent(body, "resolution", request.getResolution());
+        putIfPresent(body, "ratio", request.getAspectRatio());
+        if (request.getExtraFields() != null) {
+            for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
+                // last_frame_url 已在 content 数组里以 role=last_frame 消费，不进顶层
+                if (entry.getValue() != null && !"last_frame_url".equals(entry.getKey())) {
+                    body.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return body;
+    }
+
+    /** content 数组：text 在前，随后 first_frame / reference_image / last_frame 图片项。 */
+    private List<Object> toContent(VideoCreateRequest request) {
+        List<Object> content = new ArrayList<Object>();
+        if (request.getPrompt() != null) {
+            Map<String, Object> text = new LinkedHashMap<String, Object>();
+            text.put("type", "text");
+            text.put("text", request.getPrompt());
+            content.add(text);
+        }
+        if (request.getInputImage() != null) {
+            content.add(imageItem(request.getInputImage(), "first_frame"));
+        }
+        if (request.getReferenceImages() != null) {
+            for (String image : request.getReferenceImages()) {
+                content.add(imageItem(image, "reference_image"));
+            }
+        }
+        Object lastFrame = request.getExtraFields() == null ? null : request.getExtraFields().get("last_frame_url");
+        if (lastFrame instanceof String && !((String) lastFrame).isEmpty()) {
+            content.add(imageItem((String) lastFrame, "last_frame"));
+        }
+        return content;
+    }
+
+    private static Map<String, Object> imageItem(String url, String role) {
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("type", "image_url");
+        item.put("image_url", Collections.singletonMap("url", url));
+        item.put("role", role);
+        return item;
+    }
+
+    private VideoResponse toVideoResponse(SeedanceVideoResponse seedance) {
+        VideoResponse response = new VideoResponse();
+        response.setId(seedance.taskId());
+        response.setStatus(mapStatus(seedance.getStatus()));
+        response.setModel(seedance.getModel());
+        if (seedance.getContent() != null) {
+            response.setVideoUrl(seedance.getContent().getVideoUrl());
+        }
+        response.setRaw(mapper.convertValue(seedance, new TypeReference<Map<String, Object>>() { }));
+        if (seedance.getError() != null) {
+            VideoResponse.VideoError error = new VideoResponse.VideoError();
+            error.setCode(String.valueOf(seedance.getError().getCode()));
+            error.setMessage(seedance.getError().getMessage());
+            response.setError(error);
+        }
+        return response;
+    }
+
+    /** queued → SUBMITTED，processing → RUNNING，succeeded → SUCCEEDED，failed → FAILED。 */
+    private String mapStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        switch (status) {
+            case "queued":
+                return "SUBMITTED";
+            case "processing":
+                return "RUNNING";
+            case "succeeded":
+                return "SUCCEEDED";
+            case "failed":
+                return "FAILED";
+            default:
+                return status.toUpperCase(java.util.Locale.ROOT);
+        }
+    }
+
+    private SeedanceVideoResponse parse(Response response) throws IOException {
+        if (response.isSuccessful() && response.body() != null) {
+            return mapper.readValue(response.body().string(), SeedanceVideoResponse.class);
+        }
+        throw HttpErrorDecoder.decode(response);
+    }
+
+    private static void putIfPresent(Map<String, Object> body, String key, Object value) {
+        if (value != null) {
+            body.put(key, value);
+        }
+    }
+
+    private String resolveBaseUrl(String baseUrl) {
+        if (baseUrl != null && !baseUrl.isEmpty()) {
+            return baseUrl;
+        }
+        if (doubaoConfig.getVideoApiHost() != null && !doubaoConfig.getVideoApiHost().isEmpty()) {
+            return doubaoConfig.getVideoApiHost();
+        }
+        return ARK_ROOT;
+    }
+
+    private String resolveApiKey(String apiKey) {
+        if (apiKey != null && !apiKey.isEmpty()) {
+            return apiKey;
+        }
+        String key = doubaoConfig.getVideoApiKey();
+        return (key == null || key.isEmpty()) ? doubaoConfig.getApiKey() : key;
+    }
+
+    private static String encode(String value) throws IOException {
+        return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+    }
+
+    private static final class ResponseInputStream extends FilterInputStream {
+        private final Response response;
+
+        private ResponseInputStream(Response response, InputStream delegate) {
+            super(delegate);
+            this.response = response;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                response.close();
+            }
+        }
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/entity/SeedanceVideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/entity/SeedanceVideoResponse.java
@@ -1,0 +1,60 @@
+package io.github.lnyocly.ai4j.platform.doubao.video.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Seedance 视频任务响应（创建与轮询共用）。
+ *
+ * <p>创建返回 {@code id}/{@code task_id}（同值）；轮询返回 {@code status} 与嵌套的
+ * {@code content.video_url}，失败任务携带顶层 {@code error}。
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SeedanceVideoResponse {
+    private String id;
+
+    @JsonProperty("task_id")
+    private String taskId;
+
+    /** {@code queued | processing | succeeded | failed} */
+    private String status;
+
+    private String model;
+
+    private Content content;
+
+    private TaskError error;
+
+    /** 任务 id：创建响应两个字段同值，任取其一。 */
+    public String taskId() {
+        return id != null && !id.isEmpty() ? id : taskId;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Content {
+        @JsonProperty("video_url")
+        private String videoUrl;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TaskError {
+        private Object code;
+        private String message;
+    }
+}

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/service/factory/AiService.java
@@ -232,6 +232,8 @@ public class AiService {
                 return new GrokVideoService(configuration);
             case MINIMAX:
                 return new io.github.lnyocly.ai4j.platform.minimax.video.MinimaxVideoService(configuration);
+            case DOUBAO:
+                return new io.github.lnyocly.ai4j.platform.doubao.video.SeedanceVideoService(configuration);
             default:
                 throw new IllegalArgumentException("No video service for platform: " + platform);
         }

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/rerank/DoubaoRerankServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/rerank/DoubaoRerankServiceTest.java
@@ -43,7 +43,11 @@ public class DoubaoRerankServiceTest {
                     "images/generations",
                     "responses",
                     "http://127.0.0.1:" + server.getAddress().getPort(),
-                    "api/knowledge/service/rerank"
+                    "api/knowledge/service/rerank",
+                    "",
+                    "",
+                    "api/v3/contents/generations/tasks",
+                    "api/v3/contents/generations/tasks"
             ));
 
             DoubaoRerankService service = new DoubaoRerankService(configuration);

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
@@ -1,0 +1,323 @@
+package io.github.lnyocly.ai4j.platform.doubao.video;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import io.github.lnyocly.ai4j.config.DoubaoConfig;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoCreateRequest;
+import io.github.lnyocly.ai4j.platform.openai.video.entity.VideoResponse;
+import io.github.lnyocly.ai4j.service.Configuration;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class SeedanceVideoServiceTest {
+
+    @Test
+    public void test_create_posts_seedance_dialect_body() throws Exception {
+        MockWebServer server = new MockWebServer();
+        // Live shape (verified 2026-08-27 via notoken.pro gateway): id/task_id + queued.
+        server.enqueue(jsonResponse("{\"id\":\"cgt-1\",\"task_id\":\"cgt-1\",\"status\":\"queued\",\"model\":\"seedance-2.0-mini\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            VideoResponse response = service.create(VideoCreateRequest.builder()
+                    .model("seedance-2.0-mini")
+                    .prompt("一只猫在月光下奔跑")
+                    .inputImage("https://cdn.example/first.png")
+                    .durationSeconds(4)
+                    .resolution("480p")
+                    .aspectRatio("16:9")
+                    .build());
+
+            Assert.assertEquals("cgt-1", response.getTaskId());
+            Assert.assertEquals("SUBMITTED", response.getStatus());
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertNotNull(request);
+            Assert.assertEquals("/api/v3/contents/generations/tasks", request.getPath());
+            Assert.assertEquals("Bearer test-key", request.getHeader("Authorization"));
+            Assert.assertTrue(request.getHeader("Content-Type").startsWith("application/json"));
+            JSONObject body = JSON.parseObject(request.getBody().readUtf8());
+            Assert.assertEquals("seedance-2.0-mini", body.getString("model"));
+            Assert.assertEquals(Integer.valueOf(4), body.getInteger("duration"));
+            Assert.assertEquals("480p", body.getString("resolution"));
+            Assert.assertEquals("16:9", body.getString("ratio"));
+            JSONArray content = body.getJSONArray("content");
+            Assert.assertEquals(2, content.size());
+            JSONObject text = content.getJSONObject(0);
+            Assert.assertEquals("text", text.getString("type"));
+            Assert.assertEquals("一只猫在月光下奔跑", text.getString("text"));
+            JSONObject firstFrame = content.getJSONObject(1);
+            Assert.assertEquals("image_url", firstFrame.getString("type"));
+            Assert.assertEquals("https://cdn.example/first.png", firstFrame.getJSONObject("image_url").getString("url"));
+            Assert.assertEquals("first_frame", firstFrame.getString("role"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_maps_reference_images_and_last_frame_roles() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-2\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            Map<String, Object> extra = new LinkedHashMap<String, Object>();
+            extra.put("last_frame_url", "https://cdn.example/last.png");
+            service.create(VideoCreateRequest.builder()
+                    .model("seedance-2.5")
+                    .prompt("p")
+                    .inputImage("https://cdn.example/first.png")
+                    .referenceImages(java.util.Arrays.asList("https://cdn.example/ref1.png", "https://cdn.example/ref2.png"))
+                    .extraFields(extra)
+                    .build());
+
+            JSONObject body = JSON.parseObject(server.takeRequest(1, TimeUnit.SECONDS).getBody().readUtf8());
+            // last_frame_url 是图片角色而非顶层参数
+            Assert.assertFalse(body.containsKey("last_frame_url"));
+            JSONArray content = body.getJSONArray("content");
+            Assert.assertEquals(5, content.size());
+            Assert.assertEquals("first_frame", content.getJSONObject(1).getString("role"));
+            Assert.assertEquals("reference_image", content.getJSONObject(2).getString("role"));
+            Assert.assertEquals("https://cdn.example/ref1.png", content.getJSONObject(2).getJSONObject("image_url").getString("url"));
+            Assert.assertEquals("reference_image", content.getJSONObject(3).getString("role"));
+            Assert.assertEquals("last_frame", content.getJSONObject(4).getString("role"));
+            Assert.assertEquals("https://cdn.example/last.png", content.getJSONObject(4).getJSONObject("image_url").getString("url"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_merges_extra_fields_for_vendor_params() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-3\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            Map<String, Object> extra = new LinkedHashMap<String, Object>();
+            extra.put("generate_audio", Boolean.TRUE);
+            extra.put("watermark", Boolean.FALSE);
+            extra.put("seed", 42);
+            service.create(VideoCreateRequest.builder()
+                    .model("seedance-2.0-mini")
+                    .prompt("p")
+                    .extraFields(extra)
+                    .build());
+
+            JSONObject body = JSON.parseObject(server.takeRequest(1, TimeUnit.SECONDS).getBody().readUtf8());
+            Assert.assertEquals(Boolean.TRUE, body.getBoolean("generate_audio"));
+            Assert.assertEquals(Boolean.FALSE, body.getBoolean("watermark"));
+            Assert.assertEquals(Integer.valueOf(42), body.getInteger("seed"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_falls_back_to_legacy_seconds_for_duration() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-4\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            service.create(VideoCreateRequest.builder()
+                    .model("seedance-1.5")
+                    .prompt("p")
+                    .seconds(8)
+                    .build());
+
+            JSONObject body = JSON.parseObject(server.takeRequest(1, TimeUnit.SECONDS).getBody().readUtf8());
+            Assert.assertEquals(Integer.valueOf(8), body.getInteger("duration"));
+            Assert.assertFalse(body.containsKey("seconds"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_task_id_field_alone_is_mapped() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"task_id\":\"cgt-5\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            VideoResponse response = service.create(VideoCreateRequest.builder().model("seedance-2.0").prompt("p").build());
+            Assert.assertEquals("cgt-5", response.getTaskId());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_queued_and_processing_map_status_without_video() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"queued\"}"));
+        server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"processing\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            Assert.assertEquals("SUBMITTED", service.retrieve("cgt-6").getStatus());
+            VideoResponse processing = service.retrieve("cgt-6");
+            Assert.assertEquals("RUNNING", processing.getStatus());
+            Assert.assertNull(processing.getVideoUrl());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_succeeded_extracts_nested_video_url() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"id\":\"cgt-7\",\"status\":\"succeeded\",\"model\":\"seedance-2.0-mini\",\"content\":{\"video_url\":\"https://ark.example.com/output.mp4\"}}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            VideoResponse response = service.retrieve("cgt-7");
+
+            Assert.assertEquals("SUCCEEDED", response.getStatus());
+            Assert.assertEquals("https://ark.example.com/output.mp4", response.getVideoUrl());
+            Assert.assertEquals("seedance-2.0-mini", response.getModel());
+            Assert.assertEquals("cgt-7", response.getRaw().get("id"));
+
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/api/v3/contents/generations/tasks/cgt-7", request.getPath());
+            Assert.assertEquals("Bearer test-key", request.getHeader("Authorization"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_failed_maps_status_and_task_error() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"id\":\"cgt-8\",\"status\":\"failed\",\"error\":{\"code\":400,\"message\":\"content policy violation\"}}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            VideoResponse response = service.retrieve("cgt-8");
+
+            Assert.assertEquals("FAILED", response.getStatus());
+            Assert.assertNull(response.getVideoUrl());
+            Assert.assertEquals("400", response.getError().getCode());
+            Assert.assertEquals("content policy violation", response.getErrorMessage());
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_http_error_surfaces_via_decoder() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(404)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":{\"code\":\"NotFound\",\"message\":\"task not found\"}}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            service.retrieve("cgt-missing");
+            Assert.fail("expected exception for 404");
+        } catch (Exception expected) {
+            Assert.assertTrue(expected.getMessage().contains("task not found")
+                    || expected.getMessage().contains("404"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_content_downloads_video_stream() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        server.enqueue(jsonResponse(
+                "{\"id\":\"cgt-9\",\"status\":\"succeeded\",\"content\":{\"video_url\":\"" + server.url("/download.mp4") + "\"}}"));
+        byte[] expected = "fake-seedance-video".getBytes(StandardCharsets.UTF_8);
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "video/mp4")
+                .setBody(new okio.Buffer().write(expected)));
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            byte[] actual;
+            try (InputStream stream = service.content("cgt-9")) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[256];
+                int read;
+                while ((read = stream.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                actual = out.toByteArray();
+            }
+            Assert.assertArrayEquals(expected, actual);
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_create_uses_explicit_base_url_and_api_key_overrides() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-10\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            // 网关场景：base/key 全部由调用方传入，配置留空
+            DoubaoConfig doubaoConfig = new DoubaoConfig();
+            Configuration configuration = new Configuration();
+            configuration.setDoubaoConfig(doubaoConfig);
+            configuration.setOkHttpClient(new OkHttpClient());
+            SeedanceVideoService service = new SeedanceVideoService(configuration);
+            VideoResponse response = service.create(server.url("/").toString(), "gateway-key",
+                    VideoCreateRequest.builder().model("seedance-2.0-mini").prompt("p").build());
+
+            Assert.assertEquals("cgt-10", response.getTaskId());
+            RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+            Assert.assertEquals("/api/v3/contents/generations/tasks", request.getPath());
+            Assert.assertEquals("Bearer gateway-key", request.getHeader("Authorization"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_remix_is_unsupported() {
+        SeedanceVideoService service = new SeedanceVideoService(configuration(new MockWebServer()));
+        try {
+            service.remix("cgt-1", "p");
+            Assert.fail("expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            // Seedance 无 remix 端点
+        }
+    }
+
+    private static Configuration configuration(MockWebServer server) {
+        DoubaoConfig doubaoConfig = new DoubaoConfig();
+        doubaoConfig.setApiKey("chat-key");
+        doubaoConfig.setVideoApiHost(server.url("/").toString());
+        doubaoConfig.setVideoApiKey("test-key");
+
+        Configuration configuration = new Configuration();
+        configuration.setDoubaoConfig(doubaoConfig);
+        configuration.setOkHttpClient(new OkHttpClient());
+        return configuration;
+    }
+
+    private static MockResponse jsonResponse(String body) {
+        return new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(body);
+    }
+}


### PR DESCRIPTION
## 概要

为火山引擎 Seedance（doubao-seedance 系列）新增视频生成服务。协议 2026-08-27 经 notoken.pro 网关实测：POST `api/v3/contents/generations/tasks` 建任务 → GET 同路径 `/{task_id}` 轮询 → `content.video_url` 取结果。

## 设计

- **API 格式统一，参数向后兼容**：1.5 是基础格式，2.0/2.5 只增加可选参数（last_frame/reference_image role、generate_audio、seed）。adapter 不做版本分支，调用方按模型能力带参。
- 私有任务协议（task_id 在 `id` 字段、视频地址嵌套 `content.video_url`），不继承 AbstractVideoService，与 MinimaxVideoService 同型。

### 映射

| VideoCreateRequest | Seedance 请求 |
|---|---|
| model | model |
| prompt | content[0] = {type:text, text} |
| inputImage | content += {type:image_url, image_url:{url}, role:first_frame} |
| referenceImages | 每项 content += {…, role:reference_image} |
| extraFields["last_frame_url"] | content += {…, role:last_frame}（不进顶层） |
| durationSeconds（回退 seconds） | duration |
| resolution | resolution |
| aspectRatio | ratio |
| 其余 extraFields | 顶层透传（generate_audio/watermark/seed） |

retrieve status：queued→SUBMITTED、processing→RUNNING、succeeded→SUCCEEDED、failed→FAILED；失败任务顶层 error 映射 VideoResponse.error；非 2xx 走 HttpErrorDecoder。

## 变更

- 新增 `SeedanceVideoService` + `SeedanceVideoResponse`（doubao/video）
- `DoubaoConfig`：videoApiHost（默认空，网关场景由调用方传 baseUrl；为空且未传参回退 Ark 官方根，避免与含 /api/v3/ 的 chat apiHost 拼重）/ videoApiKey（回退 apiKey）/ videoCreatePath / videoQueryPath
- `AiService.createVideoService` 注册 DOUBAO 分支（PlatformType.DOUBAO 已存在，Configuration getter 已由 @Data 提供）
- `DoubaoRerankServiceTest` 适配 DoubaoConfig 新增字段后的全参构造

## 测试

`SeedanceVideoServiceTest` 12 用例（MockWebServer）：content 数组结构/role、last_frame extraField、extraFields 透传、seconds 回退、task_id 单字段、状态映射×3、404 解码、流式下载、baseUrl/key 显式覆盖、remix 不支持。全模块 345 tests 0 failures。