### PR TITLE
feat(doubao): Seedance 对齐完整官方文档——video/audio 参考内容项、running/expired 状态、尾帧 URL

### DIFF
--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoService.java
@@ -36,12 +36,16 @@ import java.util.Map;
  * <p>流程：POST {@code api/v3/contents/generations/tasks} 建任务 → 轮询
  * GET 同路径 {@code /{task_id}} 直到 succeeded，取 {@code content.video_url}。
  *
- * <p>模型版本差异（1.5 / 2.0 / 2.5）只是可选参数与 image role 的增减——last_frame、
- * reference_image、generate_audio、seed 由调用方按模型能力放进请求，本服务不做版本分支。
+ * <p>模型版本差异（1.5 / 2.0 / 2.5）只是可选参数与 role 类型的增减——SDK 是透传层，
+ * 不校验模型能力，参数由调用方按模型按需传（generate_audio/seed/camera_fixed 等经
+ * extraFields 顶层透传）。role 互斥（first_frame/last_frame/reference_image）同样由调用方保证。
  */
 public class SeedanceVideoService implements IVideoService {
 
     private static final MediaType JSON_MEDIA_TYPE = MediaType.get(Constants.APPLICATION_JSON);
+    /** 消费为 content 数组项、不透传到顶层的 extraFields 键。 */
+    private static final java.util.Set<String> CONTENT_EXTRA_KEYS = new java.util.HashSet<String>(
+            java.util.Arrays.asList("last_frame_url", "reference_video_urls", "reference_audio_urls"));
     /** chat 网关 {@link DoubaoConfig#getApiHost()} 默认已含 /api/v3/ 段，直接回退会和路径拼重，故回退到 Ark 根。 */
     private static final String ARK_ROOT = "https://ark.cn-beijing.volces.com/";
 
@@ -137,8 +141,8 @@ public class SeedanceVideoService implements IVideoService {
         putIfPresent(body, "ratio", request.getAspectRatio());
         if (request.getExtraFields() != null) {
             for (Map.Entry<String, Object> entry : request.getExtraFields().entrySet()) {
-                // last_frame_url 已在 content 数组里以 role=last_frame 消费，不进顶层
-                if (entry.getValue() != null && !"last_frame_url".equals(entry.getKey())) {
+                // last_frame_url / reference_video_urls / reference_audio_urls 已在 content 数组里消费，不进顶层
+                if (entry.getValue() != null && !CONTENT_EXTRA_KEYS.contains(entry.getKey())) {
                     body.put(entry.getKey(), entry.getValue());
                 }
             }
@@ -146,7 +150,11 @@ public class SeedanceVideoService implements IVideoService {
         return body;
     }
 
-    /** content 数组：text 在前，随后 first_frame / reference_image / last_frame 图片项。 */
+    /**
+     * content 数组：text 在前，随后 first_frame / reference_image / last_frame 图片项、
+     * reference_video 视频项、reference_audio 音频项。draft_task 样片任务暂无 extraFields 约定，
+     * 需要时再加。
+     */
     private List<Object> toContent(VideoCreateRequest request) {
         List<Object> content = new ArrayList<Object>();
         if (request.getPrompt() != null) {
@@ -156,26 +164,48 @@ public class SeedanceVideoService implements IVideoService {
             content.add(text);
         }
         if (request.getInputImage() != null) {
-            content.add(imageItem(request.getInputImage(), "first_frame"));
+            content.add(mediaItem("image_url", request.getInputImage(), "first_frame"));
         }
         if (request.getReferenceImages() != null) {
             for (String image : request.getReferenceImages()) {
-                content.add(imageItem(image, "reference_image"));
+                content.add(mediaItem("image_url", image, "reference_image"));
             }
         }
-        Object lastFrame = request.getExtraFields() == null ? null : request.getExtraFields().get("last_frame_url");
-        if (lastFrame instanceof String && !((String) lastFrame).isEmpty()) {
-            content.add(imageItem((String) lastFrame, "last_frame"));
-        }
+        Map<String, Object> extra = request.getExtraFields();
+        addUrlItems(content, "image_url", "last_frame", stringExtra(extra, "last_frame_url"));
+        addUrlItems(content, "video_url", "reference_video", stringExtras(extra, "reference_video_urls"));
+        addUrlItems(content, "audio_url", "reference_audio", stringExtras(extra, "reference_audio_urls"));
         return content;
     }
 
-    private static Map<String, Object> imageItem(String url, String role) {
+    private static Map<String, Object> mediaItem(String type, String url, String role) {
         Map<String, Object> item = new LinkedHashMap<String, Object>();
-        item.put("type", "image_url");
-        item.put("image_url", Collections.singletonMap("url", url));
+        item.put("type", type);
+        item.put(type, Collections.singletonMap("url", url));
         item.put("role", role);
         return item;
+    }
+
+    private static void addUrlItems(List<Object> content, String type, String role, List<String> urls) {
+        if (urls == null) {
+            return;
+        }
+        for (String url : urls) {
+            content.add(mediaItem(type, url, role));
+        }
+    }
+
+    private static List<String> stringExtra(Map<String, Object> extra, String key) {
+        Object value = extra == null ? null : extra.get(key);
+        return value instanceof String && !((String) value).isEmpty()
+                ? Collections.singletonList((String) value) : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> stringExtras(Map<String, Object> extra, String key) {
+        Object value = extra == null ? null : extra.get(key);
+        return value instanceof List && !((List<Object>) value).isEmpty()
+                ? (List<String>) value : null;
     }
 
     private VideoResponse toVideoResponse(SeedanceVideoResponse seedance) {
@@ -185,6 +215,7 @@ public class SeedanceVideoService implements IVideoService {
         response.setModel(seedance.getModel());
         if (seedance.getContent() != null) {
             response.setVideoUrl(seedance.getContent().getVideoUrl());
+            response.setLastFrameUrl(seedance.getContent().getLastFrameUrl());
         }
         response.setRaw(mapper.convertValue(seedance, new TypeReference<Map<String, Object>>() { }));
         if (seedance.getError() != null) {
@@ -196,7 +227,7 @@ public class SeedanceVideoService implements IVideoService {
         return response;
     }
 
-    /** queued → SUBMITTED，processing → RUNNING，succeeded → SUCCEEDED，failed → FAILED。 */
+    /** queued → SUBMITTED，processing/running → RUNNING，succeeded → SUCCEEDED，failed/expired → FAILED。 */
     private String mapStatus(String status) {
         if (status == null) {
             return null;
@@ -205,10 +236,12 @@ public class SeedanceVideoService implements IVideoService {
             case "queued":
                 return "SUBMITTED";
             case "processing":
+            case "running":
                 return "RUNNING";
             case "succeeded":
                 return "SUCCEEDED";
             case "failed":
+            case "expired":
                 return "FAILED";
             default:
                 return status.toUpperCase(java.util.Locale.ROOT);

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/entity/SeedanceVideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/doubao/video/entity/SeedanceVideoResponse.java
@@ -46,6 +46,10 @@ public class SeedanceVideoResponse {
     public static class Content {
         @JsonProperty("video_url")
         private String videoUrl;
+
+        /** return_last_frame=true 时返回的尾帧图 URL。 */
+        @JsonProperty("last_frame_url")
+        private String lastFrameUrl;
     }
 
     @Data

--- a/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
+++ b/ai4j/src/main/java/io/github/lnyocly/ai4j/platform/openai/video/entity/VideoResponse.java
@@ -38,6 +38,10 @@ public class VideoResponse {
     @JsonProperty("video_url")
     private String videoUrl;
 
+    /** Seedance return_last_frame=true 时返回的尾帧图 URL（其他厂商为 null）。 */
+    @JsonProperty("last_frame_url")
+    private String lastFrameUrl;
+
     @JsonProperty("created_at")
     private Long createdAt;
 

--- a/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
+++ b/ai4j/src/test/java/io/github/lnyocly/ai4j/platform/doubao/video/SeedanceVideoServiceTest.java
@@ -127,6 +127,41 @@ public class SeedanceVideoServiceTest {
     }
 
     @Test
+    public void test_create_maps_reference_video_and_audio_content_items() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse("{\"id\":\"cgt-11\",\"status\":\"queued\"}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            Map<String, Object> extra = new LinkedHashMap<String, Object>();
+            extra.put("reference_video_urls", java.util.Arrays.asList("https://cdn.example/ref.mp4", "asset://v-1"));
+            extra.put("reference_audio_urls", java.util.Collections.singletonList("https://cdn.example/voice.mp3"));
+            service.create(VideoCreateRequest.builder()
+                    .model("seedance-2.5")
+                    .prompt("p")
+                    .extraFields(extra)
+                    .build());
+
+            JSONObject body = JSON.parseObject(server.takeRequest(1, TimeUnit.SECONDS).getBody().readUtf8());
+            Assert.assertFalse(body.containsKey("reference_video_urls"));
+            Assert.assertFalse(body.containsKey("reference_audio_urls"));
+            JSONArray content = body.getJSONArray("content");
+            Assert.assertEquals(4, content.size());
+            JSONObject video = content.getJSONObject(1);
+            Assert.assertEquals("video_url", video.getString("type"));
+            Assert.assertEquals("https://cdn.example/ref.mp4", video.getJSONObject("video_url").getString("url"));
+            Assert.assertEquals("reference_video", video.getString("role"));
+            Assert.assertEquals("asset://v-1", content.getJSONObject(2).getJSONObject("video_url").getString("url"));
+            JSONObject audio = content.getJSONObject(3);
+            Assert.assertEquals("audio_url", audio.getString("type"));
+            Assert.assertEquals("https://cdn.example/voice.mp3", audio.getJSONObject("audio_url").getString("url"));
+            Assert.assertEquals("reference_audio", audio.getString("role"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
     public void test_create_falls_back_to_legacy_seconds_for_duration() throws Exception {
         MockWebServer server = new MockWebServer();
         server.enqueue(jsonResponse("{\"id\":\"cgt-4\",\"status\":\"queued\"}"));
@@ -166,6 +201,8 @@ public class SeedanceVideoServiceTest {
         MockWebServer server = new MockWebServer();
         server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"queued\"}"));
         server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"processing\"}"));
+        server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"running\"}"));
+        server.enqueue(jsonResponse("{\"id\":\"cgt-6\",\"status\":\"expired\"}"));
         server.start();
         try {
             SeedanceVideoService service = new SeedanceVideoService(configuration(server));
@@ -173,6 +210,10 @@ public class SeedanceVideoServiceTest {
             VideoResponse processing = service.retrieve("cgt-6");
             Assert.assertEquals("RUNNING", processing.getStatus());
             Assert.assertNull(processing.getVideoUrl());
+            // 官方文档用 running，网关实测用 processing，两者都归一为 RUNNING
+            Assert.assertEquals("RUNNING", service.retrieve("cgt-6").getStatus());
+            // expired（执行超时）归一为 FAILED
+            Assert.assertEquals("FAILED", service.retrieve("cgt-6").getStatus());
         } finally {
             server.shutdown();
         }
@@ -196,6 +237,24 @@ public class SeedanceVideoServiceTest {
             RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
             Assert.assertEquals("/api/v3/contents/generations/tasks/cgt-7", request.getPath());
             Assert.assertEquals("Bearer test-key", request.getHeader("Authorization"));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void test_retrieve_succeeded_extracts_last_frame_url() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(jsonResponse(
+                "{\"id\":\"cgt-12\",\"status\":\"succeeded\",\"content\":{\"video_url\":\"https://ark.example.com/output.mp4\",\"last_frame_url\":\"https://ark.example.com/last.png\"}}"));
+        server.start();
+        try {
+            SeedanceVideoService service = new SeedanceVideoService(configuration(server));
+            VideoResponse response = service.retrieve("cgt-12");
+
+            Assert.assertEquals("SUCCEEDED", response.getStatus());
+            Assert.assertEquals("https://ark.example.com/output.mp4", response.getVideoUrl());
+            Assert.assertEquals("https://ark.example.com/last.png", response.getLastFrameUrl());
         } finally {
             server.shutdown();
         }


### PR DESCRIPTION
## 概要

按火山引擎完整官方文档（docs/82379/1520757）补齐 #273 的 Seedance 服务。透传设计不变：SDK 不校验模型能力，参数由调用方按需传。

## 变更

1. **content 数组新类型**（extraFields 约定，消费后不进顶层）：
   - `reference_video_urls` (List) → 每项 `{type:video_url, video_url:{url}, role:reference_video}`（支持 asset://ID）
   - `reference_audio_urls` (List) → 每项 `{type:audio_url, audio_url:{url}, role:reference_audio}`
   - draft_task 样片任务暂无 extraFields 约定，需要时再加
2. **状态归一**：官方文档用 `running`、网关实测用 `processing`——两者都 → RUNNING；新增 `expired`（执行超时）→ FAILED
3. **尾帧 URL**：`VideoResponse` 新增 `lastFrameUrl`（`return_last_frame=true` 时 `content.last_frame_url`）
4. 顶层参数（generate_audio/seed/camera_fixed/return_last_frame/output_format/service_tier/tools 等）全部经 extraFields 透传，无需逐一定义

role 互斥（first_frame/last_frame/reference_image）由调用方保证，SDK 不校验。

## 测试

14 用例（+2）：video/audio 内容项结构与顶层排除、running/expired 归一、lastFrameUrl 提取。全模块 347 tests / 0 failures。